### PR TITLE
BUG: Fix issues related to opening files

### DIFF
--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -316,7 +316,7 @@ class AtefItem(QTreeWidgetItem):
     """
     widget_class: type[QWidget]
     widget_args: list[Any]
-    widget_cached: Optional[QWidget]
+    widget_cached: QWidget
 
     def __init__(
         self,
@@ -336,17 +336,12 @@ class AtefItem(QTreeWidgetItem):
         self.widget_args = widget_args or []
         if append_item_arg:
             self.widget_args.append(self)
-        self.widget_cached = None
+        self.widget_cached = self.widget_class(*self.widget_args)
 
     def get_widget(self) -> QWidget:
         """
         Return the edit widget associated with this tree node.
-
-        On the first call, the widget is created. On subsequent calls
-        we use the cached widget.
         """
-        if self.widget_cached is None:
-            self.widget_cached = self.widget_class(*self.widget_args)
         return self.widget_cached
 
 

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1209,8 +1209,8 @@ class IdAndCompWidget(ConfigTextMixin, AtefCfgDisplay, QWidget):
             layout=QVBoxLayout(),
         )
         self.comp_content.addWidget(self.comparison_list)
-        for comparison in self.bridge.comparisons.get():
-            self.add_comparison(comparison=comparison)
+        for bridge in self.comparison_list.bridges:
+            self.setup_comparison_item_bridge(bridge)
         self.add_comp_button.clicked.connect(self.add_comparison)
 
     def setup_comparison_item_bridge(self, bridge: QDataclassBridge) -> None:

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -280,7 +280,7 @@ class Tree(AtefCfgDisplay, QWidget):
             name='Overview',
             func_name='overview'
         )
-        self.tree_widget.addTopLevelItem(self.overview_item)
+        self.tree_widget.insertTopLevelItem(0, self.overview_item)
 
     def show_selected_display(self, item: AtefItem, *args, **kwargs):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Fix an issue where we would iterate and extend a list infinitely on startup. I was calling a function meant for adding a new comparison widget instead of just the function meant for setting up an existing comparison.
- Actively create all the ATEF items at startup to fill the whole tree, rather than on an as-needed basis.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #49 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only so far

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->
