### PR TITLE
ENH: add/finish mechanisms for removing configurations, checklists, and comparisons

### DIFF
--- a/atef/ui/config_overview_row.ui
+++ b/atef/ui/config_overview_row.ui
@@ -84,6 +84,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="delete_button">
+          <property name="text">
+           <string>DELETE CONFIG</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -10,7 +10,7 @@ import os.path
 from functools import partial
 from pathlib import Path
 from pprint import pprint
-from typing import Any, ClassVar, Dict, List, Optional, Type, Union
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type, Union
 
 from apischema import deserialize, serialize
 from qtpy.QtCore import QEvent, QObject, QTimer
@@ -374,6 +374,7 @@ class Overview(AtefCfgDisplay, QWidget):
     config_list: QDataclassList
     tree_ref: QTreeWidget
     row_count: int
+    row_mapping: Dict[OverviewRow, Tuple[Configuration, AtefItem]]
 
     def __init__(
         self,
@@ -386,6 +387,7 @@ class Overview(AtefCfgDisplay, QWidget):
         self.config_list = config_list
         self.tree_ref = tree_ref
         self.row_count = 0
+        self.row_mapping = {}
         self.initialize_overview()
         self.add_device_button.clicked.connect(self.add_device_config)
         self.add_pv_button.clicked.connect(self.add_pv_config)
@@ -479,7 +481,7 @@ class Overview(AtefCfgDisplay, QWidget):
             func_name = 'device config'
         else:
             func_name = 'pv config'
-        row = OverviewRow(config)
+        row = OverviewRow(config, self)
         self.scroll_content.layout().insertWidget(
             self.row_count,
             row,
@@ -494,6 +496,8 @@ class Overview(AtefCfgDisplay, QWidget):
         self.tree_ref.addTopLevelItem(item)
         self.row_count += 1
 
+        self.row_mapping[row] = (config, item)
+
         # If either of the widgets change the name, update tree
         row.bridge.name.changed_value.connect(
             partial(item.setText, 0)
@@ -502,6 +506,28 @@ class Overview(AtefCfgDisplay, QWidget):
         # we add new config data
         if update_data:
             self.config_list.append(config)
+
+    def delete_row(self, row: OverviewRow) -> None:
+        """
+        Delete a row and the corresponding data from the file.
+
+        This will remove the config data structure and the
+        tree node, and leave us in a state where adding a new
+        config will work as expected.
+
+        Parameters
+        ----------
+        row : OverviewRow
+            The row that we want to remove from the display.
+            This row has an associated tree item and config
+            dataclass.
+        """
+        config, tree_item = self.row_mapping[row]
+        self.config_list.remove_value(config)
+        self.tree_ref.invisibleRootItem().removeChild(tree_item)
+        self.row_count -= 1
+        del self.row_mapping[row]
+        row.deleteLater()
 
 
 class ConfigTextMixin:
@@ -609,15 +635,18 @@ class OverviewRow(ConfigTextMixin, AtefCfgDisplay, QWidget):
     config_type: QLabel
     lock_button: QPushButton
     desc_edit: QPlainTextEdit
+    delete_button: QPushButton
 
     def __init__(
         self,
         config: Union[DeviceConfiguration, PVConfiguration],
+        overview: Overview,
         *args,
         **kwargs
     ):
         super().__init__(*args, **kwargs)
         self.bridge = QDataclassBridge(config, parent=self)
+        self.overview = overview
         self.initialize_row()
 
     def initialize_row(self):
@@ -629,8 +658,12 @@ class OverviewRow(ConfigTextMixin, AtefCfgDisplay, QWidget):
             self.config_type.setText('Device Config')
         else:
             self.config_type.setText('PV Config')
-        # Setup the lock button
+        # Setup the lock and delete buttons
         self.lock_button.toggled.connect(self.handle_locking)
+        self.name_edit.textChanged.connect(
+            self.on_name_changed,
+        )
+        self.delete_button.clicked.connect(self.delete_this_config)
         if self.name_edit.text():
             # Start locked if we are reading from file
             self.lock_button.toggle()
@@ -638,6 +671,11 @@ class OverviewRow(ConfigTextMixin, AtefCfgDisplay, QWidget):
     def lock_editing(self, locked: bool):
         """
         Set the checked state of the "locked" button as the user would.
+
+        Parameters
+        ----------
+        locked : bool
+            True if locking, False if unlocking
         """
         self.lock_button.setChecked(locked)
 
@@ -650,6 +688,11 @@ class OverviewRow(ConfigTextMixin, AtefCfgDisplay, QWidget):
 
         It is expected that the user won't edit these a lot, and that it is easier
         to browse through the rows with the non-edit style.
+
+        Parameters
+        ----------
+        locked : bool
+            True if locking, False if unlocking
         """
         self.name_edit.setReadOnly(locked)
         self.name_edit.setFrame(not locked)
@@ -659,11 +702,45 @@ class OverviewRow(ConfigTextMixin, AtefCfgDisplay, QWidget):
             self.setStyleSheet(
                 "QLineEdit, QPlainTextEdit { background: transparent }"
             )
+            self.delete_button.hide()
         else:
             self.desc_edit.setFrameShape(self.desc_edit.StyledPanel)
             self.setStyleSheet(
                 "QLineEdit, QPlainTextEdit { background: white }"
             )
+            if not self.name_edit.text():
+                self.delete_button.show()
+
+    def on_name_changed(self, name: str) -> None:
+        """
+        Actions to perform when the name field changes.
+
+        This will hide/show the delete button as appropriate.
+        Only show the delete button in an unlocked state with an
+        empty name. This is to help prevent someone from
+        accidentally nuking their entire config tree.
+
+        Parameters
+        ----------
+        name : str
+            The updated configuration name.
+        """
+        if not name and not self.lock_button.isChecked():
+            self.delete_button.show()
+        else:
+            self.delete_button.hide()
+
+    def delete_this_config(self, checked: Optional[bool] = None) -> None:
+        """
+        Helper function to facilitate the removal of this row.
+
+        Parameters
+        ----------
+        checked : bool, optional
+            This argument is unused, but it will be sent by various button
+            widgets via the "clicked" signal so it must be present.
+        """
+        self.overview.delete_row(self)
 
 
 class Group(ConfigTextMixin, AtefCfgDisplay, QWidget):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add delete buttons to the top-level overview screen. These are visible for unlocked configurations with empty name fields.
- Make the checklist and comparison delete buttons work properly (by modifying the tree)
- Add docstrings and fill in some more missing docstring info

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If we decide that we have too many of any of these, we need to be able to delete them.
closes #32 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings only

<!--
## Screenshots (if appropriate):
-->
