### PR TITLE
ENH: Equals and NotEquals widgets

### DIFF
--- a/atef/check.py
+++ b/atef/check.py
@@ -331,7 +331,7 @@ class Comparison:
 
 @dataclass
 class Equals(Comparison):
-    value: PrimitiveType = 0
+    value: PrimitiveType = 0.0
     rtol: Optional[Number] = None
     atol: Optional[Number] = None
 

--- a/atef/ui/comp_equals.ui
+++ b/atef/ui/comp_equals.ui
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>236</width>
+    <height>120</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="equals_label">
+       <property name="text">
+        <string>x =</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="value_edit">
+       <property name="placeholderText">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="range_label">
+       <property name="text">
+        <string>[low, high]</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="atol_label">
+       <property name="text">
+        <string>Absolute Tolerance:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="rtol_label">
+       <property name="text">
+        <string>Relative Tolerance:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="data_type_label">
+       <property name="text">
+        <string>Data Type:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="atol_edit">
+       <property name="placeholderText">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="rtol_edit">
+       <property name="placeholderText">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="data_type_combo"/>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/comp_equals.ui
+++ b/atef/ui/comp_equals.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
-    <number>1</number>
+    <number>6</number>
    </property>
    <property name="leftMargin">
     <number>0</number>
@@ -33,6 +33,11 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="equals_label">
+       <property name="font">
+        <font>
+         <pointsize>16</pointsize>
+        </font>
+       </property>
        <property name="text">
         <string>x = </string>
        </property>
@@ -40,6 +45,11 @@
      </item>
      <item>
       <widget class="QLineEdit" name="value_edit">
+       <property name="font">
+        <font>
+         <pointsize>16</pointsize>
+        </font>
+       </property>
        <property name="placeholderText">
         <string>0</string>
        </property>
@@ -47,6 +57,11 @@
      </item>
      <item>
       <widget class="QLabel" name="range_label">
+       <property name="font">
+        <font>
+         <pointsize>16</pointsize>
+        </font>
+       </property>
        <property name="text">
         <string>+-0</string>
        </property>

--- a/atef/ui/comp_equals.ui
+++ b/atef/ui/comp_equals.ui
@@ -6,20 +6,35 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>236</width>
-    <height>120</height>
+    <width>238</width>
+    <height>97</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>1</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="equals_label">
        <property name="text">
-        <string>x =</string>
+        <string>x = </string>
        </property>
       </widget>
      </item>
@@ -33,9 +48,22 @@
      <item>
       <widget class="QLabel" name="range_label">
        <property name="text">
-        <string>[low, high]</string>
+        <string>+-0</string>
        </property>
       </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -24,7 +24,7 @@ from qtpy.uic import loadUiType
 
 from ..check import (Comparison, Configuration, ConfigurationFile,
                      DeviceConfiguration, Equals, IdentifierAndComparison,
-                     PVConfiguration)
+                     NotEquals, PVConfiguration)
 from ..enums import Severity
 from ..qt_helpers import QDataclassBridge, QDataclassList
 from ..reduce import ReduceMethod
@@ -1992,3 +1992,14 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         if not self.rtol_edit.hasFocus():
             self.rtol_edit.setText(str(rtol))
             self.update_range_label()
+
+
+class NotEqualsWidget(EqualsWidget):
+    data_type = NotEquals
+
+    def setup_equals_widget(self) -> None:
+        """
+        After the equals widget setup, change the symbol.
+        """
+        super().setup_equals_widget()
+        self.equals_label.setText('x ≠ ')

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1811,6 +1811,12 @@ def user_string_to_bool(text: str) -> bool:
     like "fa" should evaluate to False, numeric inputs like
     1 or 2 should evaluate to True, numeric inputs like 0 or
     0.0 should evaluate to False, etc.
+
+    Parameters
+    ----------
+    text : str
+        The user's text input as a string. This is usually
+        the value directly from a line edit widget.
     """
     if not text:
         return False
@@ -1867,7 +1873,7 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         self.bridge = bridge
         self.setup_equals_widget()
 
-    def setup_equals_widget(self):
+    def setup_equals_widget(self) -> None:
         """
         Do all the setup needed to make this widget functional.
 
@@ -1905,9 +1911,16 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         self.bridge.atol.changed_value.connect(self.new_internal_atol)
         self.bridge.rtol.changed_value.connect(self.new_internal_rtol)
 
-    def update_value_size(self, text: str):
+    def update_value_size(self, text: str) -> None:
         """
         Call match_line_edit_text_with with specific kwargs.
+
+        This makes the value edit box expand or contract as needed.
+
+        Parameters
+        ----------
+        text : str
+            The text from the textUpdated signal.
         """
         match_line_edit_text_width(
             self.value_edit,
@@ -1916,13 +1929,16 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
             buffer=15,
         )
 
-    def update_range_label(self):
+    def update_range_label(self) -> None:
         """
         Update the range label as appropriate.
 
         If our value is an int or float, this will do calculations
         using the atol and rtol to report the tolerance
         of the range to the user.
+
+        If our value is a bool, this will summarize whether our
+        value is being interpretted as True or False.
         """
         value = self.bridge.value.get()
         if not isinstance(value, (int, float, bool)):
@@ -1937,8 +1953,15 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
             text = f' ± {diff:.3g}'
         self.range_label.setText(text)
 
-    def new_gui_value(self, value: str):
-        """Slot for when the user inputs a new value using the GUI."""
+    def new_gui_value(self, value: str) -> None:
+        """
+        Slot for when the user inputs a new value using the GUI.
+
+        Parameters
+        ----------
+        value : str
+            The user's text input from the GUI
+        """
         self.update_value_size(value)
         type_cast = self.cast_from_user_str[
             self.label_to_type[
@@ -1952,8 +1975,15 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         self.bridge.value.put(typed_value)
         self.update_range_label()
 
-    def new_gui_atol(self, atol: str):
-        """Slot for when the user inputs a new atol using the GUI."""
+    def new_gui_atol(self, atol: str) -> None:
+        """
+        Slot for when the user inputs a new atol using the GUI.
+
+        Parameters
+        ----------
+        atol : str
+            The user's text input from the GUI
+        """
         try:
             typed_atol = float(atol)
         except ValueError:
@@ -1961,8 +1991,15 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         self.bridge.atol.put(typed_atol)
         self.update_range_label()
 
-    def new_gui_rtol(self, rtol: str):
-        """Slot for when the user inputs a new atol using the GUI."""
+    def new_gui_rtol(self, rtol: str) -> None:
+        """
+        Slot for when the user inputs a new atol using the GUI.
+
+        Parameters
+        ----------
+        rtol : str
+            The user's text input from the GUI
+        """
         try:
             typed_rtol = float(rtol)
         except ValueError:
@@ -1970,7 +2007,7 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         self.bridge.rtol.put(typed_rtol)
         self.update_range_label()
 
-    def new_gui_type(self, gui_type_str: str):
+    def new_gui_type(self, gui_type_str: str) -> None:
         """
         Slot for when the user changes the GUI data type.
 
@@ -1979,6 +2016,11 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
 
         If we have a numeric type, we'll enable the range and
         tolerance widgets. Otherwise, we'll disable them.
+
+        Parameters
+        ----------
+        gui_type_str : str
+            The user's text input from the data type combobox.
         """
         gui_type = self.label_to_type[gui_type_str]
         user_cast = self.cast_from_user_str[gui_type]
@@ -2000,9 +2042,18 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         self.rtol_label.setVisible(tol_vis)
         self.rtol_edit.setVisible(tol_vis)
 
-    def new_internal_value(self, value: PrimitiveType):
+    def new_internal_value(self, value: PrimitiveType) -> None:
         """
         Slot for when anything besides the user updates the value.
+
+        Through this, we'll  update the user's live view
+        of the data structure.
+
+        Parameters
+        ----------
+        value : any primitive
+            The value we recieve from the dataclass bridge's
+            changed_value signal.
         """
         if not self.value_edit.hasFocus():
             text = str(value)
@@ -2010,17 +2061,35 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
             self.update_value_size(text)
             self.update_range_label()
 
-    def new_internal_atol(self, atol: Number):
+    def new_internal_atol(self, atol: Number) -> None:
         """
         Slot for when anything besides the user updates the atol.
+
+        Through this, we'll  update the user's live view
+        of the data structure.
+
+        Parameters
+        ----------
+        atol : any primitive
+            The value we recieve from the dataclass bridge's
+            changed_value signal.
         """
         if not self.atol_edit.hasFocus():
             self.atol_edit.setText(str(atol))
             self.update_range_label()
 
-    def new_internal_rtol(self, rtol: Number):
+    def new_internal_rtol(self, rtol: Number) -> None:
         """
         Slot for when anything besides the user updates the rtol.
+
+        Through this, we'll  update the user's live view
+        of the data structure.
+
+        Parameters
+        ----------
+        rtol : any primitive
+            The value we recieve from the dataclass bridge's
+            changed_value signal.
         """
         if not self.rtol_edit.hasFocus():
             self.rtol_edit.setText(str(rtol))
@@ -2028,6 +2097,18 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
 
 
 class NotEqualsWidget(EqualsWidget):
+    """
+    Variant of the "EqualsWidget" for the "NotEquals" case.
+
+    Parameters
+    ----------
+    bridge : QDataclassBridge
+        Dataclass bridge to a "NotEquals" object. This widget will
+        read from and write to the "value", "atol", and "rtol"
+        fields.
+    parent : QObject, keyword=only
+        The normal qt parent argument
+    """
     data_type = NotEquals
 
     def setup_equals_widget(self) -> None:
@@ -2035,4 +2116,6 @@ class NotEqualsWidget(EqualsWidget):
         After the equals widget setup, change the symbol.
         """
         super().setup_equals_widget()
-        self.equals_label.setText('x ≠ ')
+        self.equals_label.setText(
+            self.equals_label.text().replace('=', '≠')
+        )

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1839,7 +1839,7 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         Dataclass bridge to an "Equals" object. This widget will
         read from and write to the "value", "atol", and "rtol"
         fields.
-    parent : QObject, keyword=only
+    parent : QObject, keyword-only
         The normal qt parent argument
     """
     filename = 'comp_equals.ui'
@@ -2106,7 +2106,7 @@ class NotEqualsWidget(EqualsWidget):
         Dataclass bridge to a "NotEquals" object. This widget will
         read from and write to the "value", "atol", and "rtol"
         fields.
-    parent : QObject, keyword=only
+    parent : QObject, keyword-only
         The normal qt parent argument
     """
     data_type = NotEquals

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1886,8 +1886,8 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         match_line_edit_text_width(
             self.value_edit,
             text=text,
-            min=20,
-            buffer=10,
+            min=30,
+            buffer=15,
         )
 
     def update_range_label(self):
@@ -1905,7 +1905,7 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         rtol = self.bridge.rtol.get() or 0
 
         diff = atol + abs(rtol * value)
-        self.range_label.setText(f'± {diff:.3g}')
+        self.range_label.setText(f' ± {diff:.3g}')
 
     def new_gui_value(self, value: str):
         """Slot for when the user inputs a new value using the GUI."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
An equals/not equals widget for comparison editing. Both are the same widget, just using a different dataclass type and switching out the equals/not equals symbols.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Works toward #30 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings only

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/10647860/165371870-cfae1239-4bc0-45c9-9a1f-dd91dc6dfded.png)

