### PR TITLE
REF: rework device/pv config storage

### DIFF
--- a/atef/check.py
+++ b/atef/check.py
@@ -604,15 +604,30 @@ class ConfigurationFile:
 
     def get_by_device(self, name: str) -> Generator[DeviceConfiguration, None, None]:
         """Get all configurations that match the device name."""
-        ...
+        for config in self.configs:
+            if isinstance(config, DeviceConfiguration):
+                if name in config.devices:
+                    yield config
 
-    def get_by_pv(self, pvname: str) -> Generator[PVConfiguration, None, None]:
-        """Get all configurations that match the PV name."""
-        ...
+    def get_by_pv(
+        self, pvname: str
+    ) -> Generator[Tuple[PVConfiguration, List[IdentifierAndComparison]], None, None]:
+        """Get all configurations + IdentifierAndComparison that match the PV name."""
+        for config in self.configs:
+            if isinstance(config, PVConfiguration):
+                checks = [check for check in config.checklist if pvname in check.ids]
+                if checks:
+                    yield config, checks
 
     def get_by_tag(self, *tags: str) -> Generator[Configuration, None, None]:
         """Get all configurations that match the tag name."""
-        ...
+        if not tags:
+            return
+
+        tag_set = set(tags)
+        for config in self.configs:
+            if tag_set.intersection(set(config.tags or [])):
+                yield config
 
 
 def check_device(

--- a/atef/check.py
+++ b/atef/check.py
@@ -551,13 +551,13 @@ class Range(Comparison):
 @dataclass
 class IdentifierAndComparison:
     """
-    Set of identifiers and comparisons to perform on those identifiers.
+    Set of identifiers (IDs) and comparisons to perform on those identifiers.
     """
     #: An optional identifier for this set.
     name: Optional[str] = None
     #: PV name, attribute name, or test-specific identifier.
-    identifiers: List[str] = field(default_factory=list)
-    #: The comparisons to perform for *each* of the identifiers.
+    ids: List[str] = field(default_factory=list)
+    #: The comparisons to perform for *each* of the ids.
     comparisons: List[Comparison] = field(default_factory=list)
 
 
@@ -584,7 +584,7 @@ class Configuration:
 
 @dataclass
 class DeviceConfiguration(Configuration):
-    #: Happi device names which give meaning to self.checklist[].identifiers.
+    #: Happi device names which give meaning to self.checklist[].ids.
     devices: List[str] = field(default_factory=list)
 
 
@@ -642,7 +642,7 @@ def check_device(
     results = []
     for checklist_item in checklist:
         for comparison in checklist_item.comparisons:
-            for attr in checklist_item.identifiers:
+            for attr in checklist_item.ids:
                 full_attr = f"{device.name}.{attr}"
                 logger.debug("Checking %s.%s with comparison %s", full_attr, comparison)
                 signal = getattr(device, attr, None)
@@ -693,7 +693,7 @@ def check_pvs(
     def get_comparison_and_pvname():
         for checklist_item in checklist:
             for comparison in checklist_item.comparisons:
-                for pvname in checklist_item.identifiers:
+                for pvname in checklist_item.ids:
                     yield comparison, pvname
 
     for comparison, pvname in get_comparison_and_pvname():

--- a/atef/tests/test_comparison_device.py
+++ b/atef/tests/test_comparison_device.py
@@ -27,9 +27,17 @@ config_and_severity = pytest.mark.parametrize(
             check.DeviceConfiguration(
                 devices=[],
                 checklist=[
-                    check.IdentifierAndComparison(["sig1"], [check.Equals(value=1)]),
-                    check.IdentifierAndComparison(["sig2"], [check.Equals(value=2.5)]),
-                    check.IdentifierAndComparison(["sig3"], [check.Equals(value="abc")]),
+                    check.IdentifierAndComparison(
+                        identifiers=["sig1"],
+                        comparisons=[check.Equals(value=1)]
+                    ),
+                    check.IdentifierAndComparison(
+                        identifiers=["sig2"],
+                        comparisons=[check.Equals(value=2.5)]),
+                    check.IdentifierAndComparison(
+                        identifiers=["sig3"],
+                        comparisons=[check.Equals(value="abc")]
+                    ),
                 ]
             ),
             Severity.success,
@@ -40,8 +48,8 @@ config_and_severity = pytest.mark.parametrize(
                 devices=[],
                 checklist=[
                     check.IdentifierAndComparison(
-                        ["sig1", "sig2"],
-                        [check.Equals(value=1, atol=0)],
+                        identifiers=["sig1", "sig2"],
+                        comparisons=[check.Equals(value=1, atol=0)],
                     ),
                 ],
             ),
@@ -53,8 +61,8 @@ config_and_severity = pytest.mark.parametrize(
                 devices=[],
                 checklist=[
                     check.IdentifierAndComparison(
-                        ["sig1", "sig2"],
-                        [check.Equals(value=1, atol=2)],
+                        identifiers=["sig1", "sig2"],
+                        comparisons=[check.Equals(value=1, atol=2)],
                     ),
                 ],
             ),
@@ -66,8 +74,8 @@ config_and_severity = pytest.mark.parametrize(
                 devices=[],
                 checklist=[
                     check.IdentifierAndComparison(
-                        ["sig1", "sig2"],
-                        [
+                        identifiers=["sig1", "sig2"],
+                        comparisons=[
                             check.Equals(value=1, atol=2),
                             check.Equals(value=3, atol=4),
                         ],
@@ -82,16 +90,16 @@ config_and_severity = pytest.mark.parametrize(
                 devices=[],
                 checklist=[
                     check.IdentifierAndComparison(
-                        ["sig1"],
-                        [check.Equals(value=2)],
+                        identifiers=["sig1"],
+                        comparisons=[check.Equals(value=2)],
                     ),
                     check.IdentifierAndComparison(
-                        ["sig2"],
-                        [check.Equals(value=2.5)],
+                        identifiers=["sig2"],
+                        comparisons=[check.Equals(value=2.5)],
                     ),
                     check.IdentifierAndComparison(
-                        ["sig3"],
-                        [check.Equals(value="abc")],
+                        identifiers=["sig3"],
+                        comparisons=[check.Equals(value="abc")],
                     ),
                 ]
             ),
@@ -158,8 +166,8 @@ def test_at2l0_standin(at2l0):
     }[state1.get()]
     checklist = [
         check.IdentifierAndComparison(
-            at2l0.state_attrs,
-            [
+            identifiers=at2l0.state_attrs,
+            comparisons=[
                 check.NotEquals(
                     description="Filter is moving",
                     value=0,
@@ -195,8 +203,8 @@ def test_at2l0_standin_reduce(at2l0):
     state1.put(1.0)
     checklist = [
         check.IdentifierAndComparison(
-            at2l0.state_attrs[:1],
-            [
+            identifiers=at2l0.state_attrs[:1],
+            comparisons=[
                 check.Equals(
                     description="Duration test",
                     value=1,
@@ -225,8 +233,8 @@ def test_at2l0_standin_value_map(at2l0):
     severity = value_to_severity[state1.get()]
     checklist = [
         check.IdentifierAndComparison(
-            at2l0.state_attrs,
-            [
+            identifiers=at2l0.state_attrs,
+            comparisons=[
                 check.ValueSet(
                     values=[
                         check.Value(

--- a/atef/tests/test_comparison_device.py
+++ b/atef/tests/test_comparison_device.py
@@ -28,14 +28,14 @@ config_and_severity = pytest.mark.parametrize(
                 devices=[],
                 checklist=[
                     check.IdentifierAndComparison(
-                        identifiers=["sig1"],
+                        ids=["sig1"],
                         comparisons=[check.Equals(value=1)]
                     ),
                     check.IdentifierAndComparison(
-                        identifiers=["sig2"],
+                        ids=["sig2"],
                         comparisons=[check.Equals(value=2.5)]),
                     check.IdentifierAndComparison(
-                        identifiers=["sig3"],
+                        ids=["sig3"],
                         comparisons=[check.Equals(value="abc")]
                     ),
                 ]
@@ -48,7 +48,7 @@ config_and_severity = pytest.mark.parametrize(
                 devices=[],
                 checklist=[
                     check.IdentifierAndComparison(
-                        identifiers=["sig1", "sig2"],
+                        ids=["sig1", "sig2"],
                         comparisons=[check.Equals(value=1, atol=0)],
                     ),
                 ],
@@ -61,7 +61,7 @@ config_and_severity = pytest.mark.parametrize(
                 devices=[],
                 checklist=[
                     check.IdentifierAndComparison(
-                        identifiers=["sig1", "sig2"],
+                        ids=["sig1", "sig2"],
                         comparisons=[check.Equals(value=1, atol=2)],
                     ),
                 ],
@@ -74,7 +74,7 @@ config_and_severity = pytest.mark.parametrize(
                 devices=[],
                 checklist=[
                     check.IdentifierAndComparison(
-                        identifiers=["sig1", "sig2"],
+                        ids=["sig1", "sig2"],
                         comparisons=[
                             check.Equals(value=1, atol=2),
                             check.Equals(value=3, atol=4),
@@ -90,15 +90,15 @@ config_and_severity = pytest.mark.parametrize(
                 devices=[],
                 checklist=[
                     check.IdentifierAndComparison(
-                        identifiers=["sig1"],
+                        ids=["sig1"],
                         comparisons=[check.Equals(value=2)],
                     ),
                     check.IdentifierAndComparison(
-                        identifiers=["sig2"],
+                        ids=["sig2"],
                         comparisons=[check.Equals(value=2.5)],
                     ),
                     check.IdentifierAndComparison(
-                        identifiers=["sig3"],
+                        ids=["sig3"],
                         comparisons=[check.Equals(value="abc")],
                     ),
                 ]
@@ -166,7 +166,7 @@ def test_at2l0_standin(at2l0):
     }[state1.get()]
     checklist = [
         check.IdentifierAndComparison(
-            identifiers=at2l0.state_attrs,
+            ids=at2l0.state_attrs,
             comparisons=[
                 check.NotEquals(
                     description="Filter is moving",
@@ -203,7 +203,7 @@ def test_at2l0_standin_reduce(at2l0):
     state1.put(1.0)
     checklist = [
         check.IdentifierAndComparison(
-            identifiers=at2l0.state_attrs[:1],
+            ids=at2l0.state_attrs[:1],
             comparisons=[
                 check.Equals(
                     description="Duration test",
@@ -233,7 +233,7 @@ def test_at2l0_standin_value_map(at2l0):
     severity = value_to_severity[state1.get()]
     checklist = [
         check.IdentifierAndComparison(
-            identifiers=at2l0.state_attrs,
+            ids=at2l0.state_attrs,
             comparisons=[
                 check.ValueSet(
                     values=[
@@ -278,11 +278,11 @@ def mock_signal_cache() -> check._SignalCache[ophyd.sim.FakeEpicsSignalRO]:
         pytest.param(
             [
                 check.IdentifierAndComparison(
-                    identifiers=["pv1", "pv2"],
+                    ids=["pv1", "pv2"],
                     comparisons=[check.Equals(value=1)],
                 ),
                 check.IdentifierAndComparison(
-                    identifiers=["pv3"],
+                    ids=["pv3"],
                     comparisons=[check.Equals(value=2)],
                 )
             ],
@@ -292,7 +292,7 @@ def mock_signal_cache() -> check._SignalCache[ophyd.sim.FakeEpicsSignalRO]:
         pytest.param(
             [
                 check.IdentifierAndComparison(
-                    identifiers=["pv1", "pv2"],
+                    ids=["pv1", "pv2"],
                     comparisons=[check.Equals(value=2)],
                 ),
             ],

--- a/atef/tests/test_comparison_device.py
+++ b/atef/tests/test_comparison_device.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import apischema
 import ophyd
 import ophyd.sim
@@ -23,52 +25,75 @@ config_and_severity = pytest.mark.parametrize(
     [
         pytest.param(
             check.DeviceConfiguration(
-                checks=dict(
-                    sig1=check.Equals(value=1),
-                    sig2=check.Equals(value=2.5),
-                    sig3=check.Equals(value="abc"),
-                ),
+                devices=[],
+                checklist=[
+                    check.IdentifierAndComparison(["sig1"], [check.Equals(value=1)]),
+                    check.IdentifierAndComparison(["sig2"], [check.Equals(value=2.5)]),
+                    check.IdentifierAndComparison(["sig3"], [check.Equals(value="abc")]),
+                ]
             ),
             Severity.success,
             id="all_good",
         ),
         pytest.param(
             check.DeviceConfiguration(
-                checks={
-                    "sig1 sig2": check.Equals(value=1, atol=0),
-                },
+                devices=[],
+                checklist=[
+                    check.IdentifierAndComparison(
+                        ["sig1", "sig2"],
+                        [check.Equals(value=1, atol=0)],
+                    ),
+                ],
             ),
             Severity.error,
             id="multi_attr_no_tol",
         ),
         pytest.param(
             check.DeviceConfiguration(
-                checks={
-                    "sig1 sig2": check.Equals(value=1, atol=2),
-                },
+                devices=[],
+                checklist=[
+                    check.IdentifierAndComparison(
+                        ["sig1", "sig2"],
+                        [check.Equals(value=1, atol=2)],
+                    ),
+                ],
             ),
             Severity.success,
             id="multi_attr_ok",
         ),
         pytest.param(
             check.DeviceConfiguration(
-                checks={
-                    "sig1 sig2": [
-                        check.Equals(value=1, atol=2),
-                        check.Equals(value=3, atol=4),
-                    ],
-                },
+                devices=[],
+                checklist=[
+                    check.IdentifierAndComparison(
+                        ["sig1", "sig2"],
+                        [
+                            check.Equals(value=1, atol=2),
+                            check.Equals(value=3, atol=4),
+                        ],
+                    ),
+                ],
             ),
             Severity.success,
             id="multi_attr_multi_test",
         ),
         pytest.param(
             check.DeviceConfiguration(
-                checks=dict(
-                    sig1=check.Equals(value=2),
-                    sig2=check.Equals(value=2.5),
-                    sig3=check.Equals(value="abc"),
-                ),
+                devices=[],
+                checklist=[
+                    check.IdentifierAndComparison(
+                        ["sig1"],
+                        [check.Equals(value=2)],
+                    ),
+                    check.IdentifierAndComparison(
+                        ["sig2"],
+                        [check.Equals(value=2.5)],
+                    ),
+                    check.IdentifierAndComparison(
+                        ["sig3"],
+                        [check.Equals(value="abc")],
+                    ),
+                ]
             ),
             Severity.error,
             id="sig1_failure",
@@ -87,7 +112,7 @@ def test_serializable(config: check.DeviceConfiguration, severity: Severity):
 def test_result_severity(
     device, config: check.DeviceConfiguration, severity: Severity
 ):
-    overall, _ = check.check_device(device=device, attr_to_checks=config.checks)
+    overall, _ = check.check_device(device=device, checklist=config.checklist)
     assert overall == severity
 
 
@@ -105,7 +130,7 @@ def at2l0(request):
 
     class FakeAT2L0:
         name: str = "fakedev"
-        state_attrs: str = (
+        state_attrs: List[str] = (
             "blade_01.state.state blade_02.state.state blade_03.state.state "
             "blade_04.state.state blade_05.state.state blade_06.state.state "
             "blade_07.state.state blade_08.state.state blade_09.state.state "
@@ -113,7 +138,7 @@ def at2l0(request):
             "blade_13.state.state blade_14.state.state blade_15.state.state "
             "blade_16.state.state blade_17.state.state blade_18.state.state "
             "blade_19.state.state"
-        )
+        ).split()
 
         def __getattr__(self, attr):
             if attr.startswith("blade_"):
@@ -131,33 +156,36 @@ def test_at2l0_standin(at2l0):
         2: Severity.warning,
         3: Severity.error,
     }[state1.get()]
-    checks = {
-        at2l0.state_attrs: [
-            check.NotEquals(
-                description="Filter is moving",
-                value=0,
-                severity_on_failure=Severity.error,
-            ),
-            check.NotEquals(
-                description="Filter is out of the beam",
-                value=1,
-                severity_on_failure=Severity.success,
-            ),
-            check.NotEquals(
-                description="Filter is in the beam",
-                value=2,
-                severity_on_failure=Severity.warning,
-            ),
-            check.GreaterOrEqual(
-                description="Filter status unknown",
-                value=3,
-                severity_on_failure=Severity.error,
-                invert=True,
-            ),
-        ],
-    }
+    checklist = [
+        check.IdentifierAndComparison(
+            at2l0.state_attrs,
+            [
+                check.NotEquals(
+                    description="Filter is moving",
+                    value=0,
+                    severity_on_failure=Severity.error,
+                ),
+                check.NotEquals(
+                    description="Filter is out of the beam",
+                    value=1,
+                    severity_on_failure=Severity.success,
+                ),
+                check.NotEquals(
+                    description="Filter is in the beam",
+                    value=2,
+                    severity_on_failure=Severity.warning,
+                ),
+                check.GreaterOrEqual(
+                    description="Filter status unknown",
+                    value=3,
+                    severity_on_failure=Severity.error,
+                    invert=True,
+                ),
+            ],
+        ),
+    ]
 
-    overall, results = check.check_device(at2l0, checks)
+    overall, results = check.check_device(at2l0, checklist=checklist)
     print("\n".join(res.reason or "n/a" for res in results))
     assert overall == severity
 
@@ -165,19 +193,22 @@ def test_at2l0_standin(at2l0):
 def test_at2l0_standin_reduce(at2l0):
     state1: ophyd.Signal = getattr(at2l0, "blade_01.state.state")
     state1.put(1.0)
-    checks = {
-        at2l0.state_attrs.split()[0]: [
-            check.Equals(
-                description="Duration test",
-                value=1,
-                reduce_method=reduce.ReduceMethod.average,
-                reduce_period=0.1,
-                severity_on_failure=Severity.error,
-            ),
-        ],
-    }
+    checklist = [
+        check.IdentifierAndComparison(
+            at2l0.state_attrs[:1],
+            [
+                check.Equals(
+                    description="Duration test",
+                    value=1,
+                    reduce_method=reduce.ReduceMethod.average,
+                    reduce_period=0.1,
+                    severity_on_failure=Severity.error,
+                ),
+            ],
+        ),
+    ]
 
-    overall, results = check.check_device(at2l0, checks)
+    overall, results = check.check_device(at2l0, checklist=checklist)
     print("\n".join(res.reason or "n/a" for res in results))
     assert overall == Severity.success
 
@@ -192,67 +223,80 @@ def test_at2l0_standin_value_map(at2l0):
     }
 
     severity = value_to_severity[state1.get()]
-    checks = {
-        at2l0.state_attrs: [
-            check.ValueSet(
-                values=[
-                    check.Value(
-                        value=0,
-                        description="Filter is moving",
-                        severity=Severity.error,
-                    ),
-                    check.Value(
-                        description="Filter is out of the beam",
-                        value=1,
-                        severity=Severity.success,
-                    ),
-                    check.Value(
-                        description="Filter is in the beam",
-                        value=2,
-                        severity=Severity.warning,
-                    ),
-                ],
-            )
-        ]
-    }
+    checklist = [
+        check.IdentifierAndComparison(
+            at2l0.state_attrs,
+            [
+                check.ValueSet(
+                    values=[
+                        check.Value(
+                            value=0,
+                            description="Filter is moving",
+                            severity=Severity.error,
+                        ),
+                        check.Value(
+                            description="Filter is out of the beam",
+                            value=1,
+                            severity=Severity.success,
+                        ),
+                        check.Value(
+                            description="Filter is in the beam",
+                            value=2,
+                            severity=Severity.warning,
+                        ),
+                    ],
+                ),
+            ]
+        )
+    ]
 
-    overall, results = check.check_device(at2l0, checks)
+    overall, results = check.check_device(at2l0, checklist=checklist)
     print("\n".join(res.reason or "n/a" for res in results))
     assert overall == severity
 
 
-def test_pv_conversion():
-    dev = check.pvs_to_device(["pv1 pv2", "pv3"])
-    assert dev._pv_to_attr_ == {
-        # Due to sort order
-        "pv1": "attr_0",
-        "pv2": "attr_1",
-        "pv3": "attr_2",
-    }
-
-    # TODO: FakeEpicsSignal has no pvname attribute
-    # fake_dev = ophyd.sim.make_fake_device(dev)(name="test")
-    # assert fake_dev.attr_0.name == "pv1"
-    # assert fake_dev.attr_1.name == "pv2"
-    # assert fake_dev.attr_2.name == "pv3"
+@pytest.fixture
+def mock_signal_cache() -> check._SignalCache[ophyd.sim.FakeEpicsSignalRO]:
+    cache = check._SignalCache(ophyd.sim.FakeEpicsSignalRO)
+    cache["pv1"].sim_put(1)
+    cache["pv2"].sim_put(1)
+    cache["pv3"].sim_put(2)
+    return cache
 
 
-def test_pv_config_to_device_config():
-    check1 = check.Equals(value=1)
-    check2 = check.Equals(value=2)
-
-    pv_config = check.PVConfiguration(
-        description="abc",
-        checks={
-            "pv1 pv2": check1,
-            "pv3": check2,
-        }
-    )
-
-    _, config = check.pv_config_to_device_config(pv_config)
-    assert list(config.checks) == [
-        "attr_0 attr_1",
-        "attr_2",
-    ]
-
-    assert config.description == pv_config.description
+@pytest.mark.parametrize(
+    "checklist, expected_severity",
+    [
+        pytest.param(
+            [
+                check.IdentifierAndComparison(
+                    identifiers=["pv1", "pv2"],
+                    comparisons=[check.Equals(value=1)],
+                ),
+                check.IdentifierAndComparison(
+                    identifiers=["pv3"],
+                    comparisons=[check.Equals(value=2)],
+                )
+            ],
+            Severity.success,
+            id="exact_values_ok",
+        ),
+        pytest.param(
+            [
+                check.IdentifierAndComparison(
+                    identifiers=["pv1", "pv2"],
+                    comparisons=[check.Equals(value=2)],
+                ),
+            ],
+            Severity.error,
+            id="values_wrong",
+        ),
+    ],
+)
+def test_pv_config(
+    mock_signal_cache: check._SignalCache[ophyd.sim.FakeEpicsSignalRO],
+    checklist: List[check.IdentifierAndComparison],
+    expected_severity: check.Severity
+):
+    overall, _ = check.check_pvs(checklist, cache=mock_signal_cache)
+    assert overall == expected_severity


### PR DESCRIPTION
* One possibility for a path forward; fleshed out to the point of working tests (lack of discussion time? why not code!)
* Not entirely sold on this just yet
* This represents a "verbose config" storage, avoiding the ugly-but-terse "attribute to checklist" style that was previously here
* Since we've decided on providing a configuration GUI for v0, I myself am at least less worried about making the format something a human would _want_ to edit (though this form absolutely is something they _could_ edit).
* Some is still not implemented (methods to search the configuration for attributes or PVs or tags)

(for discussion tomorrow, hopefully, @ZLLentz !)