### PR TITLE
ENH: GreaterWidget, LessWidget, OrEquals variants

### DIFF
--- a/atef/ui/comp_equals.ui
+++ b/atef/ui/comp_equals.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>238</width>
-    <height>97</height>
+    <height>113</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -31,15 +31,30 @@
    </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>9</number>
+     </property>
      <item>
-      <widget class="QLabel" name="equals_label">
+      <widget class="QLabel" name="x_label">
        <property name="font">
         <font>
          <pointsize>16</pointsize>
         </font>
        </property>
        <property name="text">
-        <string>x = </string>
+        <string>x</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="comp_symbol_label">
+       <property name="font">
+        <font>
+         <pointsize>16</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>=</string>
        </property>
       </widget>
      </item>

--- a/atef/ui/comp_float_gtlt.ui
+++ b/atef/ui/comp_float_gtlt.ui
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>31</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="x_label">
+     <property name="font">
+      <font>
+       <pointsize>16</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>x </string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="comp_symbol_label">
+     <property name="font">
+      <font>
+       <pointsize>16</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>?</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="empty_label">
+     <property name="font">
+      <font>
+       <pointsize>16</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="value_edit">
+     <property name="font">
+      <font>
+       <pointsize>16</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="placeholderText">
+      <string>0.0</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/comp_float_gtlt.ui
+++ b/atef/ui/comp_float_gtlt.ui
@@ -14,6 +14,9 @@
    <string>Form</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="spacing">
+    <number>9</number>
+   </property>
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -34,7 +37,7 @@
       </font>
      </property>
      <property name="text">
-      <string>x </string>
+      <string>x</string>
      </property>
     </widget>
    </item>
@@ -47,18 +50,6 @@
      </property>
      <property name="text">
       <string>?</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="empty_label">
-     <property name="font">
-      <font>
-       <pointsize>16</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string/>
      </property>
     </widget>
    </item>

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -28,9 +28,9 @@ from ..check import (Comparison, Configuration, ConfigurationFile,
                      IdentifierAndComparison, Less, LessOrEqual, NotEquals,
                      PVConfiguration)
 from ..enums import Severity
-from ..qt_helpers import QDataclassBridge, QDataclassList
+from ..qt_helpers import QDataclassBridge, QDataclassList, QDataclassValue
 from ..reduce import ReduceMethod
-from ..type_hints import Number, PrimitiveType
+from ..type_hints import PrimitiveType
 
 logger = logging.getLogger(__name__)
 
@@ -1218,7 +1218,7 @@ class StrListElem(AtefCfgDisplay, QWidget):
 def match_line_edit_text_width(
     line_edit: QLineEdit,
     text: Optional[str] = None,
-    min: int = 40,
+    minimum: int = 40,
     buffer: int = 10,
 ) -> None:
     """
@@ -1238,7 +1238,7 @@ def match_line_edit_text_width(
         In a slot you could pass in the text we get from the
         signal update. If omitted, we'll use the current text
         in the widget.
-    min : int, optional
+    minimum : int, optional
         The minimum width of the line edit, even when we have no
         text. If omitted, we'll use a default value.
     buffer : int, optional
@@ -1250,7 +1250,7 @@ def match_line_edit_text_width(
     if text is None:
         text = line_edit.text()
     width = font_metrics.boundingRect(text).width()
-    line_edit.setFixedWidth(max(width + buffer, min))
+    line_edit.setFixedWidth(max(width + buffer, minimum))
 
 
 class FrameOnEditFilter(QObject):
@@ -1830,6 +1830,101 @@ def user_string_to_bool(text: str) -> bool:
     return True
 
 
+def setup_line_edit_data(
+    line_edit: QLineEdit,
+    value_obj: QDataclassValue,
+    from_str: Callable[[str], Any],
+    to_str: Callable[[Any], str],
+) -> None:
+    """
+    Setup a line edit for bilateral data exchange with a bridge.
+
+    Parameters
+    ----------
+    line_edit : QLineEdit
+        The line edit to set up.
+    value_obj : QDataclassValue
+        The bridge member that has the value we care about.
+    from_str : callable
+        A callable from str to the dataclass value. This is used
+        to interpret the contents of the line edit.
+    to_str : callable
+        A callable from the dataclass value to str. This is used
+        to fill the line edit when the dataclass updates.
+    """
+    def update_dataclass(text: str) -> None:
+        try:
+            value = from_str(text)
+        except ValueError:
+            return
+        value_obj.put(value)
+
+    def update_widget(value: Any) -> None:
+        if not line_edit.hasFocus():
+            try:
+                text = to_str(value)
+            except ValueError:
+                return
+            line_edit.setText(text)
+
+    starting_value = value_obj.get()
+    starting_text = to_str(starting_value)
+    line_edit.setText(starting_text)
+    line_edit.textEdited.connect(update_dataclass)
+    value_obj.changed_value.connect(update_widget)
+
+
+def setup_line_edit_sizing(
+    line_edit: QLineEdit,
+    minimum: int,
+    buffer: int,
+) -> None:
+    """
+    Setup a line edit for dynamic resizing as the text changes.
+
+    Parameters
+    ----------
+    line_edit : QLineEdit,
+        The line edit to setup.
+    minimum : int
+        Minimum width of the line edit in pixels.
+    buffer : int
+        Extra width beyond the exact size of the text in pixels.
+    """
+    def update_sizing(text):
+        match_line_edit_text_width(
+            line_edit=line_edit,
+            text=text,
+            minimum=minimum,
+            buffer=buffer,
+        )
+
+    line_edit.textChanged.connect(update_sizing)
+    update_sizing(line_edit.text())
+
+
+def setup_line_edit_all(
+    line_edit: QLineEdit,
+    value_obj: QDataclassValue,
+    from_str: Callable[[str], Any],
+    to_str: Callable[[Any], str],
+    minimum: int,
+    buffer: int,
+) -> None:
+    """Combination of setup_line_edit_data and setup_line_edit_sizing."""
+    setup_line_edit_data(
+        line_edit=line_edit,
+        value_obj=value_obj,
+        from_str=from_str,
+        to_str=to_str,
+    )
+    setup_line_edit_sizing(
+        line_edit=line_edit,
+        minimum=minimum,
+        buffer=buffer,
+    )
+
+
 class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
     """
     Widget to handle the fields unique to the "Equals" Comparison.
@@ -1890,47 +1985,37 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         """
         for option in self.label_to_type:
             self.data_type_combo.addItem(option)
+        setup_line_edit_all(
+            line_edit=self.value_edit,
+            value_obj=self.bridge.value,
+            from_str=self.value_from_str,
+            to_str=str,
+            minimum=30,
+            buffer=15,
+        )
+        setup_line_edit_data(
+            line_edit=self.atol_edit,
+            value_obj=self.bridge.atol,
+            from_str=float,
+            to_str=str,
+        )
+        setup_line_edit_data(
+            line_edit=self.rtol_edit,
+            value_obj=self.bridge.rtol,
+            from_str=float,
+            to_str=str,
+        )
         starting_value = self.bridge.value.get()
-        starting_text = str(starting_value)
-        self.value_edit.setText(starting_text)
-        self.update_value_size(starting_text)
         self.data_type_combo.setCurrentText(
             self.type_to_label[type(starting_value)]
         )
-        starting_atol = self.bridge.atol.get()
-        if starting_atol is not None:
-            self.atol_edit.setText(str(starting_atol))
-        starting_rtol = self.bridge.rtol.get()
-        if starting_rtol is not None:
-            self.rtol_edit.setText(str(starting_rtol))
-        self.update_range_label()
-        self.value_edit.textEdited.connect(self.new_gui_value)
-        self.atol_edit.textEdited.connect(self.new_gui_atol)
-        self.rtol_edit.textEdited.connect(self.new_gui_rtol)
+        self.update_range_label(starting_value)
         self.data_type_combo.currentTextChanged.connect(self.new_gui_type)
-        self.bridge.value.changed_value.connect(self.new_internal_value)
-        self.bridge.atol.changed_value.connect(self.new_internal_atol)
-        self.bridge.rtol.changed_value.connect(self.new_internal_rtol)
+        self.bridge.value.changed_value.connect(self.update_range_label)
+        self.bridge.atol.changed_value.connect(self.update_range_label)
+        self.bridge.rtol.changed_value.connect(self.update_range_label)
 
-    def update_value_size(self, text: str) -> None:
-        """
-        Call match_line_edit_text_with with specific kwargs.
-
-        This makes the value edit box expand or contract as needed.
-
-        Parameters
-        ----------
-        text : str
-            The text from the textUpdated signal.
-        """
-        match_line_edit_text_width(
-            self.value_edit,
-            text=text,
-            min=30,
-            buffer=15,
-        )
-
-    def update_range_label(self) -> None:
+    def update_range_label(self, *args, **kwargs) -> None:
         """
         Update the range label as appropriate.
 
@@ -1954,59 +2039,32 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
             text = f' ± {diff:.3g}'
         self.range_label.setText(text)
 
-    def new_gui_value(self, value: str) -> None:
+    def value_from_str(
+        self,
+        value: Optional[str] = None,
+        gui_type_str: Optional[str] = None,
+    ) -> PrimitiveType:
         """
-        Slot for when the user inputs a new value using the GUI.
+        Convert our line edit value into a string based on the combobox.
 
         Parameters
         ----------
-        value : str
-            The user's text input from the GUI
-        """
-        self.update_value_size(value)
-        type_cast = self.cast_from_user_str[
-            self.label_to_type[
-                self.data_type_combo.currentText()
-            ]
-        ]
-        try:
-            typed_value = type_cast(value)
-        except ValueError:
-            return
-        self.bridge.value.put(typed_value)
-        self.update_range_label()
+        value : str, optional
+            The text contents of our line edit.
+        gui_type_str : str, optional
+            The text contents of our combobox.
 
-    def new_gui_atol(self, atol: str) -> None:
+        Returns
+        -------
+        converted : Any
+            The casted datatype.
         """
-        Slot for when the user inputs a new atol using the GUI.
-
-        Parameters
-        ----------
-        atol : str
-            The user's text input from the GUI
-        """
-        try:
-            typed_atol = float(atol)
-        except ValueError:
-            return
-        self.bridge.atol.put(typed_atol)
-        self.update_range_label()
-
-    def new_gui_rtol(self, rtol: str) -> None:
-        """
-        Slot for when the user inputs a new atol using the GUI.
-
-        Parameters
-        ----------
-        rtol : str
-            The user's text input from the GUI
-        """
-        try:
-            typed_rtol = float(rtol)
-        except ValueError:
-            return
-        self.bridge.rtol.put(typed_rtol)
-        self.update_range_label()
+        if value is None:
+            value = self.value_edit.text()
+        if gui_type_str is None:
+            gui_type_str = self.data_type_combo.currentText()
+        type_cast = self.cast_from_user_str[self.label_to_type[gui_type_str]]
+        return type_cast(value)
 
     def new_gui_type(self, gui_type_str: str) -> None:
         """
@@ -2024,10 +2082,9 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
             The user's text input from the data type combobox.
         """
         gui_type = self.label_to_type[gui_type_str]
-        user_cast = self.cast_from_user_str[gui_type]
         # Try the gui value first
         try:
-            new_value = user_cast(self.value_edit.text())
+            new_value = self.value_from_str(gui_type_str=gui_type_str)
         except ValueError:
             # Try the bridge value second, or give up
             try:
@@ -2042,59 +2099,6 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         self.atol_edit.setVisible(tol_vis)
         self.rtol_label.setVisible(tol_vis)
         self.rtol_edit.setVisible(tol_vis)
-
-    def new_internal_value(self, value: PrimitiveType) -> None:
-        """
-        Slot for when anything besides the user updates the value.
-
-        Through this, we'll  update the user's live view
-        of the data structure.
-
-        Parameters
-        ----------
-        value : any primitive
-            The value we recieve from the dataclass bridge's
-            changed_value signal.
-        """
-        if not self.value_edit.hasFocus():
-            text = str(value)
-            self.value_edit.setText(text)
-            self.update_value_size(text)
-            self.update_range_label()
-
-    def new_internal_atol(self, atol: Number) -> None:
-        """
-        Slot for when anything besides the user updates the atol.
-
-        Through this, we'll  update the user's live view
-        of the data structure.
-
-        Parameters
-        ----------
-        atol : any primitive
-            The value we recieve from the dataclass bridge's
-            changed_value signal.
-        """
-        if not self.atol_edit.hasFocus():
-            self.atol_edit.setText(str(atol))
-            self.update_range_label()
-
-    def new_internal_rtol(self, rtol: Number) -> None:
-        """
-        Slot for when anything besides the user updates the rtol.
-
-        Through this, we'll  update the user's live view
-        of the data structure.
-
-        Parameters
-        ----------
-        rtol : any primitive
-            The value we recieve from the dataclass bridge's
-            changed_value signal.
-        """
-        if not self.rtol_edit.hasFocus():
-            self.rtol_edit.setText(str(rtol))
-            self.update_range_label()
 
 
 class NotEqualsWidget(EqualsWidget):
@@ -2155,67 +2159,14 @@ class GtLtBaseWidget(AtefCfgDisplay, QWidget):
         - Connect the edit widget to its data field
         """
         self.comp_symbol_label.setText(self.symbol)
-        starting_value = self.bridge.value.get()
-        starting_text = str(starting_value)
-        self.value_edit.setText(starting_text)
-        self.update_value_size(starting_text)
-        self.value_edit.textEdited.connect(self.new_gui_value)
-        self.bridge.value.changed_value.connect(self.new_internal_value)
-
-    def update_value_size(self, text: str) -> None:
-        """
-        Call match_line_edit_text_with with specific kwargs.
-
-        This makes the value edit box expand or contract as needed.
-
-        Parameters
-        ----------
-        text : str
-            The text from the textUpdated signal.
-        """
-        match_line_edit_text_width(
-            self.value_edit,
-            text=text,
-            min=30,
+        setup_line_edit_all(
+            line_edit=self.value_edit,
+            value_obj=self.bridge.value,
+            from_str=float,
+            to_str=str,
+            minimum=30,
             buffer=15,
         )
-
-    def new_gui_value(self, value: str) -> None:
-        """
-        Slot for when the user inputs a new value using the GUI.
-
-        Parameters
-        ----------
-        value : str
-            The user's text input from the GUI
-        """
-        self.update_value_size(value)
-        try:
-            typed_value = int(value)
-        except ValueError:
-            try:
-                typed_value = float(value)
-            except ValueError:
-                return
-        self.bridge.value.put(typed_value)
-
-    def new_internal_value(self, value: Number) -> None:
-        """
-        Slot for when anything besides the user updates the value.
-
-        Through this, we'll  update the user's live view
-        of the data structure.
-
-        Parameters
-        ----------
-        value : any primitive
-            The value we recieve from the dataclass bridge's
-            changed_value signal.
-        """
-        if not self.value_edit.hasFocus():
-            text = str(value)
-            self.value_edit.setText(text)
-            self.update_value_size(text)
 
 
 class GreaterWidget(CompMixin, GtLtBaseWidget):

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1940,6 +1940,7 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
     """
     filename = 'comp_equals.ui'
     data_type = Equals
+    symbol = '='
     label_to_type: Dict[str, type] = {
         'float': float,
         'integer': int,
@@ -1954,7 +1955,7 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
     }
     cast_from_user_str[bool] = user_string_to_bool
 
-    equals_label: QLabel
+    comp_symbol_label: QLabel
     value_edit: QLineEdit
     range_label: QLabel
     atol_label: QLabel
@@ -2014,6 +2015,7 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
         self.bridge.value.changed_value.connect(self.update_range_label)
         self.bridge.atol.changed_value.connect(self.update_range_label)
         self.bridge.rtol.changed_value.connect(self.update_range_label)
+        self.comp_symbol_label.setText(self.symbol)
 
     def update_range_label(self, *args, **kwargs) -> None:
         """
@@ -2036,7 +2038,7 @@ class EqualsWidget(CompMixin, AtefCfgDisplay, QWidget):
             rtol = self.bridge.rtol.get() or 0
 
             diff = atol + abs(rtol * value)
-            text = f' ± {diff:.3g}'
+            text = f'± {diff:.3g}'
         self.range_label.setText(text)
 
     def value_from_str(
@@ -2115,15 +2117,7 @@ class NotEqualsWidget(EqualsWidget):
         The normal qt parent argument
     """
     data_type = NotEquals
-
-    def setup_equals_widget(self) -> None:
-        """
-        After the equals widget setup, change the symbol.
-        """
-        super().setup_equals_widget()
-        self.equals_label.setText(
-            self.equals_label.text().replace('=', '≠')
-        )
+    symbol = '≠'
 
 
 class GtLtBaseWidget(AtefCfgDisplay, QWidget):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add config widgets for the following data classes:
- `Greater`
- `GreaterOrEquals`
- `Less`
- `LessOrEquals`

Includes some code consolidation/deduplication for all of these very similar classes.

Compared to the others, I think these were/will be the simplest to define- there is only one field to represent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Progress towards #30

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings only


## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/10647860/165413889-63fee065-d940-44e1-b4a3-e8822cce500c.png)

