### PR TITLE
BUG: do not allow the user to attempt to save the base Comparison

### DIFF
--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1019,7 +1019,7 @@ class IdAndCompWidget(ConfigTextMixin, AtefCfgDisplay, QWidget):
     ):
         if comparison is None:
             # Empty default
-            comparison = Comparison()
+            comparison = Equals()
         bridge = self.comparison_list.add_item(comparison)
         self.setup_comparison_item_bridge(bridge)
         # TODO make the delete button work
@@ -1228,14 +1228,6 @@ class CompMixin:
     def __init_subclass__(cls, *args, **kwargs):
         super().__init_subclass__(*args, **kwargs)
         CompView.register_comparison(cls.data_type, cls)
-
-
-class ComparisonWidget(CompMixin, QLabel):
-    data_type = Comparison
-
-    def __init__(self, bridge: QDataclassBridge, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.setText('Please select a comparison type above.')
 
 
 # This class should be replaced by a real "Equals" widget


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The base class for `Comparison` data types is not serializable.
To ensure we don't attempt to serialize a `ConfigurationFile` that contains the base class, stop using it as the default and stop allowing it as an option.
Deleting the widget here also removes the code path that would register `Comparison` as a valid option.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The file cannot be saved if we have an instance of `Configuration` in the data structure.
closes #36 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactive saving/loading

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->
