### PR TITLE
ENH: happi search tool, ophyd device/component display/selection tool

### DIFF
--- a/atef/qt_helpers.py
+++ b/atef/qt_helpers.py
@@ -292,7 +292,8 @@ class ThreadWorker(QtCore.QThread):
         Keyword arguments for the function call.
     """
 
-    error_caught = QtCore.Signal(Exception)
+    error_raised = QtCore.Signal(Exception)
+    returned = QtCore.Signal(object)
     func: Callable
     args: Tuple[Any, ...]
     kwargs: Dict[str, Any]
@@ -317,7 +318,9 @@ class ThreadWorker(QtCore.QThread):
                 self.kwargs,
             )
             self.return_value = ex
-            self.error_caught.emit(ex)
+            self.error_raised.emit(ex)
+        else:
+            self.returned.emit(self.return_value)
 
 
 def run_in_gui_thread(func: Callable, *args, _start_delay_ms: int = 0, **kwargs):

--- a/atef/ui/happi_device_component.ui
+++ b/atef/ui/happi_device_component.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <widget class="QSplitter" name="splitter">
+    <widget class="QSplitter" name="splitter_main">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -41,27 +41,54 @@
        </item>
       </layout>
      </widget>
-     <widget class="QGroupBox" name="component_info_group">
-      <property name="title">
-       <string>Component information</string>
+     <widget class="QSplitter" name="splitter_md_component">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
       </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0">
-       <property name="leftMargin">
-        <number>0</number>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Happi Item Metadata</string>
        </property>
-       <property name="topMargin">
-        <number>0</number>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="HappiItemMetadataView" name="metadata_widget" native="true"/>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QGroupBox" name="component_info_group">
+       <property name="title">
+        <string>Component information</string>
        </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="OphydDeviceTableWidget" name="device_widget"/>
-       </item>
-      </layout>
+       <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="OphydDeviceTableWidget" name="device_widget"/>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </widget>
    </item>
@@ -78,6 +105,12 @@
    <class>OphydDeviceTableWidget</class>
    <extends>QFrame</extends>
    <header>atef.widgets.ophyd</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>HappiItemMetadataView</class>
+   <extends>QWidget</extends>
+   <header>atef.widgets.happi</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/atef/ui/happi_device_component.ui
+++ b/atef/ui/happi_device_component.ui
@@ -6,20 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>753</width>
-    <height>608</height>
+    <width>729</width>
+    <height>494</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
     <widget class="QGroupBox" name="device_selection_group">
      <property name="title">
       <string>Device selection</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -38,6 +38,30 @@
      </layout>
     </widget>
    </item>
+   <item row="0" column="1">
+    <widget class="QGroupBox" name="component_info_group">
+     <property name="title">
+      <string>Component information</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="DeviceWidget" name="device_widget"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -45,6 +69,12 @@
    <class>HappiSearchWidget</class>
    <extends>QWidget</extends>
    <header>atef.widgets.happi</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>DeviceWidget</class>
+   <extends>QFrame</extends>
+   <header>atef.widgets.ophyd</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/atef/ui/happi_device_component.ui
+++ b/atef/ui/happi_device_component.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Happi Item and Ophyd Component Selection</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
@@ -57,7 +57,7 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="DeviceWidget" name="device_widget"/>
+       <widget class="OphydDeviceTableWidget" name="device_widget"/>
       </item>
      </layout>
     </widget>
@@ -72,7 +72,7 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>DeviceWidget</class>
+   <class>OphydDeviceTableWidget</class>
    <extends>QFrame</extends>
    <header>atef.widgets.ophyd</header>
    <container>1</container>

--- a/atef/ui/happi_device_component.ui
+++ b/atef/ui/happi_device_component.ui
@@ -13,53 +13,56 @@
   <property name="windowTitle">
    <string>Happi Item and Ophyd Component Selection</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="device_selection_group">
-     <property name="title">
-      <string>Device selection</string>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
-      <property name="leftMargin">
-       <number>0</number>
+     <widget class="QGroupBox" name="device_selection_group">
+      <property name="title">
+       <string>Device selection</string>
       </property>
-      <property name="topMargin">
-       <number>0</number>
+      <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="HappiSearchWidget" name="item_search_widget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QGroupBox" name="component_info_group">
+      <property name="title">
+       <string>Component information</string>
       </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="HappiSearchWidget" name="item_search_widget" native="true"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QGroupBox" name="component_info_group">
-     <property name="title">
-      <string>Component information</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="OphydDeviceTableWidget" name="device_widget"/>
-      </item>
-     </layout>
+      <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="OphydDeviceTableWidget" name="device_widget"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/atef/ui/happi_device_component.ui
+++ b/atef/ui/happi_device_component.ui
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>753</width>
+    <height>608</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QGroupBox" name="device_selection_group">
+     <property name="title">
+      <string>Device selection</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="HappiSearchWidget" name="item_search_widget" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>HappiSearchWidget</class>
+   <extends>QWidget</extends>
+   <header>atef.widgets.happi</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/happi_metadata_view.ui
+++ b/atef/ui/happi_metadata_view.ui
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label_title">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTableView" name="table_view">
+     <attribute name="horizontalHeaderVisible">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="verticalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/happi_metadata_view.ui
+++ b/atef/ui/happi_metadata_view.ui
@@ -33,7 +33,7 @@
       <bool>false</bool>
      </attribute>
      <attribute name="verticalHeaderStretchLastSection">
-      <bool>true</bool>
+      <bool>false</bool>
      </attribute>
     </widget>
    </item>

--- a/atef/ui/happi_search_widget.ui
+++ b/atef/ui/happi_search_widget.ui
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>681</width>
+    <height>381</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout_2">
+   <item>
+    <widget class="QGroupBox" name="device_selection_group">
+     <property name="title">
+      <string>Device selection</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="layout_by_name">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
+        </property>
+        <item>
+         <widget class="QRadioButton" name="radio_by_name">
+          <property name="text">
+           <string>By &amp;name</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="device_selection_spacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radio_by_category">
+          <property name="text">
+           <string>&amp;By</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="combo_by_category">
+          <item>
+           <property name="text">
+            <string>beamline</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>device_class</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>functional_group</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>location_group</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>stand</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>prefix</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QFrame" name="list_or_tree_frame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item alignment="Qt::AlignRight">
+          <widget class="QPushButton" name="button_refresh">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>&amp;Refresh</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/happi_search_widget.ui
+++ b/atef/ui/happi_search_widget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Happi search</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2">
    <item>

--- a/atef/ui/happi_search_widget.ui
+++ b/atef/ui/happi_search_widget.ui
@@ -86,6 +86,23 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label_filter">
+       <property name="text">
+        <string>&amp;Filter</string>
+       </property>
+       <property name="buddy">
+        <cstring>edit_filter</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="edit_filter"/>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QFrame" name="list_or_tree_frame">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
@@ -144,6 +161,13 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>radio_by_name</tabstop>
+  <tabstop>radio_by_category</tabstop>
+  <tabstop>combo_by_category</tabstop>
+  <tabstop>edit_filter</tabstop>
+  <tabstop>button_refresh</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/atef/ui/happi_search_widget.ui
+++ b/atef/ui/happi_search_widget.ui
@@ -6,132 +6,123 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>681</width>
-    <height>381</height>
+    <width>825</width>
+    <height>643</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Happi search</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="device_selection_group">
-     <property name="title">
-      <string>Device selection</string>
+    <layout class="QHBoxLayout" name="layout_by_name">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QHBoxLayout" name="layout_by_name">
-        <property name="sizeConstraint">
-         <enum>QLayout::SetDefaultConstraint</enum>
+     <item>
+      <widget class="QRadioButton" name="radio_by_name">
+       <property name="text">
+        <string>By &amp;name</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="device_selection_spacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="radio_by_category">
+       <property name="text">
+        <string>&amp;By</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="combo_by_category">
+       <item>
+        <property name="text">
+         <string>beamline</string>
         </property>
-        <item>
-         <widget class="QRadioButton" name="radio_by_name">
-          <property name="text">
-           <string>By &amp;name</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="device_selection_spacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="radio_by_category">
-          <property name="text">
-           <string>&amp;By</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="combo_by_category">
-          <item>
-           <property name="text">
-            <string>beamline</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>device_class</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>functional_group</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>location_group</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>stand</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>prefix</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
+       </item>
+       <item>
+        <property name="text">
+         <string>device_class</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>functional_group</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>location_group</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>stand</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>prefix</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QFrame" name="list_or_tree_frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="HappiDeviceListView" name="happi_list_view" native="true"/>
       </item>
       <item>
-       <widget class="QFrame" name="list_or_tree_frame">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+       <widget class="HappiDeviceTreeView" name="happi_tree_view" native="true"/>
+      </item>
+      <item alignment="Qt::AlignRight">
+       <widget class="QPushButton" name="button_refresh">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
+        <property name="maximumSize">
+         <size>
+          <width>100</width>
+          <height>16777215</height>
+         </size>
         </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="text">
+         <string>&amp;Refresh</string>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <item>
-          <widget class="HappiDeviceListView" name="happi_list_view" native="true"/>
-         </item>
-         <item>
-          <widget class="HappiDeviceTreeView" name="happi_tree_view" native="true"/>
-         </item>
-         <item alignment="Qt::AlignRight">
-          <widget class="QPushButton" name="button_refresh">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>&amp;Refresh</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </widget>
       </item>
      </layout>

--- a/atef/ui/happi_search_widget.ui
+++ b/atef/ui/happi_search_widget.ui
@@ -106,6 +106,12 @@
          <enum>QFrame::Raised</enum>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="HappiDeviceListView" name="happi_list_view" native="true"/>
+         </item>
+         <item>
+          <widget class="HappiDeviceTreeView" name="happi_tree_view" native="true"/>
+         </item>
          <item alignment="Qt::AlignRight">
           <widget class="QPushButton" name="button_refresh">
            <property name="minimumSize">
@@ -133,6 +139,20 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>HappiDeviceListView</class>
+   <extends>QWidget</extends>
+   <header>happi.qt.model</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>HappiDeviceTreeView</class>
+   <extends>QWidget</extends>
+   <header>happi.qt.model</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/atef/ui/ophyd_device_tree_widget.ui
+++ b/atef/ui/ophyd_device_tree_widget.ui
@@ -28,7 +28,17 @@
     <widget class="QLineEdit" name="edit_filter"/>
    </item>
    <item row="1" column="0" colspan="2">
-    <widget class="OphydDeviceTableView" name="device_table_view"/>
+    <widget class="OphydDeviceTableView" name="device_table_view">
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/atef/ui/ophyd_device_tree_widget.ui
+++ b/atef/ui/ophyd_device_tree_widget.ui
@@ -36,7 +36,7 @@
       <bool>true</bool>
      </attribute>
      <attribute name="verticalHeaderStretchLastSection">
-      <bool>true</bool>
+      <bool>false</bool>
      </attribute>
     </widget>
    </item>

--- a/atef/ui/ophyd_device_tree_widget.ui
+++ b/atef/ui/ophyd_device_tree_widget.ui
@@ -73,6 +73,13 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QPushButton" name="button_select_attrs">
+     <property name="text">
+      <string>Select</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/atef/ui/ophyd_device_tree_widget.ui
+++ b/atef/ui/ophyd_device_tree_widget.ui
@@ -6,28 +6,22 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>483</width>
-    <height>410</height>
+    <width>436</width>
+    <height>336</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_filter">
+   <item row="2" column="2">
+    <widget class="QPushButton" name="button_update_data">
      <property name="text">
-      <string>&amp;Filter</string>
-     </property>
-     <property name="buddy">
-      <cstring>edit_filter</cstring>
+      <string>Refresh data</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="edit_filter"/>
-   </item>
-   <item row="1" column="0" colspan="2">
+   <item row="1" column="0" colspan="3">
     <widget class="OphydDeviceTableView" name="device_table_view">
      <property name="sortingEnabled">
       <bool>true</bool>
@@ -38,6 +32,45 @@
      <attribute name="verticalHeaderStretchLastSection">
       <bool>false</bool>
      </attribute>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_filter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&amp;Filter</string>
+     </property>
+     <property name="buddy">
+      <cstring>edit_filter</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QLineEdit" name="edit_filter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
     </widget>
    </item>
   </layout>

--- a/atef/ui/ophyd_device_tree_widget.ui
+++ b/atef/ui/ophyd_device_tree_widget.ui
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>483</width>
+    <height>410</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_filter">
+     <property name="text">
+      <string>&amp;Filter</string>
+     </property>
+     <property name="buddy">
+      <cstring>edit_filter</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="edit_filter"/>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="OphydDeviceTableView" name="device_table_view"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>OphydDeviceTableView</class>
+   <extends>QTableView</extends>
+   <header>atef.widgets.ophyd</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/util.py
+++ b/atef/util.py
@@ -1,4 +1,5 @@
 import logging
+import pathlib
 from typing import Optional, Sequence
 
 import happi
@@ -8,6 +9,8 @@ from .enums import Severity
 from .exceptions import HappiLoadError, MissingHappiDeviceError
 
 logger = logging.getLogger(__name__)
+
+ATEF_SOURCE_PATH = pathlib.Path(__file__).parent
 
 
 def ophyd_cleanup():

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -8,7 +8,6 @@ import json
 import logging
 import os.path
 from functools import partial
-from pathlib import Path
 from pprint import pprint
 from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type, Union
 
@@ -20,7 +19,6 @@ from qtpy.QtWidgets import (QAction, QComboBox, QFileDialog, QFormLayout,
                             QMainWindow, QMessageBox, QPlainTextEdit,
                             QPushButton, QTabWidget, QToolButton, QTreeWidget,
                             QTreeWidgetItem, QVBoxLayout, QWidget)
-from qtpy.uic import loadUiType
 
 from ..check import (Comparison, Configuration, ConfigurationFile,
                      DeviceConfiguration, Equals, IdentifierAndComparison,
@@ -28,32 +26,12 @@ from ..check import (Comparison, Configuration, ConfigurationFile,
 from ..enums import Severity
 from ..qt_helpers import QDataclassBridge, QDataclassList
 from ..reduce import ReduceMethod
+from .core import DesignerDisplay
 
 logger = logging.getLogger(__name__)
 
 
-class AtefCfgDisplay:
-    """Helper class for loading the .ui files and adding logic."""
-    filename: str
-
-    def __init_subclass__(cls):
-        """Read the file when the class is created"""
-        super().__init_subclass__()
-        cls.ui_form, _ = loadUiType(
-            str(Path(__file__).parent.parent / 'ui' / cls.filename)
-        )
-
-    def __init__(self, *args, **kwargs):
-        """Apply the file to this widget when the instance is created"""
-        super().__init__(*args, **kwargs)
-        self.ui_form.setupUi(self, self)
-
-    def retranslateUi(self, *args, **kwargs):
-        """Required function for setupUi to work in __init__"""
-        self.ui_form.retranslateUi(self, *args, **kwargs)
-
-
-class Window(AtefCfgDisplay, QMainWindow):
+class Window(DesignerDisplay, QMainWindow):
     """
     Main atef config window
 
@@ -233,7 +211,7 @@ class Window(AtefCfgDisplay, QMainWindow):
         pprint(self.serialize_tree(self.get_current_tree()))
 
 
-class Tree(AtefCfgDisplay, QWidget):
+class Tree(DesignerDisplay, QWidget):
     """
     The main per-file widget as a "native" view into the file.
 
@@ -347,7 +325,7 @@ class AtefItem(QTreeWidgetItem):
         return self.widget_cached
 
 
-class Overview(AtefCfgDisplay, QWidget):
+class Overview(DesignerDisplay, QWidget):
     """
     A view of all the top-level "Configuration" objects.
 
@@ -614,7 +592,7 @@ class ConfigTextMixin:
         self.desc_edit.setFixedHeight(line_count * 13 + 12)
 
 
-class OverviewRow(ConfigTextMixin, AtefCfgDisplay, QWidget):
+class OverviewRow(ConfigTextMixin, DesignerDisplay, QWidget):
     """
     A single row in the overview widget.
 
@@ -743,7 +721,7 @@ class OverviewRow(ConfigTextMixin, AtefCfgDisplay, QWidget):
         self.overview.delete_row(self)
 
 
-class Group(ConfigTextMixin, AtefCfgDisplay, QWidget):
+class Group(ConfigTextMixin, DesignerDisplay, QWidget):
     """
     The group of checklists and devices associated with a Configuration.
 
@@ -1172,7 +1150,7 @@ class NamedDataclassList(StrList):
         self.data_list.put_to_index(index, new_bridge.data)
 
 
-class StrListElem(AtefCfgDisplay, QWidget):
+class StrListElem(DesignerDisplay, QWidget):
     """
     A single element for the StrList widget.
 
@@ -1234,7 +1212,7 @@ class FrameOnEditFilter(QObject):
         return False
 
 
-class IdAndCompWidget(ConfigTextMixin, AtefCfgDisplay, QWidget):
+class IdAndCompWidget(ConfigTextMixin, DesignerDisplay, QWidget):
     """
     A widget to manage the ids and comparisons associated with a checklist.
 
@@ -1419,7 +1397,7 @@ class IdAndCompWidget(ConfigTextMixin, AtefCfgDisplay, QWidget):
         bridge.deleteLater()
 
 
-class CompView(ConfigTextMixin, AtefCfgDisplay, QWidget):
+class CompView(ConfigTextMixin, DesignerDisplay, QWidget):
     """
     Widget to view and edit a single Comparison subclass.
 

--- a/atef/widgets/core.py
+++ b/atef/widgets/core.py
@@ -1,6 +1,8 @@
 """
 Core classes for atef Qt-based display GUIs.
 """
+from typing import ClassVar
+
 from qtpy.uic import loadUiType
 
 from ..util import ATEF_SOURCE_PATH
@@ -8,7 +10,7 @@ from ..util import ATEF_SOURCE_PATH
 
 class DesignerDisplay:
     """Helper class for loading designer .ui files and adding logic."""
-    filename: str
+    filename: ClassVar[str]
 
     def __init_subclass__(cls):
         """Read the file when the class is created"""

--- a/atef/widgets/core.py
+++ b/atef/widgets/core.py
@@ -1,0 +1,27 @@
+"""
+Core classes for atef Qt-based display GUIs.
+"""
+from qtpy.uic import loadUiType
+
+from ..util import ATEF_SOURCE_PATH
+
+
+class DesignerDisplay:
+    """Helper class for loading designer .ui files and adding logic."""
+    filename: str
+
+    def __init_subclass__(cls):
+        """Read the file when the class is created"""
+        super().__init_subclass__()
+        cls.ui_form, _ = loadUiType(
+            str(ATEF_SOURCE_PATH / 'ui' / cls.filename)
+        )
+
+    def __init__(self, *args, **kwargs):
+        """Apply the file to this widget when the instance is created"""
+        super().__init__(*args, **kwargs)
+        self.ui_form.setupUi(self, self)
+
+    def retranslateUi(self, *args, **kwargs):
+        """Required function for setupUi to work in __init__"""
+        self.ui_form.retranslateUi(self, *args, **kwargs)

--- a/atef/widgets/core.py
+++ b/atef/widgets/core.py
@@ -25,3 +25,20 @@ class DesignerDisplay:
     def retranslateUi(self, *args, **kwargs):
         """Required function for setupUi to work in __init__"""
         self.ui_form.retranslateUi(self, *args, **kwargs)
+
+    def show_type_hints(self):
+        """Show type hints of widgets included in the display for development help."""
+        cls_attrs = set()
+        obj_attrs = set(dir(self))
+        annotated = set(self.__annotations__)
+        for cls in type(self).mro():
+            cls_attrs |= set(dir(cls))
+        likely_from_ui = obj_attrs - cls_attrs - annotated
+        for attr in sorted(likely_from_ui):
+            try:
+                obj = getattr(self, attr, None)
+            except Exception:
+                ...
+            else:
+                if obj is not None:
+                    print(f"{attr}: {obj.__class__.__module__}.{obj.__class__.__name__}")

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -409,7 +409,6 @@ class HappiDeviceComponentWidget(DesignerDisplay, QWidget):
         self._device_worker = None
         self._device_cache = {}
         self.client = client
-        # self._setup_ui()
         self.item_search_widget.happi_items_selected.connect(
             self._new_item_selection
         )

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -1,0 +1,94 @@
+"""
+Widget classes designed for atef-to-happi interaction.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import happi
+from happi.qt import HappiDeviceListView
+from happi.qt.model import HappiDeviceTreeView
+from qtpy import QtCore, QtWidgets
+from qtpy.QtWidgets import QWidget
+
+from .core import DesignerDisplay
+
+
+class HappiSearchWidget(DesignerDisplay, QWidget):
+    filename = 'happi_search_widget.ui'
+
+    client: happi.client.Client
+    combo_by_category: QtWidgets.QComboBox
+    device_selection_group: QtWidgets.QGroupBox
+    layout_by_name: QtWidgets.QHBoxLayout
+    radio_by_category: QtWidgets.QRadioButton
+    radio_by_name: QtWidgets.QRadioButton
+    list_or_tree_frame: QtWidgets.QFrame
+    button_refresh: QtWidgets.QPushButton
+    happi_tree_view: Optional[HappiDeviceTreeView]
+    happi_list_view: HappiDeviceListView
+
+    def __init__(
+        self,
+        client: Optional[happi.Client] = None,
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(parent=parent)
+        if client is None:
+            client = happi.Client.from_config()
+        self.client = client
+        self._setup_ui()
+
+    def _setup_ui(self):
+        self.happi_list_view = HappiDeviceListView(client=self.client)
+        self.happi_tree_view = None
+
+        self.button_refresh.clicked.connect(self.refresh_happi)
+        self.list_or_tree_frame.layout().insertWidget(0, self.happi_list_view)
+
+        self.radio_by_name.clicked.connect(self._select_device_widget)
+        self.radio_by_category.clicked.connect(self._select_device_widget)
+        self.combo_by_category.currentTextChanged.connect(self._category_changed)
+        self.button_refresh.clicked.emit()
+
+    @property
+    def selected_device_widget(self) -> Union[HappiDeviceListView, HappiDeviceTreeView]:
+        """The selected device widget - either the list or tree view."""
+        if self.radio_by_name.isChecked():
+            return self.happi_list_view
+
+        if self.happi_tree_view is None:
+            self.happi_tree_view = HappiDeviceTreeView(client=self.client)
+            # self.happi_tree_view.setSortingEnabled(True)
+            self.happi_tree_view.search()
+            self.happi_tree_view.groups = [
+                self.combo_by_category.itemText(idx)
+                for idx in range(self.combo_by_category.count())
+            ]
+            self._category_changed(self.combo_by_category.currentText())
+            self.list_or_tree_frame.layout().insertWidget(0, self.happi_tree_view)
+
+        return self.happi_tree_view
+
+    @QtCore.Slot(str)
+    def _category_changed(self, category: str):
+        if self.happi_tree_view is None:
+            return
+
+        self.happi_tree_view.group_by(category)
+        # Bugfix (?) otherwise this ends up in descending order
+        self.happi_tree_view.proxy_model.sort(0, QtCore.Qt.AscendingOrder)
+
+    @QtCore.Slot()
+    def _select_device_widget(self):
+        """Switch between the list/table view."""
+        selected = self.selected_device_widget
+        for widget in (self.happi_tree_view, self.happi_list_view):
+            if widget is not None:
+                widget.setVisible(selected is widget)
+
+    @QtCore.Slot()
+    def refresh_happi(self):
+        """Search happi again and update the widgets."""
+        self.selected_device_widget.search()

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -16,6 +16,18 @@ from .core import DesignerDisplay
 
 
 class HappiSearchWidget(DesignerDisplay, QWidget):
+    """
+    Happi device search widget.
+
+    Parameters
+    ----------
+    client : happi.Client, optional
+        Happi client instance.  One will be created using ``from_config`` if
+        not supplied.
+
+    parent : QWidget, optional
+        The parent widget.
+    """
     filename = 'happi_search_widget.ui'
 
     client: happi.client.Client
@@ -60,7 +72,6 @@ class HappiSearchWidget(DesignerDisplay, QWidget):
 
         if self.happi_tree_view is None:
             self.happi_tree_view = HappiDeviceTreeView(client=self.client)
-            # self.happi_tree_view.setSortingEnabled(True)
             self.happi_tree_view.search()
             self.happi_tree_view.groups = [
                 self.combo_by_category.itemText(idx)
@@ -73,6 +84,7 @@ class HappiSearchWidget(DesignerDisplay, QWidget):
 
     @QtCore.Slot(str)
     def _category_changed(self, category: str):
+        """By-category category has changed."""
         if self.happi_tree_view is None:
             return
 

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -51,8 +51,10 @@ class HappiSearchWidget(DesignerDisplay, QWidget):
     button_refresh: QtWidgets.QPushButton
     combo_by_category: QtWidgets.QComboBox
     device_selection_group: QtWidgets.QGroupBox
+    edit_filter: QtWidgets.QLineEdit
     happi_list_view: HappiDeviceListView
     happi_tree_view: HappiDeviceTreeView
+    label_filter: QtWidgets.QLabel
     layout_by_name: QtWidgets.QHBoxLayout
     list_or_tree_frame: QtWidgets.QFrame
     radio_by_category: QtWidgets.QRadioButton
@@ -103,6 +105,11 @@ class HappiSearchWidget(DesignerDisplay, QWidget):
             self._list_view_context_menu
         )
 
+        def set_filter(text):
+            self.happi_list_view.proxy_model.setFilterRegExp(text)
+
+        self.edit_filter.textEdited.connect(set_filter)
+
     def _setup_tree_view(self):
         """Set up the happi_tree_view."""
         view = self.happi_tree_view
@@ -128,6 +135,12 @@ class HappiSearchWidget(DesignerDisplay, QWidget):
 
         view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         view.customContextMenuRequested.connect(self._tree_view_context_menu)
+
+        def set_filter(text):
+            self.happi_tree_view.proxy_model.setFilterRegExp(text)
+
+        self.edit_filter.textEdited.connect(set_filter)
+        view.proxy_model.setRecursiveFilteringEnabled(True)
 
     def _tree_view_context_menu(self, pos: QtCore.QPoint) -> None:
         """Context menu for the happi tree view."""

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -87,6 +87,35 @@ class HappiSearchWidget(DesignerDisplay, QWidget):
             list_selection_changed
         )
 
+        self.happi_list_view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.happi_list_view.customContextMenuRequested.connect(
+            self._list_view_context_menu
+        )
+
+    def _tree_view_context_menu(self, pos: QtCore.QPoint) -> None:
+        self.menu = QtWidgets.QMenu(self)
+        index: QtCore.QModelIndex = self.happi_tree_view.indexAt(pos)
+        if index is not None:
+            def copy(*_):
+                copy_to_clipboard(index.data())
+
+            copy_action = self.menu.addAction(f"&Copy: {index.data()}")
+            copy_action.triggered.connect(copy)
+
+        self.menu.exec_(self.happi_tree_view.mapToGlobal(pos))
+
+    def _list_view_context_menu(self, pos: QtCore.QPoint) -> None:
+        self.menu = QtWidgets.QMenu(self)
+        index: QtCore.QModelIndex = self.happi_list_view.indexAt(pos)
+        if index is not None:
+            def copy(*_):
+                copy_to_clipboard(index.data())
+
+            copy_action = self.menu.addAction(f"&Copy: {index.data()}")
+            copy_action.triggered.connect(copy)
+
+        self.menu.exec_(self.happi_list_view.mapToGlobal(pos))
+
     def _setup_tree_view(self):
         """Set up the happi_tree_view if not already configured."""
         view = self.happi_tree_view
@@ -109,7 +138,8 @@ class HappiSearchWidget(DesignerDisplay, QWidget):
             tree_selection_changed
         )
 
-        self.happi_tree_view = view
+        view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        view.customContextMenuRequested.connect(self._tree_view_context_menu)
 
     @property
     def selected_device_widget(self) -> Union[HappiDeviceListView, HappiDeviceTreeView]:

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -16,7 +16,7 @@ from qtpy.QtWidgets import QWidget
 
 from ..qt_helpers import ThreadWorker
 from .core import DesignerDisplay
-from .ophyd import DeviceWidget
+from .ophyd import OphydDeviceTableWidget
 
 logger = logging.getLogger(__name__)
 
@@ -199,7 +199,7 @@ class HappiDeviceComponentWidget(DesignerDisplay, QWidget):
     filename: ClassVar[str] = 'happi_device_component.ui'
 
     item_search_widget: HappiSearchWidget
-    device_widget: DeviceWidget
+    device_widget: OphydDeviceTableWidget
     _client: Optional[happi.client.Client]
     _device_worker: Optional[ThreadWorker]
     _device_cache: Dict[str, ophyd.Device]

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -254,13 +254,14 @@ class HappiItemMetadataView(DesignerDisplay, QtWidgets.QWidget):
         self.model.setHorizontalHeaderLabels(["Key", "Value"])
         skip_keys = {"_id", "name"}
         for key, value in sorted(metadata.items()):
-            if key not in skip_keys:
-                self.model.appendRow(
-                    [
-                        QtGui.QStandardItem(str(key)),
-                        QtGui.QStandardItem(str(value)),
-                    ]
-                )
+            if key in skip_keys:
+                continue
+
+            key_item = QtGui.QStandardItem(str(key))
+            value_item = QtGui.QStandardItem(str(value))
+            key_item.setFlags(key_item.flags() & ~QtCore.Qt.ItemIsEditable)
+            value_item.setFlags(value_item.flags() & ~QtCore.Qt.ItemIsEditable)
+            self.model.appendRow([key_item, value_item])
 
     @property
     def client(self) -> Optional[happi.Client]:

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -344,12 +344,14 @@ class HappiDeviceComponentWidget(DesignerDisplay, QWidget):
 
         def set_device(device: Optional[ophyd.Device] = None):
             self.device_widget.device = device
-            self.metadata_widget.item_name = item
 
         if self._device_worker is not None and self._device_worker.isRunning():
             return
 
         item, *_ = items
+
+        # Set metadata early, even if instantiation fails
+        self.metadata_widget.item_name = item
 
         worker = ThreadWorker(get_device)
         self._device_worker = worker

--- a/atef/widgets/ophyd.py
+++ b/atef/widgets/ophyd.py
@@ -238,7 +238,7 @@ class PolledDeviceModel(QtCore.QAbstractTableModel):
         ]
         self.start()
 
-    def start(self):
+    def start(self) -> None:
         "Start the polling thread"
         if self._polling:
             return
@@ -250,13 +250,13 @@ class PolledDeviceModel(QtCore.QAbstractTableModel):
         self._poll_thread.data_changed.connect(self._data_changed)
         self._poll_thread.start()
 
-    def _data_changed(self, attr):
+    def _data_changed(self, attr: str) -> None:
         row = list(self._data).index(attr)
         self.dataChanged.emit(
             self.createIndex(row, 0), self.createIndex(row, self.columnCount(0))
         )
 
-    def stop(self):
+    def stop(self) -> None:
         thread = self._poll_thread
         if self._polling or not thread:
             return
@@ -265,16 +265,18 @@ class PolledDeviceModel(QtCore.QAbstractTableModel):
         self._poll_thread = None
         self._polling = False
 
-    def hasChildren(self, index):
+    def hasChildren(self, index: QtCore.QModelIndex) -> bool:
         # TODO sub-devices?
         return False
 
-    def headerData(self, section, orientation, role=Qt.DisplayRole):
-        if role == Qt.DisplayRole:
-            if orientation == Qt.Horizontal:
-                return self.horizontal_header[section]
+    def headerData(self, section, orientation, role=Qt.DisplayRole) -> Optional[str]:
+        if role == Qt.DisplayRole and orientation == Qt.Horizontal:
+            return self.horizontal_header[section]
+        return None
 
-    def setData(self, index, value, role=Qt.EditRole):
+    def setData(
+        self, index: QtCore.QModelIndex, value: Any, role: int = Qt.EditRole
+    ) -> bool:
         row = index.row()
         column = index.column()
         info = self._row_to_data[row]
@@ -295,7 +297,7 @@ class PolledDeviceModel(QtCore.QAbstractTableModel):
         self._set_thread.start()
         return True
 
-    def flags(self, index):
+    def flags(self, index: QtCore.QModelIndex) -> Qt.ItemFlags:
         flags = super().flags(index)
 
         row = index.row()
@@ -336,10 +338,10 @@ class PolledDeviceModel(QtCore.QAbstractTableModel):
                     f"{idx}: {item!r}" for idx, item in enumerate(enum_strings)
                 )
 
-    def columnCount(self, index) -> int:
+    def columnCount(self, index: QtCore.QModelIndex) -> int:
         return DeviceColumn.total_columns
 
-    def rowCount(self, index) -> int:
+    def rowCount(self, index: QtCore.QModelIndex) -> int:
         return len(self._data)
 
 

--- a/atef/widgets/ophyd.py
+++ b/atef/widgets/ophyd.py
@@ -1,0 +1,423 @@
+"""
+Ophyd Device-related widgets.
+"""
+from __future__ import annotations
+
+import dataclasses
+import enum
+import logging
+import threading
+import time
+from typing import Any, Dict, List, Optional, Set
+
+import numpy as np
+import ophyd
+import ophyd.device
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import Qt
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class OphydAttributeData:
+    attr: str
+    description: Dict[str, Any]
+    docstring: Optional[str]
+    pvname: str
+    read_only: bool
+    readback: Any
+    setpoint: Any
+    signal: ophyd.Signal
+
+    @classmethod
+    def from_device_attribute(
+        cls, device: ophyd.Device, attr: str
+    ) -> OphydAttributeData:
+        """Get attribute information given a device and dotted attribute name."""
+        inst = getattr(device, attr)
+        cpt = getattr(type(device), attr)
+        read_only = isinstance(inst, (ophyd.EpicsSignalRO,))
+        return cls(
+            attr=attr,
+            description={},
+            docstring=cpt.doc,
+            pvname=getattr(inst, "pvname", "(Python)"),
+            read_only=read_only,
+            readback=None,
+            setpoint=None,
+            signal=inst,
+        )
+
+    @classmethod
+    def from_device(cls, device: ophyd.Device) -> Dict[str, OphydAttributeData]:
+        """Create a data dictionary for a given device."""
+        data = {
+            attr: cls.from_device_attribute(device, attr)
+            for attr in device.component_names
+            if attr not in device._sub_devices
+        }
+
+        for sub_name in device._sub_devices:
+            sub_dev = getattr(device, sub_name)
+            sub_data = {
+                f"{sub_name}.{key}": value
+                for key, value in OphydAttributeData.from_device(sub_dev).items()
+            }
+            for key, value in sub_data.items():
+                value.attr = key
+            data.update(sub_data)
+
+        return data
+
+
+class DeviceColumn(enum.IntEnum):
+    """Column information for the device model."""
+    attribute = 0
+    readback = 1
+    setpoint = 2
+    pvname = 3
+
+    total_columns = 4
+
+
+class _DevicePollThread(QtCore.QThread):
+    """
+    Polling thread
+    """
+
+    data_changed = QtCore.Signal(str)
+    _attrs: Set[str]
+
+    def __init__(
+        self,
+        device: ophyd.Device,
+        data: Dict[str, OphydAttributeData],
+        poll_rate: float,
+        *,
+        parent: Optional[QtWidgets.QWidget] = None
+    ):
+        super().__init__(parent=parent)
+        self.device = device
+        self.data = data
+        self.poll_rate = poll_rate
+        self._attrs = set()
+
+    def _instantiate_device(self) -> Set[str]:
+        """Instantiate the device and return the attrs to pay attention to."""
+        attrs = set(self.data)
+        # Instantiate all signals first
+        with ophyd.device.do_not_wait_for_lazy_connection(self.device):
+            for attr in list(attrs):
+                try:
+                    getattr(self.device, attr)
+                except Exception:
+                    logger.exception(
+                        "Poll thread for %s.%s @ %.3f sec failure on initial access",
+                        self.device.name,
+                        attr,
+                        self.poll_rate,
+                    )
+                    attrs.remove(attr)
+        return attrs
+
+    def _update_attr(self, attr: str):
+        """Update an attribute of the device."""
+        setpoint = None
+        data = self.data[attr]
+        try:
+            sig = data.signal
+
+            if not data.description:
+                data.description = sig.describe()[sig.name] or {}
+
+            if hasattr(sig, "get_setpoint"):
+                setpoint = sig.get_setpoint()
+            elif hasattr(sig, "setpoint"):
+                setpoint = sig.setpoint
+            readback = sig.get()
+        except Exception:
+            logger.exception(
+                "Poll thread for %s.%s @ %.3f sec failure",
+                self.device.name,
+                attr,
+                self.poll_rate,
+            )
+            self._attrs.remove(attr)
+            return
+
+        new_data = {}
+        if readback is not None:
+            units = data.description.get("units", "") or ""
+            new_data["readback"] = f"{readback} {units}"
+        if setpoint is not None:
+            new_data["setpoint"] = setpoint
+
+        for key, value in new_data.items():
+            old_value = getattr(data, key)
+
+            try:
+                changed = np.any(old_value != value)
+            except Exception:
+                ...
+            else:
+                if changed or old_value is None:
+                    for key, value in new_data.items():
+                        setattr(data, key, value)
+                    self.data_changed.emit(attr)
+                    return
+
+    def run(self):
+        self.running = True
+        attrs = self._instantiate_device()
+
+        while self.running:
+            t0 = time.monotonic()
+            for attr in list(attrs):
+                self._update_attr(attr)
+
+            elapsed = time.monotonic() - t0
+            time.sleep(max((0, self.poll_rate - elapsed)))
+
+
+class PolledDeviceModel(QtCore.QAbstractTableModel):
+    """A table model representing an ophyd Device with periodic data polling."""
+
+    device: ophyd.Device
+    poll_rate: float
+    _polling: bool
+    poll_thread: Optional[QtCore.QThread]
+    read_only: bool
+    _data: Dict[str, OphydAttributeData]
+    _row_to_data: Dict[int, OphydAttributeData]
+    horizontal_header: List[str]
+
+    def __init__(
+        self,
+        device: ophyd.Device,
+        *,
+        poll_rate: float = 1.0,
+        parent: Optional[QtWidgets.QWidget] = None,
+        read_only: bool = True,
+        **kwargs
+    ):
+        super().__init__(parent=parent, **kwargs)
+        self.device = device
+        self.poll_rate = float(poll_rate)
+        self._polling = False
+        self.poll_thread = None
+        self.read_only = read_only
+
+        self._data = OphydAttributeData.from_device(device)
+        self._row_to_data = {
+            row: data for row, (_, data) in enumerate(sorted(self._data.items()))
+        }
+        self.horizontal_header = [
+            "Attribute",
+            "Readback",
+            "Setpoint",
+            "PV Name",
+        ]
+        self.start()
+
+    def start(self):
+        "Start the polling thread"
+        if self._polling:
+            return
+
+        self._polling = True
+        self._poll_thread = _DevicePollThread(
+            self.device, self._data, self.poll_rate, parent=self
+        )
+        self._poll_thread.data_changed.connect(self._data_changed)
+        self._poll_thread.start()
+
+    def _data_changed(self, attr):
+        row = list(self._data).index(attr)
+        self.dataChanged.emit(
+            self.createIndex(row, 0), self.createIndex(row, self.columnCount(0))
+        )
+
+    def stop(self):
+        thread = self._poll_thread
+        if self._polling or not thread:
+            return
+
+        thread.running = False
+        self._poll_thread = None
+        self._polling = False
+
+    def hasChildren(self, index):
+        # TODO sub-devices?
+        return False
+
+    def headerData(self, section, orientation, role=Qt.DisplayRole):
+        if role == Qt.DisplayRole:
+            if orientation == Qt.Horizontal:
+                return self.horizontal_header[section]
+
+    def setData(self, index, value, role=Qt.EditRole):
+        row = index.row()
+        column = index.column()
+        info = self._row_to_data[row]
+
+        if role != Qt.EditRole or column != DeviceColumn.setpoint:
+            return False
+
+        obj = info.signal
+
+        def set_thread():
+            try:
+                logger.debug("Setting %s = %r", obj.name, value)
+                obj.put(value, wait=False)
+            except Exception:
+                logger.exception("Failed to set %s to %r", obj.name, value)
+
+        self._set_thread = threading.Thread(target=set_thread, daemon=True)
+        self._set_thread.start()
+        return True
+
+    def flags(self, index):
+        flags = super().flags(index)
+
+        row = index.row()
+        if index.column() == DeviceColumn.setpoint:
+            info = self._row_to_data[row]
+            if not info.read_only and not self.read_only:
+                return flags | Qt.ItemIsEnabled | Qt.ItemIsEditable
+        return flags
+
+    def data(self, index, role):
+        row = index.row()
+        column = index.column()
+        info = self._row_to_data[row]
+
+        if role == Qt.EditRole and column == DeviceColumn.setpoint:
+            return info.setpoint
+
+        if role == Qt.DisplayRole:
+            setpoint = info.setpoint
+            if setpoint is None or np.size(setpoint) == 0:
+                setpoint = ""
+            columns = {
+                0: info.attr,
+                1: info.readback,
+                2: setpoint,
+                3: info.pvname,
+            }
+            return str(columns[column])
+
+        if role == Qt.ToolTipRole:
+            if column in (0,):
+                return info.docstring
+            if column in (DeviceColumn.readback, DeviceColumn.setpoint):
+                enum_strings = info.description.get("enum_strs", None)
+                if not enum_strings:
+                    return
+                return "\n".join(
+                    f"{idx}: {item!r}" for idx, item in enumerate(enum_strings)
+                )
+
+    def columnCount(self, index) -> int:
+        return DeviceColumn.total_columns
+
+    def rowCount(self, index) -> int:
+        return len(self._data)
+
+
+class DeviceView(QtWidgets.QTableView):
+    """A tabular view of an ophyd.Device."""
+
+    def __init__(
+        self,
+        parent: Optional[QtWidgets.QWidget] = None,
+        device: Optional[ophyd.Device] = None,
+    ):
+        super().__init__(parent=parent)
+        self.proxy_model = QtCore.QSortFilterProxyModel()
+        self.proxy_model.setFilterKeyColumn(-1)
+        self.proxy_model.setDynamicSortFilter(True)
+        self.setModel(self.proxy_model)
+
+        self.models = {}
+        self._device = None
+
+        # Set the property last
+        self.device = device
+
+    def clear(self):
+        for model in self.models.values():
+            model.stop()
+        self.models.clear()
+        self._device = None
+
+    @property
+    def device(self) -> Optional[ophyd.Device]:
+        return self._device
+
+    @device.setter
+    def device(self, device: Optional[ophyd.Device]):
+        if device is self._device:
+            return
+
+        if self._device is not None:
+            self.models[device].stop()
+
+        self._device = device
+        if device:
+            try:
+                model = self.models[device]
+            except KeyError:
+                model = PolledDeviceModel(device=device)
+                self.models[device] = model
+
+            model.start()
+
+            self.proxy_model.setSourceModel(model)
+
+
+class DeviceWidget(QtWidgets.QFrame):
+    """A convenient frame with an embedded DeviceView."""
+    closed = QtCore.Signal()
+
+    def __init__(
+        self,
+        parent: Optional[QtWidgets.QWidget] = None,
+        *,
+        device: Optional[ophyd.Device] = None
+    ):
+        super().__init__(parent=parent)
+
+        if device is not None:
+            self.setWindowTitle(device.name)
+
+        self.setMinimumSize(500, 400)
+
+        self.filter_label = QtWidgets.QLabel("&Filter")
+        self.filter_edit = QtWidgets.QLineEdit()
+        self.filter_label.setBuddy(self.filter_edit)
+
+        def set_filter(text):
+            self.view.proxy_model.setFilterRegExp(text)
+
+        self.filter_edit.textEdited.connect(set_filter)
+        self.view = DeviceView(device=device)
+        layout = QtWidgets.QGridLayout()
+        self.setLayout(layout)
+
+        layout.addWidget(self.filter_label, 0, 0)
+        layout.addWidget(self.filter_edit, 0, 1)
+        layout.addWidget(self.view, 1, 0, 1, 2)
+
+    def closeEvent(self, ev):
+        super().closeEvent(ev)
+        self.view.clear()
+        self.closed.emit()
+
+    @property
+    def device(self) -> Optional[ophyd.Device]:
+        return self.view.device
+
+    @device.setter
+    def device(self, device: Optional[ophyd.Device]):
+        self.view.device = device

--- a/atef/widgets/ophyd.py
+++ b/atef/widgets/ophyd.py
@@ -566,16 +566,24 @@ class OphydDeviceTableView(QtWidgets.QTableView):
                 copy_action = self.menu.addAction(f"&Copy: {index.data()}")
                 copy_action.triggered.connect(copy)
 
-            model = self.current_model
-            if model is not None:
-                row_data = self.proxy_model.get_data_for_row(index.row())
-                if row_data is not None:
-                    select_action = self.menu.addAction(
-                        f"&Select attribute: {row_data.attr}"
-                    )
-                    select_action.triggered.connect(select_attr)
+            row_data = self.get_data_from_proxy_index(index)
+            if row_data is not None:
+                select_action = self.menu.addAction(
+                    f"&Select attribute: {row_data.attr}"
+                )
+                select_action.triggered.connect(select_attr)
 
         self.menu.exec_(self.mapToGlobal(pos))
+
+    def get_data_from_proxy_index(
+        self, index: QtCore.QModelIndex
+    ) -> Optional[OphydAttributeData]:
+        """Proxy model index -> source model index -> OphydAttributeData."""
+        model = self.current_model
+        if model is None:
+            return None
+
+        return model.get_data_for_row(self.proxy_model.mapToSource(index).row())
 
     @property
     def current_model(self) -> Optional[PolledDeviceModel]:
@@ -691,7 +699,7 @@ class OphydDeviceTableWidget(DesignerDisplay, QtWidgets.QFrame):
             if model is not None:
                 rows = sorted(
                     set(
-                        index.row()
+                        self.device_table_view.proxy_model.mapToSource(index).row()
                         for index in self.device_table_view.selectedIndexes()
                     )
                 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add widget for selection of happi item
* Add widget for selection of component + viewing of live control system status

## Motivation and Context
Closes #59 

## How Has This Been Tested?
Interactively only

## Where Has This Been Documented?
Issue + PR

## Screenshots (if appropriate):

<details>
<summary>Old screenshots</summary>
### By name / list:

<img width="793" alt="image" src="https://user-images.githubusercontent.com/5139267/165192862-24fd508d-ac7e-4848-8247-114341ec6982.png">


### By selectable category:
<img width="793" alt="image" src="https://user-images.githubusercontent.com/5139267/165192946-9295aa35-f7b8-4584-8de0-348fcf8d901d.png">
</details>

### By name/list (on macOS with simulated IOC)
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/5139267/165410138-29475483-7b34-487c-9fec-c7484099534a.png">

### By beamline (on psbuild)
<img width="1131" alt="image" src="https://user-images.githubusercontent.com/5139267/165411339-e5da7697-d43c-47d0-8b59-0703adbee447.png">


## TODO

- [x] Investigate performance - did enough for now, switched from polling -> user-requested updates
- [x] Add signals for component selection
- [ ] Integrate with config editor
- [ ] Consider if ArchiveDevice can fit into this somehow
- [x] Allow copy/paste of metadata, attribute names, and values
- [x] Look back into sorting bug again
- [x] Add docstrings 
- [ ] Consider adding some tests