### PR TITLE
ENH: add the default pydm exception handler

### DIFF
--- a/atef/bin/config.py
+++ b/atef/bin/config.py
@@ -3,6 +3,7 @@
 """
 import argparse
 
+from pydm import exception
 from qtpy.QtWidgets import QApplication
 
 from ..widgets.config import Window
@@ -18,4 +19,5 @@ def main():
     app = QApplication([])
     main_window = Window()
     main_window.show()
+    exception.install()
     app.exec()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add the exception handler from `pydm.exception`, which will display any exceptions we hit in a dialog window instead of simply crashing the app and dumping the exception to terminal.

Use the default handler for now. Later, we may want to expand this similar to what we've done in lucid.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #42 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a fake error temporarily, pressed the button to cause the error
