### PR TITLE
REF/ENH: hook up device list with the happi search tool

### DIFF
--- a/atef/ui/config_group.ui
+++ b/atef/ui/config_group.ui
@@ -135,13 +135,6 @@
          </layout>
         </item>
         <item>
-         <widget class="QPushButton" name="add_devices_button">
-          <property name="text">
-           <string>+ Add Device</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>

--- a/atef/ui/happi_search_widget.ui
+++ b/atef/ui/happi_search_widget.ui
@@ -123,23 +123,54 @@
       <item>
        <widget class="HappiDeviceTreeView" name="happi_tree_view" native="true"/>
       </item>
-      <item alignment="Qt::AlignRight">
-       <widget class="QPushButton" name="button_refresh">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
+      <item>
+       <widget class="QFrame" name="frame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>&amp;Refresh</string>
-        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QPushButton" name="button_refresh">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>&amp;Refresh</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="button_choose">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>&amp;Choose</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
@@ -166,7 +197,6 @@
   <tabstop>radio_by_category</tabstop>
   <tabstop>combo_by_category</tabstop>
   <tabstop>edit_filter</tabstop>
-  <tabstop>button_refresh</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/atef/ui/string_list_with_dialog.ui
+++ b/atef/ui/string_list_with_dialog.ui
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>408</width>
+    <height>282</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QListWidget" name="list_strings">
+     <property name="dragEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::InternalMove</enum>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="selectionRectVisible">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="button_layout">
+     <item>
+      <widget class="QToolButton" name="button_add">
+       <property name="text">
+        <string>+</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_remove">
+       <property name="text">
+        <string>-</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/util.py
+++ b/atef/util.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import pathlib
 from typing import Optional, Sequence
@@ -18,6 +19,12 @@ def ophyd_cleanup():
     dispatcher = ophyd.cl.get_dispatcher()
     if dispatcher is not None:
         dispatcher.stop()
+
+
+@functools.lru_cache(None)
+def get_happi_client() -> happi.Client:
+    """Get the atef-configured happi client or the one as-configured by happi."""
+    return happi.Client.from_config()
 
 
 def get_happi_device_by_name(

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -789,9 +789,17 @@ class Group(ConfigTextMixin, DesignerDisplay, QWidget):
             layout=QHBoxLayout(),
         )
         self.tags_content.addWidget(tags_list)
-        self.add_tag_button.clicked.connect(
-            partial(tags_list.add_item, '')
-        )
+
+        def add_tag():
+            if tags_list.widgets and not tags_list.widgets[-1].line_edit.text().strip():
+                # Don't add another tag if we haven't filled out the last one
+                return
+
+            elem = tags_list.add_item('')
+            elem.line_edit.setFocus()
+
+        self.add_tag_button.clicked.connect(add_tag)
+
         if isinstance(self.bridge.data, PVConfiguration):
             self.devices_container.hide()
             self.line_between_adds.hide()
@@ -1021,7 +1029,6 @@ class StringListWithDialog(DesignerDisplay, QWidget):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
-        print(self.show_type_hints())  # TODO: remove
         self.data_list = data_list
         self.allow_duplicates = allow_duplicates
         self._setup_ui()
@@ -1497,9 +1504,17 @@ class IdAndCompWidget(ConfigTextMixin, DesignerDisplay, QWidget):
                 data_list=self.bridge.ids,
                 layout=QVBoxLayout(),
             )
-            self.add_id_button.clicked.connect(
-                partial(identifiers_list.add_item, '')
-            )
+
+            def add_pv():
+                if identifiers_list.widgets:
+                    if not identifiers_list.widgets[-1].line_edit.text().strip():
+                        # Don't add another id if we haven't filled out the last one
+                        return
+
+                widget = identifiers_list.add_item('')
+                widget.line_edit.setFocus()
+
+            self.add_id_button.clicked.connect(add_pv)
 
         self.id_content.addWidget(identifiers_list)
         # Adjust the identifier text appropriately for config type

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -12,7 +12,9 @@ from pprint import pprint
 from typing import (Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type,
                     Union)
 
+import happi
 from apischema import deserialize, serialize
+from qtpy import QtWidgets
 from qtpy.QtCore import QEvent, QObject, QTimer
 from qtpy.QtCore import Signal as QSignal
 from qtpy.QtWidgets import (QAction, QComboBox, QFileDialog, QFormLayout,
@@ -30,6 +32,7 @@ from ..qt_helpers import QDataclassBridge, QDataclassList, QDataclassValue
 from ..reduce import ReduceMethod
 from ..type_hints import PrimitiveType
 from .core import DesignerDisplay
+from .happi import HappiSearchWidget
 
 logger = logging.getLogger(__name__)
 
@@ -750,7 +753,6 @@ class Group(ConfigTextMixin, DesignerDisplay, QWidget):
     add_tag_button: QToolButton
     devices_container: QWidget
     devices_content: QVBoxLayout
-    add_devices_button: QPushButton
     checklists_container: QWidget
     checklists_content: QVBoxLayout
     add_checklist_button: QPushButton
@@ -794,14 +796,10 @@ class Group(ConfigTextMixin, DesignerDisplay, QWidget):
             self.devices_container.hide()
             self.line_between_adds.hide()
         else:
-            devices_list = StrList(
+            devices_list = DeviceListWidget(
                 data_list=self.bridge.devices,
-                layout=QVBoxLayout(),
             )
             self.devices_content.addWidget(devices_list)
-            self.add_devices_button.clicked.connect(
-                partial(devices_list.add_item, '')
-            )
         self.checklist_list = NamedDataclassList(
             data_list=self.bridge.checklist,
             layout=QVBoxLayout(),
@@ -987,6 +985,157 @@ class StrList(QWidget):
         self.widgets.remove(item)
         self.data_list.remove_index(index)
         item.deleteLater()
+
+
+class StringListWithDialog(DesignerDisplay, QWidget):
+    """
+    A widget used to modify the str variant of QDataclassList, tied to a
+    specific dialog that helps with selection of strings.
+
+    The ``item_add_request`` signal must be hooked into with the
+    caller-specific dialog tool.  This class may be subclassed to add this
+    functionality.
+
+    Parameters
+    ----------
+    data_list : QDataclassList
+        The dataclass list to edit using this widget.
+
+    allow_duplicates : bool, optional
+        Allow duplicate entries in the list.  Defaults to False.
+    """
+    filename: ClassVar[str] = "string_list_with_dialog.ui"
+    item_add_request: ClassVar[QSignal] = QSignal()
+    item_edit_request: ClassVar[QSignal] = QSignal(list)  # List[str]
+
+    button_add: QtWidgets.QToolButton
+    button_layout: QtWidgets.QVBoxLayout
+    button_remove: QtWidgets.QToolButton
+    list_strings: QtWidgets.QListWidget
+
+    def __init__(
+        self,
+        data_list: QDataclassList,
+        allow_duplicates: bool = False,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        print(self.show_type_hints())  # TODO: remove
+        self.data_list = data_list
+        self.allow_duplicates = allow_duplicates
+        self._setup_ui()
+
+    def _setup_ui(self):
+        starting_list = self.data_list.get()
+        for starting_value in starting_list or []:
+            self._add_item(starting_value, init=True)
+
+        # def test():
+        #     text, success = QtWidgets.QInputDialog.getText(
+        #         self, "Device name", "Device name?"
+        #     )
+        #     if success:
+        #         self.add_items([item for item in text.strip().split() if item])
+
+        self.button_add.clicked.connect(self.item_add_request.emit)
+        self.button_remove.clicked.connect(self._remove_item_request)
+
+        def _edit_item_request():
+            self.item_edit_request.emit(self.selected_items_text)
+
+        self.list_strings.doubleClicked.connect(_edit_item_request)
+
+    def _add_item(self, item: str, *, init: bool = False):
+        """
+        Add an item to the QListWidget and the bridge (if init is not set).
+
+        Parameters
+        ----------
+        item : str
+            The item to add.
+
+        init : bool, optional
+            Whether or not this is the initial initialization of this widget.
+            This will be set to True in __init__ so that we don't mutate
+            the underlying dataclass. False, the default, means that we're
+            adding a new dataclass to the list, which means we should
+            definitely append it.
+        """
+        if not self.allow_duplicates and item in self.data_list.get():
+            return
+
+        if not init:
+            self.data_list.append(item)
+
+        self.list_strings.addItem(QtWidgets.QListWidgetItem(item))
+
+    def add_items(self, items: List[str]) -> None:
+        """
+        Add one or more strings to the QListWidget and the bridge.
+
+        Parameters
+        ----------
+        item : list of str
+            The item(s) to add.
+        """
+        for item in items:
+            self._add_item(item)
+
+    @property
+    def selected_items_text(self) -> List[str]:
+        """
+        The text of item(s) currently selected in the QListWidget.
+
+        Returns
+        -------
+        selected : list of str
+        """
+        return [item.text() for item in list(self.list_strings.selectedItems())]
+
+    def _remove_item_request(self):
+        """Qt hook: user requested item removal."""
+        for item in list(self.list_strings.selectedItems()):
+            self.data_list.remove_value(item.text())
+            self.list_strings.removeItemWidget(item)
+
+
+class DeviceListWidget(StringListWithDialog):
+    """
+    Device list widget, with ``HappiSearchWidget`` for adding new devices.
+    """
+
+    _client: ClassVar[Optional[happi.Client]] = None
+    _search_widget: Optional[HappiSearchWidget] = None
+
+    def _setup_ui(self):
+        super()._setup_ui()
+        self.item_add_request.connect(self._open_device_chooser)
+        self.item_edit_request.connect(self._open_device_chooser)
+
+    def _open_device_chooser(self, to_select: Optional[List[str]] = None):
+        """
+        Hook: User requested adding/editing an existing device.
+
+        Parameters
+        ----------
+        to_select : list of str, optional
+            If provided, the device chooser will filter for these items.
+        """
+        if DeviceListWidget._client is None:
+            DeviceListWidget._client = happi.Client.from_config()
+
+        self._search_widget = HappiSearchWidget(
+            client=DeviceListWidget._client,
+        )
+
+        self._search_widget.happi_items_chosen.connect(self.add_items)
+        self._search_widget.show()
+        self._search_widget.activateWindow()
+
+        self._search_widget.edit_filter.setText(
+            "|".join(to_select or []),
+        )
 
 
 class NamedDataclassList(StrList):

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1105,9 +1105,9 @@ class StringListWithDialog(DesignerDisplay, QWidget):
 
     def _remove_item_request(self):
         """Qt hook: user requested item removal."""
-        for item in list(self.list_strings.selectedItems()):
+        for item in self.list_strings.selectedItems():
             self.data_list.remove_value(item.text())
-            self.list_strings.removeItemWidget(item)
+            self.list_strings.takeItem(self.list_strings.row(item))
 
 
 class DeviceListWidget(StringListWithDialog):

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -12,7 +12,6 @@ from pprint import pprint
 from typing import (Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type,
                     Union)
 
-import happi
 from apischema import deserialize, serialize
 from qtpy import QtWidgets
 from qtpy.QtCore import QEvent, QObject, QTimer
@@ -23,6 +22,7 @@ from qtpy.QtWidgets import (QAction, QComboBox, QFileDialog, QFormLayout,
                             QPushButton, QTabWidget, QToolButton, QTreeWidget,
                             QTreeWidgetItem, QVBoxLayout, QWidget)
 
+from .. import util
 from ..check import (Comparison, Configuration, ConfigurationFile,
                      DeviceConfiguration, Equals, Greater, GreaterOrEqual,
                      IdentifierAndComparison, Less, LessOrEqual, NotEquals,
@@ -1105,7 +1105,6 @@ class DeviceListWidget(StringListWithDialog):
     Device list widget, with ``HappiSearchWidget`` for adding new devices.
     """
 
-    _client: ClassVar[Optional[happi.Client]] = None
     _search_widget: Optional[HappiSearchWidget] = None
 
     def _setup_ui(self):
@@ -1122,13 +1121,7 @@ class DeviceListWidget(StringListWithDialog):
         to_select : list of str, optional
             If provided, the device chooser will filter for these items.
         """
-        if DeviceListWidget._client is None:
-            DeviceListWidget._client = happi.Client.from_config()
-
-        self._search_widget = HappiSearchWidget(
-            client=DeviceListWidget._client,
-        )
-
+        self._search_widget = HappiSearchWidget(client=util.get_happi_client())
         self._search_widget.happi_items_chosen.connect(self.add_items)
         self._search_widget.show()
         self._search_widget.activateWindow()

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1197,7 +1197,7 @@ class NamedDataclassList(StrList):
         vertically, etc.
     """
     bridge_item_removed = QSignal(QDataclassBridge)
-    bridges = List[QDataclassBridge]
+    bridges: List[QDataclassBridge]
 
     def __init__(self, *args, **kwargs):
         self.bridges = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Use the happi search widget as a device selector
* Use the device/component widget as an attribute selector
* Select happi items and double-click them or click "choose"/'select" with them selected

## Motivation and Context
* Typing in device names is not fun and error-prone
* Typing in component names is even worse

## How Has This Been Tested?
* Interactively

## Where Has This Been Documented?
* PR text, as we do 

## Screenshots (if appropriate):
<img width="1218" alt="image" src="https://user-images.githubusercontent.com/5139267/166575443-b0b17e51-aca1-4fca-8c46-7e77bd8d29c1.png">

<img width="1253" alt="image" src="https://user-images.githubusercontent.com/5139267/166587629-65ae31de-a58e-44dc-b619-435cefa93c72.png">
