### PR TITLE
REF/ENH: navigation improvements

### DIFF
--- a/atef/ui/comp_view.ui
+++ b/atef/ui/comp_view.ui
@@ -20,6 +20,13 @@
       <number>0</number>
      </property>
      <item>
+      <widget class="QToolButton" name="parent_button">
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Name:</string>
@@ -44,13 +51,6 @@
         </size>
        </property>
       </spacer>
-     </item>
-     <item>
-      <widget class="QToolButton" name="parent_button">
-       <property name="text">
-        <string>...</string>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>

--- a/atef/ui/comp_view.ui
+++ b/atef/ui/comp_view.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>358</height>
+    <height>364</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -44,6 +44,13 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="parent_button">
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/atef/ui/config_group.ui
+++ b/atef/ui/config_group.ui
@@ -150,19 +150,6 @@
           </property>
          </layout>
         </item>
-        <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
        </layout>
       </widget>
      </item>

--- a/atef/ui/config_group.ui
+++ b/atef/ui/config_group.ui
@@ -121,8 +121,17 @@
      <item>
       <widget class="QWidget" name="devices_container" native="true">
        <layout class="QVBoxLayout" name="devices_container_layout">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
         <property name="bottomMargin">
-         <number>1</number>
+         <number>0</number>
         </property>
         <item>
          <widget class="QLabel" name="label_4">
@@ -167,8 +176,17 @@
      <item>
       <widget class="QWidget" name="checklists_container" native="true">
        <layout class="QVBoxLayout" name="checklists_container_layout">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
         <property name="bottomMargin">
-         <number>1</number>
+         <number>0</number>
         </property>
         <item>
          <widget class="QLabel" name="label_5">

--- a/atef/ui/config_group.ui
+++ b/atef/ui/config_group.ui
@@ -46,6 +46,13 @@
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QToolButton" name="parent_button">
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/atef/ui/config_group.ui
+++ b/atef/ui/config_group.ui
@@ -17,6 +17,13 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QToolButton" name="parent_button">
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Name:</string>
@@ -45,13 +52,6 @@
         </size>
        </property>
       </spacer>
-     </item>
-     <item>
-      <widget class="QToolButton" name="parent_button">
-       <property name="text">
-        <string>...</string>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>

--- a/atef/ui/config_overview_row.ui
+++ b/atef/ui/config_overview_row.ui
@@ -68,6 +68,13 @@
          <number>0</number>
         </property>
         <item>
+         <widget class="QToolButton" name="child_button">
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QLineEdit" name="name_edit">
           <property name="text">
            <string/>
@@ -80,13 +87,6 @@
           </property>
           <property name="clearButtonEnabled">
            <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="delete_button">
-          <property name="text">
-           <string>DELETE CONFIG</string>
           </property>
          </widget>
         </item>
@@ -143,9 +143,9 @@
          </widget>
         </item>
         <item>
-         <widget class="QToolButton" name="child_button">
+         <widget class="QToolButton" name="delete_button">
           <property name="text">
-           <string>...</string>
+           <string>X</string>
           </property>
          </widget>
         </item>

--- a/atef/ui/config_overview_row.ui
+++ b/atef/ui/config_overview_row.ui
@@ -142,6 +142,13 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QToolButton" name="child_button">
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>

--- a/atef/ui/config_overview_row.ui
+++ b/atef/ui/config_overview_row.ui
@@ -144,6 +144,9 @@
         </item>
         <item>
          <widget class="QToolButton" name="delete_button">
+          <property name="toolTip">
+           <string>Delete configuration</string>
+          </property>
           <property name="text">
            <string>X</string>
           </property>

--- a/atef/ui/id_and_comp.ui
+++ b/atef/ui/id_and_comp.ui
@@ -56,43 +56,51 @@
     </layout>
    </item>
    <item>
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QLabel" name="id_label">
-         <property name="text">
-          <string>Identifiers</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="id_content"/>
-       </item>
-       <item>
-        <widget class="QPushButton" name="add_id_button">
-         <property name="text">
-          <string>Add Identifier</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
+      <widget class="QWidget" name="id_container" native="true">
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="id_label">
+          <property name="text">
+           <string>Identifiers</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="id_content"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="add_id_button">
+          <property name="text">
+           <string>Add Identifier</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </item>
      <item>
       <widget class="Line" name="line">
@@ -102,41 +110,55 @@
       </widget>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <widget class="QLabel" name="comp_label">
-         <property name="text">
-          <string>Comparisons</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="comp_content"/>
-       </item>
-       <item>
-        <widget class="QPushButton" name="add_comp_button">
-         <property name="text">
-          <string>Add Comparison</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
+      <widget class="QWidget" name="comp_container" native="true">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="comp_label">
+          <property name="text">
+           <string>Comparisons</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="comp_content"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="add_comp_button">
+          <property name="text">
+           <string>Add Comparison</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
      </item>
     </layout>
    </item>

--- a/atef/ui/id_and_comp.ui
+++ b/atef/ui/id_and_comp.ui
@@ -15,11 +15,45 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLineEdit" name="name_edit">
-     <property name="placeholderText">
-      <string>name</string>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="bottomMargin">
+      <number>0</number>
      </property>
-    </widget>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="name_edit">
+       <property name="placeholderText">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="parent_button">
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/atef/ui/id_and_comp.ui
+++ b/atef/ui/id_and_comp.ui
@@ -20,6 +20,13 @@
       <number>0</number>
      </property>
      <item>
+      <widget class="QToolButton" name="parent_button">
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Name:</string>
@@ -45,13 +52,6 @@
         </size>
        </property>
       </spacer>
-     </item>
-     <item>
-      <widget class="QToolButton" name="parent_button">
-       <property name="text">
-        <string>...</string>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>

--- a/atef/ui/str_list_elem.ui
+++ b/atef/ui/str_list_elem.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>392</width>
+    <width>387</width>
     <height>53</height>
    </rect>
   </property>
@@ -33,6 +33,13 @@
     <number>0</number>
    </property>
    <item>
+    <widget class="QToolButton" name="child_button">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLineEdit" name="line_edit">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -58,13 +65,6 @@
      </property>
      <property name="text">
       <string>X</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QToolButton" name="child_button">
-     <property name="text">
-      <string>...</string>
      </property>
     </widget>
    </item>

--- a/atef/ui/str_list_elem.ui
+++ b/atef/ui/str_list_elem.ui
@@ -63,6 +63,9 @@
        <height>0</height>
       </size>
      </property>
+     <property name="toolTip">
+      <string>Delete item</string>
+     </property>
      <property name="text">
       <string>X</string>
      </property>

--- a/atef/ui/str_list_elem.ui
+++ b/atef/ui/str_list_elem.ui
@@ -61,6 +61,13 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QToolButton" name="child_button">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1552,7 +1552,7 @@ class IdAndCompWidget(ConfigTextMixin, DesignerDisplay, PageWidget):
         self,
         bridge: QDataclassBridge,
         config_type: Type[Configuration],
-        parent: Optional[QWidget]
+        parent: Optional[QWidget] = None,
     ):
         super().__init__(bridge, parent=parent)
         self.config_type = config_type

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -40,31 +40,6 @@ from .happi import HappiDeviceComponentWidget, HappiSearchWidget
 logger = logging.getLogger(__name__)
 
 
-"""
-Some refactor planning: to remove later when it is no longer needed
-
-Problem is that the code here is confusing and difficult to extend
-I want to apply some order/uniformity and use that order to
-improve the navigation.
-
-I will have three kinds of widgets here:
-1. One/few-offs: the big ones (Window, Tree, etc)
-   - no special unifying elements are needed
-2. Embeddables: the small ones (repeated/reused elements, etc)
-   - no special unifying elements are needed
-3. Pages: the bit that goes on the right, corresponse to a tree node
-   - let's give them some consistent methods
-     def __init__(self, bridge, container_bridge):
-         ...
-     def assign_tree_item(self, tree_item):
-         ...
-
-And then our tree items need some additional methods:
-def assign_widget(self, widget):
-    ...
-"""
-
-
 class Window(DesignerDisplay, QMainWindow):
     """
     Main atef config window

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -320,13 +320,12 @@ class AtefItem(QTreeWidgetItem):
         if func_name is not None:
             self.setText(1, func_name)
         if isinstance(tree_parent, QTreeWidget):
-            tree_parent.insertTopLevelItem(0, self)
             self.parent_tree_item = tree_parent.invisibleRootItem()
             self.full_tree = tree_parent
         else:
-            tree_parent.addChild(self)
             self.parent_tree_item = tree_parent
             self.full_tree = tree_parent.full_tree
+        self.parent_tree_item.addChild(self)
 
     def assign_widget(self, widget: PageWidget) -> None:
         """

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -339,7 +339,7 @@ class AtefItem(QTreeWidgetItem):
         self.widget = widget
 
 
-class PageWidget(QWidget):
+class PageWidget(DesignerDisplay, QWidget):
     """
     Interface for widgets that correspond to a tree node.
 
@@ -367,6 +367,10 @@ class PageWidget(QWidget):
     full_tree: QTreeWidget
 
     parent_button: QToolButton
+
+    # Placeholder for DesignerDisplay's __init_subclass__
+    # Must be overriden properly in PageWidget subclasses
+    filename = ''
 
     def __init__(
         self,
@@ -436,7 +440,7 @@ def link_page(item: AtefItem, widget: PageWidget):
     widget.assign_tree_item(item)
 
 
-class Overview(DesignerDisplay, PageWidget):
+class Overview(PageWidget):
     """
     A view of all the top-level "Configuration" objects.
 
@@ -814,7 +818,7 @@ class OverviewRow(ConfigTextMixin, DesignerDisplay, QWidget):
         self.overview.delete_row(self)
 
 
-class Group(ConfigTextMixin, DesignerDisplay, PageWidget):
+class Group(ConfigTextMixin, PageWidget):
     """
     The group of checklists and devices associated with a Configuration.
 
@@ -1518,7 +1522,7 @@ class FrameOnEditFilter(QObject):
         return False
 
 
-class IdAndCompWidget(ConfigTextMixin, DesignerDisplay, PageWidget):
+class IdAndCompWidget(ConfigTextMixin, PageWidget):
     """
     A widget to manage the ids and comparisons associated with a checklist.
 
@@ -1714,7 +1718,7 @@ class IdAndCompWidget(ConfigTextMixin, DesignerDisplay, PageWidget):
         bridge.deleteLater()
 
 
-class CompView(ConfigTextMixin, DesignerDisplay, PageWidget):
+class CompView(ConfigTextMixin, PageWidget):
     """
     Widget to view and edit a single Comparison subclass.
 
@@ -2221,7 +2225,7 @@ class BasicSymbolMixin:
         )
 
 
-class EqualsWidget(CompMixin, BasicSymbolMixin, DesignerDisplay, PageWidget):
+class EqualsWidget(CompMixin, BasicSymbolMixin, PageWidget):
     """
     Widget to handle the fields unique to the "Equals" Comparison.
 
@@ -2404,7 +2408,7 @@ class NotEqualsWidget(EqualsWidget):
     symbol = '≠'
 
 
-class GtLtBaseWidget(BasicSymbolMixin, DesignerDisplay, PageWidget):
+class GtLtBaseWidget(BasicSymbolMixin, PageWidget):
     """
     Base widget for comparisons like greater, less, etc.
 
@@ -2487,7 +2491,7 @@ class LessOrEqualWidget(CompMixin, GtLtBaseWidget):
     symbol = '≤'
 
 
-class RangeWidget(CompMixin, DesignerDisplay, PageWidget):
+class RangeWidget(CompMixin, PageWidget):
     """
     Widget to handle the "Range" comparison.
 

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -838,21 +838,21 @@ class OverviewRow(ConfigTextMixin, DesignerDisplay, QWidget):
             self.setStyleSheet(
                 "QLineEdit, QPlainTextEdit { background: transparent }"
             )
-            self.delete_button.hide()
+            self.delete_button.setEnabled(False)
         else:
             self.desc_edit.setFrameShape(self.desc_edit.StyledPanel)
             self.setStyleSheet(
                 "QLineEdit, QPlainTextEdit { background: white }"
             )
             if not self.name_edit.text():
-                self.delete_button.show()
+                self.delete_button.setEnabled(True)
 
     def on_name_changed(self, name: str) -> None:
         """
         Actions to perform when the name field changes.
 
-        This will hide/show the delete button as appropriate.
-        Only show the delete button in an unlocked state with an
+        This will disable the delete button as appropriate.
+        Only enable the delete button in an unlocked state with an
         empty name. This is to help prevent someone from
         accidentally nuking their entire config tree.
 
@@ -862,9 +862,9 @@ class OverviewRow(ConfigTextMixin, DesignerDisplay, QWidget):
             The updated configuration name.
         """
         if not name and not self.lock_button.isChecked():
-            self.delete_button.show()
+            self.delete_button.setEnabled(True)
         else:
-            self.delete_button.hide()
+            self.delete_button.setEnabled(False)
 
     def delete_this_config(self, checked: Optional[bool] = None) -> None:
         """

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1639,6 +1639,7 @@ class IdAndCompWidget(ConfigTextMixin, PageWidget):
                 data_list=self.bridge.ids,
                 layout=QVBoxLayout(),
             )
+            self.id_container.layout().addStretch(10)
 
             def add_pv():
                 if identifiers_list.widgets:

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -523,9 +523,12 @@ class Overview(PageWidget):
         super().__init__(bridge, parent=parent)
         self.row_count = 0
         self.row_mapping = {}
-        self.initialize_overview()
         self.add_device_button.clicked.connect(self.add_device_config)
         self.add_pv_button.clicked.connect(self.add_pv_config)
+
+    def assign_tree_item(self, item: AtefItem):
+        super().assign_tree_item(item)
+        self.initialize_overview()
 
     def initialize_overview(self):
         """
@@ -917,6 +920,9 @@ class Group(ConfigTextMixin, PageWidget):
     ):
         super().__init__(bridge, parent=parent)
         self.bridge_item_map = {}
+
+    def assign_tree_item(self, item: AtefItem):
+        super().assign_tree_item(item)
         self.initialize_group()
 
     def initialize_group(self) -> None:
@@ -1658,6 +1664,9 @@ class IdAndCompWidget(ConfigTextMixin, PageWidget):
         super().__init__(bridge, parent=parent)
         self.config_type = config_type
         self.bridge_item_map = {}
+
+    def assign_tree_item(self, item: AtefItem):
+        super().assign_tree_item(item)
         self.initialize_idcomp()
 
     def initialize_idcomp(self) -> None:
@@ -1924,6 +1933,9 @@ class CompView(ConfigTextMixin, PageWidget):
         super().__init__(bridge, parent=parent)
         self.id_and_comp = id_and_comp
         self.comparison_setup_done = False
+
+    def assign_tree_item(self, item: AtefItem):
+        super().assign_tree_item(item)
         self.initialize_comp_view()
 
     def initialize_comp_view(self) -> None:

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -875,6 +875,7 @@ class Group(ConfigTextMixin, PageWidget):
         - Hide the devices layout for PVConfiguration
         - Set up the devices widget for DeviceConfiguration
         - Set up the list of checklists widget
+        - Set the sizing rules for the two columns
         """
         self.initialize_config_text()
         tags_list = StrList(
@@ -912,6 +913,23 @@ class Group(ConfigTextMixin, PageWidget):
         for bridge in self.checklist_list.bridges:
             self.setup_checklist_item_bridge(bridge)
         self.add_checklist_button.clicked.connect(self.add_checklist)
+        self.resize_columns()
+
+    def resize_columns(self) -> None:
+        """
+        Set the column widths to be equal and less than half the full weidth.
+        """
+        full_width = self.width()
+        col_width = int(full_width*0.45)
+        self.checklists_container.setFixedWidth(col_width)
+        self.devices_container.setFixedWidth(col_width)
+
+    def resizeEvent(self, *args, **kwargs) -> None:
+        """
+        Override resizeEvent to update the column widths when we resize.
+        """
+        self.resize_columns()
+        return super().resizeEvent(*args, **kwargs)
 
     def setup_checklist_item_bridge(self, bridge: QDataclassBridge) -> None:
         """

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -803,6 +803,8 @@ class OverviewRow(ConfigTextMixin, DesignerDisplay, QWidget):
         if self.name_edit.text():
             # Start locked if we are reading from file
             self.lock_button.toggle()
+        icon = self.style().standardIcon(QStyle.SP_TitleBarCloseButton)
+        self.delete_button.setIcon(icon)
 
     def lock_editing(self, locked: bool):
         """
@@ -1542,6 +1544,8 @@ class StrListElem(DesignerDisplay, QWidget):
         self.on_text_changed(start_text)
         self.line_edit.textChanged.connect(self.on_text_changed)
         self.child_button.hide()
+        icon = self.style().standardIcon(QStyle.SP_TitleBarCloseButton)
+        self.del_button.setIcon(icon)
 
     def on_text_changed(self, text: str) -> None:
         """

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1790,7 +1790,7 @@ class CompView(ConfigTextMixin, DesignerDisplay, PageWidget):
         self,
         bridge: QDataclassBridge,
         id_and_comp: IdAndCompWidget,
-        parent: Optional(QWidget) = None,
+        parent: Optional[QWidget] = None,
     ):
         super().__init__(bridge, parent=parent)
         self.id_and_comp = id_and_comp

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -270,7 +270,7 @@ class Tree(DesignerDisplay, QWidget):
             name='Overview',
             func_name='overview'
         )
-        overview = Overview(self.bridge.config)
+        overview = Overview(self.bridge.configs)
         link_page(item=self.overview_item, widget=overview)
 
     def show_selected_display(self, *args, **kwargs):
@@ -579,7 +579,7 @@ class Overview(DesignerDisplay, PageWidget):
         # Note: this is the only place in the UI where
         # we add new config data
         if update_data:
-            self.config_list.append(config)
+            self.bridge.append(config)
 
     def delete_row(self, row: OverviewRow) -> None:
         """
@@ -597,8 +597,8 @@ class Overview(DesignerDisplay, PageWidget):
             dataclass.
         """
         config, tree_item = self.row_mapping[row]
-        self.config_list.remove_value(config)
-        self.tree_ref.invisibleRootItem().removeChild(tree_item)
+        self.bridge.remove_value(config)
+        self.full_tree.invisibleRootItem().removeChild(tree_item)
         self.row_count -= 1
         del self.row_mapping[row]
         row.deleteLater()

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -417,8 +417,18 @@ class PageWidget(DesignerDisplay, QWidget):
     def navigate_to_parent(self, *args, **kwargs):
         """
         Make the tree switch to this widget's parent in the tree.
+
+        If there is no parent, this should instead go to the overview
+        widget. This is for the top-level widgets whose parents are
+        technically the invisible root item. Logically the overview
+        item is the main parent but visually in the tree it's annoying
+        to have all configs grouped under the same item.
         """
-        self.navigate_to(self.parent_tree_item)
+        if isinstance(self.parent_tree_item, AtefItem):
+            self.navigate_to(self.parent_tree_item)
+        else:
+            overview_item = self.full_tree.topLevelItem(0)
+            self.navigate_to(overview_item)
 
 
 def link_page(item: AtefItem, widget: PageWidget):

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -21,7 +21,7 @@ from qtpy.QtGui import QColor
 from qtpy.QtWidgets import (QAction, QCheckBox, QComboBox, QFileDialog,
                             QFormLayout, QHBoxLayout, QLabel, QLayout,
                             QLineEdit, QMainWindow, QMessageBox,
-                            QPlainTextEdit, QPushButton, QTabWidget,
+                            QPlainTextEdit, QPushButton, QStyle, QTabWidget,
                             QToolButton, QTreeWidget, QTreeWidgetItem,
                             QVBoxLayout, QWidget)
 
@@ -726,7 +726,37 @@ class OverviewRow(ConfigTextMixin, DesignerDisplay, QWidget):
         self.overview.delete_row(self)
 
 
-class Group(ConfigTextMixin, DesignerDisplay, QWidget):
+class TreeParentMixin:
+    """
+    Mix-in class for displays that have a tree parent display.
+
+    These displays should contain a QToolButton named "parent_button"
+    and should have a reference to their AtefItem named "tree_item"
+    for easy access to the tree structure.
+
+    This mix-in will put an icon on that button and will make the
+    tree select and display the parent in the tree when the
+    button in pressed.
+    """
+    parent_button: QToolButton
+    tree_item: AtefItem
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setup_parent_button()
+
+    def setup_parent_button(self):
+        self.parent_button.clicked.connect(self.navigate_to_parent)
+        icon = self.style().standardIcon(QStyle.SP_FileDialogToParent)
+        self.parent_button.setIcon(icon)
+
+    def navigate_to_parent(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Still need to get a reference to the tree widget"
+        )
+
+
+class Group(TreeParentMixin, ConfigTextMixin, DesignerDisplay, QWidget):
     """
     The group of checklists and devices associated with a Configuration.
 

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -254,8 +254,10 @@ class Tree(DesignerDisplay, QWidget):
         self.last_selection: Optional[AtefItem] = None
         self.built_widgets = set()
         self.assemble_tree()
-        self.show_selected_display(self.overview_item)
-        self.tree_widget.itemPressed.connect(self.show_selected_display)
+        self.tree_widget.itemSelectionChanged.connect(
+            self.show_selected_display
+        )
+        self.tree_widget.setCurrentItem(self.overview_item)
 
     def assemble_tree(self):
         """
@@ -271,20 +273,14 @@ class Tree(DesignerDisplay, QWidget):
         )
         self.tree_widget.insertTopLevelItem(0, self.overview_item)
 
-    def show_selected_display(self, item: AtefItem, *args, **kwargs):
+    def show_selected_display(self, *args, **kwargs):
         """
         Show the proper widget on the right when a tree row is selected.
 
         This works by hiding the previous widget and showing the new
         selection, creating the widget object if needed.
-
-        Parameters
-        ----------
-        item : AtefItem
-            The selected item in the tree. This contains information like
-            the textual annotation, cached widget references, and
-            arguments for creating a new widget if needed.
         """
+        item = self.tree_widget.currentItem()
         if item is self.last_selection:
             return
         if self.last_selection is not None:

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -2200,9 +2200,8 @@ class BasicSymbolMixin:
     value_edit: QLineEdit
     comp_symbol_label: QLabel
 
-    def __init__(self, bridge: QDataclassBridge, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.bridge = bridge
         self._setup_symbol_comparison()
 
     def _setup_symbol_comparison(self):
@@ -2543,7 +2542,7 @@ class RangeWidget(CompMixin, DesignerDisplay, PageWidget):
     vertical_line_3: PyDMDrawingLine
     vertical_line_4: PyDMDrawingLine
 
-    def __init__(self, bridge: QDataclassBridge, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setup_range_widget()
 

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -917,12 +917,16 @@ class Group(ConfigTextMixin, PageWidget):
 
     def resize_columns(self) -> None:
         """
-        Set the column widths to be equal and less than half the full weidth.
+        Set the column widths to be equal and less than half the full width.
+
+        This only needs to be done for the device configuration. For PV
+        configuration we only have one column.
         """
-        full_width = self.width()
-        col_width = int(full_width*0.45)
-        self.checklists_container.setFixedWidth(col_width)
-        self.devices_container.setFixedWidth(col_width)
+        if isinstance(self.bridge.data, DeviceConfiguration):
+            full_width = self.width()
+            col_width = int(full_width*0.45)
+            self.checklists_container.setFixedWidth(col_width)
+            self.devices_container.setFixedWidth(col_width)
 
     def resizeEvent(self, *args, **kwargs) -> None:
         """

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -731,29 +731,45 @@ class TreeParentMixin:
     Mix-in class for displays that have a tree parent display.
 
     These displays should contain a QToolButton named "parent_button"
-    and should have a reference to their AtefItem named "tree_item"
-    for easy access to the tree structure.
+    and, should have a reference to their AtefItem named
+    "parent_tree_item", and should have a reference to the overall
+    QTreeWidget "tree_ref".
+
+    AtefItem attempts to add the tree_ref and parent_tree_item
+    attributes after initialization to be helpful. This way, we
+    don't have to pass information about the tree or the items
+    up or down the init chains except when needed for special
+    initialization purposes.
 
     This mix-in will put an icon on that button and will make the
     tree select and display the parent in the tree when the
     button in pressed.
     """
     parent_button: QToolButton
-    tree_item: AtefItem
+
+    tree_ref: QTreeWidget
+    parent_tree_item: AtefItem
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.setup_parent_button()
+        self._setup_parent_button()
 
-    def setup_parent_button(self):
-        self.parent_button.clicked.connect(self.navigate_to_parent)
+    def _setup_parent_button(self):
+        """
+        Common setup for the "go to parent" button at the top right.
+
+        Adds an icon to the button and sets it up to help us navigate
+        to the correct tree destination.
+        """
+        self.parent_button.clicked.connect(self._navigate_to_parent)
         icon = self.style().standardIcon(QStyle.SP_FileDialogToParent)
         self.parent_button.setIcon(icon)
 
-    def navigate_to_parent(self, *args, **kwargs):
-        raise NotImplementedError(
-            "Still need to get a reference to the tree widget"
-        )
+    def _navigate_to_parent(self, *args, **kwargs):
+        """
+        Make the tree switch to this widget's parent in the tree.
+        """
+        self.tree_ref.setCurrentItem(self.parent_tree_item)
 
 
 class Group(TreeParentMixin, ConfigTextMixin, DesignerDisplay, QWidget):

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -442,8 +442,6 @@ class Overview(DesignerDisplay, PageWidget):
 
     This widget allows us to browse our config names, classes, and
     descriptions, as well as add new configs.
-
-    TODO: add a way to delete configs.
     """
     filename = 'config_overview.ui'
 

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -401,7 +401,7 @@ class PageWidget(DesignerDisplay, QWidget):
         self.parent_tree_item = item.parent_tree_item
         self.full_tree = item.full_tree
 
-    def navigate_to(self, item: AtefItem):
+    def navigate_to(self, item: AtefItem, *args, **kwargs):
         """
         Make the tree switch to a specific item.
 
@@ -429,6 +429,15 @@ class PageWidget(DesignerDisplay, QWidget):
         else:
             overview_item = self.full_tree.topLevelItem(0)
             self.navigate_to(overview_item)
+
+    def setup_child_nav_button(
+        self,
+        button: QToolButton,
+        item: AtefItem,
+    ) -> None:
+        button.clicked.connect(partial(self.navigate_to, item))
+        icon = self.style().standardIcon(QStyle.SP_ArrowRight)
+        button.setIcon(icon)
 
 
 def link_page(item: AtefItem, widget: PageWidget):
@@ -579,6 +588,7 @@ class Overview(PageWidget):
         )
         page = Group(row.bridge)
         link_page(item, page)
+        self.setup_child_nav_button(row.child_button, item)
         self.row_count += 1
 
         self.row_mapping[row] = (config, item)
@@ -721,6 +731,7 @@ class OverviewRow(ConfigTextMixin, DesignerDisplay, QWidget):
     lock_button: QPushButton
     desc_edit: QPlainTextEdit
     delete_button: QPushButton
+    child_button: QToolButton
 
     def __init__(
         self,

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1571,9 +1571,11 @@ class IdAndCompWidget(ConfigTextMixin, PageWidget):
 
     name_edit: QLineEdit
     id_label: QLabel
+    id_container: QWidget
     id_content: QVBoxLayout
     add_id_button: QPushButton
     comp_label: QLabel
+    comp_container: QWidget
     comp_content: QVBoxLayout
     add_comp_button: QPushButton
 
@@ -1645,6 +1647,23 @@ class IdAndCompWidget(ConfigTextMixin, PageWidget):
         for bridge in self.comparison_list.bridges:
             self.setup_comparison_item_bridge(bridge)
         self.add_comp_button.clicked.connect(self.add_comparison)
+        self.resize_columns()
+
+    def resize_columns(self) -> None:
+        """
+        Set the column widths to be equal and less than half the full width.
+        """
+        full_width = self.width()
+        col_width = int(full_width*0.45)
+        self.id_container.setFixedWidth(col_width)
+        self.comp_container.setFixedWidth(col_width)
+
+    def resizeEvent(self, *args, **kwargs) -> None:
+        """
+        Override resizeEvent to update the column widths when we resize.
+        """
+        self.resize_columns()
+        return super().resizeEvent(*args, **kwargs)
 
     def setup_comparison_item_bridge(self, bridge: QDataclassBridge) -> None:
         """

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -423,11 +423,24 @@ class PageWidget(QWidget):
         self.parent_tree_item = item.parent_tree_item
         self.full_tree = item.full_tree
 
+    def navigate_to(self, item: AtefItem):
+        """
+        Make the tree switch to a specific item.
+
+        This can be used to navigate to child items, for example.
+
+        Parameters
+        ----------
+        item : AtefItem
+            The tree node to navigate to.
+        """
+        self.full_tree.setCurrentItem(item)
+
     def navigate_to_parent(self, *args, **kwargs):
         """
         Make the tree switch to this widget's parent in the tree.
         """
-        self.tree_ref.setCurrentItem(self.parent_tree_item)
+        self.navigate_to(self.parent_tree_item)
 
 
 def link_page(item: AtefItem, widget: PageWidget):

--- a/atef/widgets/core.py
+++ b/atef/widgets/core.py
@@ -15,14 +15,18 @@ class DesignerDisplay:
     def __init_subclass__(cls):
         """Read the file when the class is created"""
         super().__init_subclass__()
-        cls.ui_form, _ = loadUiType(
-            str(ATEF_SOURCE_PATH / 'ui' / cls.filename)
-        )
+        if cls.filename:
+            cls.ui_form, _ = loadUiType(
+                str(ATEF_SOURCE_PATH / 'ui' / cls.filename)
+            )
+        else:
+            cls.ui_form = None
 
     def __init__(self, *args, **kwargs):
         """Apply the file to this widget when the instance is created"""
         super().__init__(*args, **kwargs)
-        self.ui_form.setupUi(self, self)
+        if self.ui_form is not None:
+            self.ui_form.setupUi(self, self)
 
     def retranslateUi(self, *args, **kwargs):
         """Required function for setupUi to work in __init__"""

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,6 @@ coverage
 flake8
 pytest
 pytest-timeout
-
 # sphinx-related dependencies:
 sphinx
 numpydoc
@@ -13,5 +12,5 @@ sphinx_rtd_theme
 doctr
 docs-versions-menu
 recommonmark
-
+# for happi loading at lcls
 pcdsdevices


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Original Scope:
- [x] Clickable up arrow on every display to go up the tree to parent items
- [x] Clickable down or right or something arrow to go down the tree to child items
- [x] Restore keyboard navigation to the tree widget

Other tweaks:
- Remove extra margins from the two-column sections to give them a little bit more room.
- Remove or hide spacers below device/signal selection widgets to make these widgets take up the whole space instead of half of it as the ui is expanded.
- Refactor the tree navigation components a bit to make it easier to consider the navigation separately from the widgets. This includes the introduction/standardization of `PageWidget` and `link_page`.
- Add a no filename clause at `DesignerDisplay` so I could create a base class that inherits from `DesignerDisplay` without loading a file. This allowed me to step around an issue where `DesignerDisplay` needs to be the last thing before `QWidget` in the `mro` usually so that all the widgets can be created before we start setting them up.
- Minor adjustments to the requirements file to make the micromamba ci work

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It should be easy to find the fields you need to edit.
Previously, the only way to browse through the config was to click around in the tree widget. Now, you can use the arrow keys in the tree widget and you can also click buttons next to subitems to check what settings they have defined.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively but needs more testing with loading files, etc.
I actually don't have happi set up on my local computer which needs to be resolved so I can give the whole thing a real run-through.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I did some docstrings as I went, but I do need to rerun through this page and make sure they all make sense- it would have been easy to mess something up here with the refactor.


## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/10647860/172736266-99528fc1-c6d1-4df1-af2a-ba00919c06b5.png)
