### PR TITLE
ENH: Range widget

### DIFF
--- a/atef/ui/comp_range.ui
+++ b/atef/ui/comp_range.ui
@@ -287,6 +287,9 @@
        <property name="toolTip">
         <string/>
        </property>
+       <property name="penWidth" stdset="0">
+        <double>3.000000000000000</double>
+       </property>
        <property name="rotation" stdset="0">
         <double>90.000000000000000</double>
        </property>
@@ -338,6 +341,9 @@
        <property name="toolTip">
         <string/>
        </property>
+       <property name="penWidth" stdset="0">
+        <double>3.000000000000000</double>
+       </property>
        <property name="rotation" stdset="0">
         <double>90.000000000000000</double>
        </property>
@@ -370,6 +376,9 @@
        <property name="toolTip">
         <string/>
        </property>
+       <property name="penWidth" stdset="0">
+        <double>3.000000000000000</double>
+       </property>
        <property name="rotation" stdset="0">
         <double>90.000000000000000</double>
        </property>
@@ -391,6 +400,9 @@
        </property>
        <property name="toolTip">
         <string/>
+       </property>
+       <property name="penWidth" stdset="0">
+        <double>3.000000000000000</double>
        </property>
        <property name="rotation" stdset="0">
         <double>90.000000000000000</double>

--- a/atef/ui/comp_range.ui
+++ b/atef/ui/comp_range.ui
@@ -1,0 +1,513 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>481</width>
+    <height>226</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <layout class="QGridLayout" name="gridLayout">
+       <property name="horizontalSpacing">
+        <number>9</number>
+       </property>
+       <item row="0" column="3">
+        <widget class="QLabel" name="comp_symbol_label_2">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>?</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="comp_symbol_label_1">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>?</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="x_label_1">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="comp_symbol_label_3">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>?</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="4">
+        <widget class="QLineEdit" name="high_edit">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="placeholderText">
+          <string>0.0</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLineEdit" name="warn_low_edit">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="placeholderText">
+          <string>0.0</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="4">
+        <widget class="QLineEdit" name="warn_high_edit">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="placeholderText">
+          <string>0.0</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QLabel" name="comp_symbol_label_4">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>?</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLineEdit" name="low_edit">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="placeholderText">
+          <string>0.0</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QLabel" name="x_label_2">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="5">
+        <widget class="QLabel" name="pass_fail_label">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>Pass/Fail</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="5">
+        <widget class="QLabel" name="warning_label">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>Warning</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="1" column="3">
+      <widget class="QLabel" name="warn_low_label">
+       <property name="text">
+        <string>0.25</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="PyDMDrawingLine" name="green_line">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="penColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>200</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="penWidth" stdset="0">
+        <double>3.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="PyDMDrawingLine" name="left_red_line">
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="penColor" stdset="0">
+        <color>
+         <red>200</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="penWidth" stdset="0">
+        <double>3.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5" alignment="Qt::AlignHCenter">
+      <widget class="PyDMDrawingLine" name="vertical_line_3">
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="rotation" stdset="0">
+        <double>90.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="PyDMDrawingLine" name="left_yellow_line">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="penColor" stdset="0">
+        <color>
+         <red>200</red>
+         <green>200</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="penWidth" stdset="0">
+        <double>3.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3" alignment="Qt::AlignHCenter">
+      <widget class="PyDMDrawingLine" name="vertical_line_2">
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="rotation" stdset="0">
+        <double>90.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="7">
+      <widget class="QLabel" name="high_label">
+       <property name="text">
+        <string>1</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="7" alignment="Qt::AlignHCenter">
+      <widget class="PyDMDrawingLine" name="vertical_line_4">
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="rotation" stdset="0">
+        <double>90.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1" alignment="Qt::AlignHCenter">
+      <widget class="PyDMDrawingLine" name="vertical_line_1">
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="rotation" stdset="0">
+        <double>90.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="6">
+      <widget class="PyDMDrawingLine" name="right_yellow_line">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="penColor" stdset="0">
+        <color>
+         <red>200</red>
+         <green>200</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="penWidth" stdset="0">
+        <double>3.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="QLabel" name="warn_high_label">
+       <property name="text">
+        <string>0.75</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="8">
+      <widget class="PyDMDrawingLine" name="right_red_line">
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="penColor" stdset="0">
+        <color>
+         <red>200</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="penWidth" stdset="0">
+        <double>3.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="low_label">
+       <property name="text">
+        <string>0</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox">
+     <property name="font">
+      <font>
+       <pointsize>16</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Inclusive</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMDrawingLine</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/comp_range.ui
+++ b/atef/ui/comp_range.ui
@@ -24,70 +24,7 @@
        <property name="horizontalSpacing">
         <number>9</number>
        </property>
-       <item row="0" column="3">
-        <widget class="QLabel" name="comp_symbol_label_2">
-         <property name="font">
-          <font>
-           <pointsize>16</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>?</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="comp_symbol_label_1">
-         <property name="font">
-          <font>
-           <pointsize>16</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>?</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QLabel" name="x_label_1">
-         <property name="font">
-          <font>
-           <pointsize>16</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>x</string>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="1">
-        <widget class="QLabel" name="comp_symbol_label_3">
-         <property name="font">
-          <font>
-           <pointsize>16</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>?</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="4">
-        <widget class="QLineEdit" name="high_edit">
-         <property name="font">
-          <font>
-           <pointsize>16</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="placeholderText">
-          <string>0.0</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
         <widget class="QLineEdit" name="warn_low_edit">
          <property name="font">
           <font>
@@ -102,7 +39,31 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="4">
+       <item row="0" column="4">
+        <widget class="QLabel" name="comp_symbol_label_2">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>?</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="comp_symbol_label_1">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>?</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="5">
         <widget class="QLineEdit" name="warn_high_edit">
          <property name="font">
           <font>
@@ -118,18 +79,18 @@
         </widget>
        </item>
        <item row="1" column="3">
-        <widget class="QLabel" name="comp_symbol_label_4">
+        <widget class="QLabel" name="x_label_2">
          <property name="font">
           <font>
            <pointsize>16</pointsize>
           </font>
          </property>
          <property name="text">
-          <string>?</string>
+          <string>x</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="0">
+       <item row="0" column="1">
         <widget class="QLineEdit" name="low_edit">
          <property name="font">
           <font>
@@ -144,8 +105,8 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="2">
-        <widget class="QLabel" name="x_label_2">
+       <item row="0" column="3">
+        <widget class="QLabel" name="x_label_1">
          <property name="font">
           <font>
            <pointsize>16</pointsize>
@@ -157,6 +118,45 @@
         </widget>
        </item>
        <item row="0" column="5">
+        <widget class="QLineEdit" name="high_edit">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="placeholderText">
+          <string>0.0</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="4">
+        <widget class="QLabel" name="comp_symbol_label_4">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>?</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QLabel" name="comp_symbol_label_3">
+         <property name="font">
+          <font>
+           <pointsize>16</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>?</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
         <widget class="QLabel" name="pass_fail_label">
          <property name="font">
           <font>
@@ -168,7 +168,7 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="5">
+       <item row="1" column="0">
         <widget class="QLabel" name="warning_label">
          <property name="font">
           <font>
@@ -199,6 +199,9 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_2">
+     <property name="horizontalSpacing">
+      <number>0</number>
+     </property>
      <item row="1" column="3">
       <widget class="QLabel" name="warn_low_label">
        <property name="text">
@@ -475,7 +478,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBox">
+    <widget class="QCheckBox" name="inclusive_check">
      <property name="font">
       <font>
        <pointsize>16</pointsize>

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -2388,16 +2388,12 @@ class RangeWidget(CompMixin, DesignerDisplay, QWidget):
             # Something is still None
             ordered = False
         real_space = self.width() * 0.7
-        if ordered:
-            # Looks OK, show everything
-            self.left_yellow_line.show()
-            self.right_yellow_line.show()
-            self.vertical_line_2.show()
-            self.vertical_line_3.show()
-            self.warn_low_label.show()
-            self.warn_high_label.show()
-        else:
-            # Not OK, hide warnings, scale green, set bound colors, and end
+
+        if not ordered or self.bridge.invert.get():
+            # No warning bounds, something is nonphysical, or we are inverted
+            # Note: inversion implies a nonsensical "fail and warn" region
+            # that should be ignored.
+            # Hide warnings, scale green, set bound colors, and end
             self.left_yellow_line.hide()
             self.right_yellow_line.hide()
             self.vertical_line_2.hide()
@@ -2416,6 +2412,14 @@ class RangeWidget(CompMixin, DesignerDisplay, QWidget):
                 self.vertical_line_1.penColor = red
                 self.vertical_line_4.penColor = red
             return
+        else:
+            # Looks OK, show everything
+            self.left_yellow_line.show()
+            self.right_yellow_line.show()
+            self.vertical_line_2.show()
+            self.vertical_line_3.show()
+            self.warn_low_label.show()
+            self.warn_high_label.show()
         # The yellow and green lines should be sized relative to each other
         total_range = high_mark - low_mark
         left_range = warn_low_mark - low_mark

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -13,18 +13,21 @@ from typing import (Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type,
                     Union)
 
 from apischema import deserialize, serialize
+from pydm.widgets.drawing import PyDMDrawingLine
 from qtpy.QtCore import QEvent, QObject, QTimer
 from qtpy.QtCore import Signal as QSignal
-from qtpy.QtWidgets import (QAction, QComboBox, QFileDialog, QFormLayout,
-                            QHBoxLayout, QLabel, QLayout, QLineEdit,
-                            QMainWindow, QMessageBox, QPlainTextEdit,
-                            QPushButton, QTabWidget, QToolButton, QTreeWidget,
-                            QTreeWidgetItem, QVBoxLayout, QWidget)
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import (QAction, QCheckBox, QComboBox, QFileDialog,
+                            QFormLayout, QHBoxLayout, QLabel, QLayout,
+                            QLineEdit, QMainWindow, QMessageBox,
+                            QPlainTextEdit, QPushButton, QTabWidget,
+                            QToolButton, QTreeWidget, QTreeWidgetItem,
+                            QVBoxLayout, QWidget)
 
 from ..check import (Comparison, Configuration, ConfigurationFile,
                      DeviceConfiguration, Equals, Greater, GreaterOrEqual,
                      IdentifierAndComparison, Less, LessOrEqual, NotEquals,
-                     PVConfiguration)
+                     PVConfiguration, Range)
 from ..enums import Severity
 from ..qt_helpers import QDataclassBridge, QDataclassList, QDataclassValue
 from ..reduce import ReduceMethod
@@ -2210,3 +2213,220 @@ class LessOrEqualWidget(CompMixin, GtLtBaseWidget):
     """
     data_type = LessOrEqual
     symbol = '≤'
+
+
+class RangeWidget(CompMixin, DesignerDisplay, QWidget):
+    """
+    Widget to handle the "Range" comparison.
+
+    Contains graphical representations of what the
+    range means, since it might not always be clear
+    to the user what a warning range means.
+
+    Parameters
+    ----------
+    bridge : QDataclassBridge
+        Dataclass bridge to an "Range" object.
+    parent : QObject, keyword-only
+        The normal qt parent argument
+    """
+    filename = 'comp_range.ui'
+    data_type = Range
+
+    _intensity = 200
+    red = QColor.fromRgb(_intensity, 0, 0)
+    yellow = QColor.fromRgb(_intensity, _intensity, 0)
+    green = QColor.fromRgb(0, _intensity, 0)
+
+    bridge: QDataclassBridge
+
+    # Core
+    low_edit: QLineEdit
+    high_edit: QLineEdit
+    warn_low_edit: QLineEdit
+    warn_high_edit: QLineEdit
+    inclusive_check: QCheckBox
+
+    # Symbols
+    comp_symbol_label_1: QLabel
+    comp_symbol_label_2: QLabel
+    comp_symbol_label_3: QLabel
+    comp_symbol_label_4: QLabel
+
+    # Graphical
+    low_label: QLabel
+    high_label: QLabel
+    warn_low_label: QLabel
+    warn_high_label: QLabel
+    left_red_line: PyDMDrawingLine
+    left_yellow_line: PyDMDrawingLine
+    green_line: PyDMDrawingLine
+    right_yellow_line: PyDMDrawingLine
+    right_red_line: PyDMDrawingLine
+    vertical_line_1: PyDMDrawingLine
+    vertical_line_2: PyDMDrawingLine
+    vertical_line_3: PyDMDrawingLine
+    vertical_line_4: PyDMDrawingLine
+
+    def __init__(self, bridge: QDataclassBridge, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.bridge = bridge
+        self.setup_range_widget()
+
+    def setup_range_widget(self) -> None:
+        """
+        Do all the setup required for a range widget.
+
+        - Connect the text entry fields and set the dynamic expand/contract
+        - Set up the inclusive checkbox
+        - Set up the symbols based on the inclusive checkbox
+        - Set up the dynamic behavior of the visualization
+        """
+        # Line edits and visualization
+        for ident in ('low', 'high', 'warn_low', 'warn_high'):
+            line_edit = getattr(self, f'{ident}_edit')
+            value_obj = getattr(self.bridge, ident)
+            # Copy all changes to the visualization labels
+            label = getattr(self, f'{ident}_label')
+            line_edit.textChanged.connect(label.setText)
+            # Trigger the visualization update on any update
+            value_obj.changed_value.connect(self.update_visualization)
+            # Standard setup and initialization
+            setup_line_edit_all(
+                line_edit=line_edit,
+                value_obj=value_obj,
+                from_str=float,
+                to_str=str,
+                minimum=100,
+                buffer=15
+            )
+        # Checkbox
+        self.bridge.inclusive.changed_value.connect(
+            self.inclusive_check.setChecked
+        )
+        self.bridge.inclusive.changed_value.connect(
+            self.update_visualization
+        )
+        self.inclusive_check.clicked.connect(self.bridge.inclusive.put)
+        self.inclusive_check.setChecked(self.bridge.inclusive.get())
+        # Symbols
+        self.bridge.inclusive.changed_value.connect(self.update_symbols)
+        self.update_symbols(self.bridge.inclusive.get())
+        # One additional visual update on inversion
+        self.bridge.invert.changed_value.connect(self.update_visualization)
+        # Make sure this was called at least once
+        self.update_visualization()
+
+    def update_symbols(self, inclusive: bool) -> None:
+        """
+        Pick the symbol type based on range inclusiveness.
+
+        Use the less than symbol if not inclusive, and the the
+        less than or equals symbol if inclusive.
+
+        Parameters
+        ----------
+        inclusive : bool
+            True if the range should be inclusive and False otherwise.
+        """
+        if inclusive:
+            symbol = '≤'
+        else:
+            symbol = '<'
+        for index in range(1, 5):
+            label = getattr(self, f'comp_symbol_label_{index}')
+            label.setText(symbol)
+
+    def resizeEvent(self, *args, **kwargs) -> None:
+        """
+        Override resizeEvent to update the visualization when we resize.
+        """
+        self.update_visualization()
+        return super().resizeEvent(*args, **kwargs)
+
+    def update_visualization(self, *args, **kwargs):
+        """
+        Make the visualization match the current data state.
+        """
+        # Cute trick: swap red and green if we're inverted
+        if self.bridge.invert.get():
+            green = self.red
+            red = self.green
+        else:
+            green = self.green
+            red = self.red
+        yellow = self.yellow
+        self.left_red_line.penColor = red
+        self.left_yellow_line.penColor = yellow
+        self.green_line.penColor = green
+        self.right_yellow_line.penColor = yellow
+        self.right_red_line.penColor = red
+        # The boundary lines should be colored to indicate inclusive/not
+        if self.bridge.inclusive.get():
+            # boundaries are the same as the inner
+            self.vertical_line_1.penColor = yellow
+            self.vertical_line_2.penColor = green
+            self.vertical_line_3.penColor = green
+            self.vertical_line_4.penColor = yellow
+        else:
+            # boundaries are the same as the outer
+            self.vertical_line_1.penColor = red
+            self.vertical_line_2.penColor = yellow
+            self.vertical_line_3.penColor = yellow
+            self.vertical_line_4.penColor = red
+
+        # Get static variables to work with for the resize
+        low_mark = self.bridge.low.get()
+        warn_low_mark = self.bridge.warn_low.get()
+        warn_high_mark = self.bridge.warn_high.get()
+        high_mark = self.bridge.high.get()
+        # Make sure the ranges make sense
+        # Nonsense ranges or no warning set: hide the warnings and skip rest
+        try:
+            ordered = low_mark < warn_low_mark < warn_high_mark < high_mark
+        except TypeError:
+            # Something is still None
+            ordered = False
+        real_space = self.width() * 0.7
+        if ordered:
+            # Looks OK, show everything
+            self.left_yellow_line.show()
+            self.right_yellow_line.show()
+            self.vertical_line_2.show()
+            self.vertical_line_3.show()
+            self.warn_low_label.show()
+            self.warn_high_label.show()
+        else:
+            # Not OK, hide warnings, scale green, set bound colors, and end
+            self.left_yellow_line.hide()
+            self.right_yellow_line.hide()
+            self.vertical_line_2.hide()
+            self.vertical_line_3.hide()
+            self.warn_low_label.hide()
+            self.warn_high_label.hide()
+            self.green_line.setFixedWidth(int(real_space))
+            # Only red and green are available in this case
+            # So we need to do the full check again
+            if self.bridge.inclusive.get():
+                # boundaries are the same as the inner
+                self.vertical_line_1.penColor = green
+                self.vertical_line_4.penColor = green
+            else:
+                # boundaries are the same as the outer
+                self.vertical_line_1.penColor = red
+                self.vertical_line_4.penColor = red
+            return
+        # The yellow and green lines should be sized relative to each other
+        total_range = high_mark - low_mark
+        left_range = warn_low_mark - low_mark
+        mid_range = warn_high_mark - warn_low_mark
+        right_range = high_mark - warn_high_mark
+        self.left_yellow_line.setFixedWidth(int(
+            real_space * left_range/total_range
+        ))
+        self.green_line.setFixedWidth(int(
+            real_space * mid_range/total_range
+        ))
+        self.right_yellow_line.setFixedWidth(int(
+            real_space * right_range/total_range
+        ))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a widget to manipulate the Range comparison dataclass while providing a helpful visualization of the range.
The visualization will change its colors and update the relative spacing of the thresholds as the user changes them.

I've implemented everything I could think of for the visualization while keeping it simple. Some ideas that I discarded because they sounded annoying:
- logarithmic ranges
- single QPainter instead of multi widgets in a grid
- use the mathematical filled/empty dots on the bounds to show inclusive/not

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Continues #30 
The visualization is motivated by a need to disambiguate what exactly the behavior of the checks will be as we manipulate the values here.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings only

## Screenshots (if appropriate):
First open:
![image](https://user-images.githubusercontent.com/10647860/166553592-a20af068-f090-4124-8bad-2fd70b6a6734.png)

Sensible settings:
![image](https://user-images.githubusercontent.com/10647860/166553671-2eaeb345-7935-4dcd-b185-7418e6643e90.png)

The borders move:
![image](https://user-images.githubusercontent.com/10647860/166553714-f5c778c7-892c-41b6-81d3-1508290f678c.png)

Inclusive:
![image](https://user-images.githubusercontent.com/10647860/166553754-16b7e795-732b-4937-b1f1-4aba9935de1d.png)

Inversion:
![image](https://user-images.githubusercontent.com/10647860/166553794-ea68d2a2-1cbd-4661-819e-1eff2d898d6e.png)
