### PR TITLE
FIX: tag button sizing

### DIFF
--- a/atef/ui/config_group.ui
+++ b/atef/ui/config_group.ui
@@ -68,25 +68,7 @@
       </layout>
      </item>
      <item>
-      <widget class="QPushButton" name="add_tag_button">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>23</width>
-         <height>23</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>23</width>
-         <height>23</height>
-        </size>
-       </property>
+      <widget class="QToolButton" name="add_tag_button">
        <property name="text">
         <string>+</string>
        </property>

--- a/atef/ui/str_list_elem.ui
+++ b/atef/ui/str_list_elem.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>174</width>
-    <height>23</height>
+    <width>392</width>
+    <height>53</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -43,24 +43,12 @@
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="del_button">
+    <widget class="QToolButton" name="del_button">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>23</width>
-       <height>23</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>23</width>
-       <height>23</height>
-      </size>
      </property>
      <property name="baseSize">
       <size>

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1252,7 +1252,7 @@ class IdAndCompWidget(ConfigTextMixin, AtefCfgDisplay, QWidget):
     name_edit: QLineEdit
     id_label: QLabel
     id_content: QVBoxLayout
-    add_id_button: QToolButton
+    add_id_button: QPushButton
     comp_label: QLabel
     comp_content: QVBoxLayout
     add_comp_button: QPushButton

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -18,7 +18,7 @@ from qtpy.QtCore import Signal as QSignal
 from qtpy.QtWidgets import (QAction, QComboBox, QFileDialog, QFormLayout,
                             QHBoxLayout, QLabel, QLayout, QLineEdit,
                             QMainWindow, QMessageBox, QPlainTextEdit,
-                            QPushButton, QTabWidget, QTreeWidget,
+                            QPushButton, QTabWidget, QToolButton, QTreeWidget,
                             QTreeWidgetItem, QVBoxLayout, QWidget)
 from qtpy.uic import loadUiType
 
@@ -766,7 +766,7 @@ class Group(ConfigTextMixin, AtefCfgDisplay, QWidget):
     name_edit: QLineEdit
     desc_edit: QPlainTextEdit
     tags_content: QVBoxLayout
-    add_tag_button: QPushButton
+    add_tag_button: QToolButton
     devices_container: QWidget
     devices_content: QVBoxLayout
     add_devices_button: QPushButton
@@ -1186,7 +1186,7 @@ class StrListElem(AtefCfgDisplay, QWidget):
     filename = 'str_list_elem.ui'
 
     line_edit: QLineEdit
-    del_button: QPushButton
+    del_button: QToolButton
 
     def __init__(self, start_text: str, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1252,7 +1252,7 @@ class IdAndCompWidget(ConfigTextMixin, AtefCfgDisplay, QWidget):
     name_edit: QLineEdit
     id_label: QLabel
     id_content: QVBoxLayout
-    add_id_button: QPushButton
+    add_id_button: QToolButton
     comp_label: QLabel
     comp_content: QVBoxLayout
     add_comp_button: QPushButton


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Tag button sizing appears incorrect on macOS.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #41

This should fix it on both macOS/Linux.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively on macOS and psbuild-rhel7 via XQuartz X server

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

See #41

Psbuild: 
<img width="230" alt="image" src="https://user-images.githubusercontent.com/5139267/165175482-6ecb580f-eedc-4d55-ba73-e0fcc191ab7c.png">
