### PR TITLE
ENH: show metadata in device selection + improve performance

### DIFF
--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -36,7 +36,7 @@ from ..qt_helpers import QDataclassBridge, QDataclassList, QDataclassValue
 from ..reduce import ReduceMethod
 from ..type_hints import PrimitiveType
 from .core import DesignerDisplay
-from .happi import HappiDeviceComponentWidget, HappiSearchWidget
+from .happi import HappiDeviceComponentWidget
 from .ophyd import OphydAttributeData, OphydAttributeDataSummary
 
 logger = logging.getLogger(__name__)
@@ -1437,11 +1437,18 @@ class DeviceListWidget(StringListWithDialog):
         to_select : list of str, optional
             If provided, the device chooser will filter for these items.
         """
-        self._search_widget = HappiSearchWidget(client=util.get_happi_client())
-        self._search_widget.happi_items_chosen.connect(self.add_items)
+        self._search_widget = HappiDeviceComponentWidget(
+            client=util.get_happi_client(),
+            show_device_components=False,
+        )
+        self._search_widget.item_search_widget.happi_items_chosen.connect(
+            self.add_items
+        )
         self._search_widget.show()
         self._search_widget.activateWindow()
-        self._search_widget.edit_filter.setText(util.regex_for_devices(to_select))
+        self._search_widget.item_search_widget.edit_filter.setText(
+            util.regex_for_devices(to_select)
+        )
 
 
 class ComponentListWidget(StringListWithDialog):

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1421,7 +1421,7 @@ class DeviceListWidget(StringListWithDialog):
     Device list widget, with ``HappiSearchWidget`` for adding new devices.
     """
 
-    _search_widget: Optional[HappiSearchWidget] = None
+    _search_widget: Optional[HappiDeviceComponentWidget] = None
 
     def _setup_ui(self):
         super()._setup_ui()

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -437,9 +437,9 @@ class HappiDeviceComponentWidget(DesignerDisplay, QWidget):
     _client: Optional[happi.client.Client]
     _device_worker: Optional[ThreadWorker]
     _device_cache: Dict[str, ophyd.Device]
-    group_happi_md: QtWidgets.QGroupBox
-    group_components: QtWidgets.QGroupBox
-    group_device_search: QtWidgets.QGroupBox
+    components_tab: QtWidgets.QWidget
+    device_tab_widget: QtWidgets.QTabWidget
+    metadata_tab: QtWidgets.QWidget
 
     def __init__(
         self,
@@ -457,7 +457,8 @@ class HappiDeviceComponentWidget(DesignerDisplay, QWidget):
             self._new_item_selection
         )
         self.item_search_widget.button_choose.setVisible(False)
-        self.group_components.setVisible(show_device_components)
+        if not self.show_device_components:
+            self.device_tab_widget.removeTab(0)
 
     @QtCore.Slot(list)
     def _new_item_selection(self, items: List[str]) -> None:

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -512,7 +512,6 @@ class HappiDeviceComponentWidget(DesignerDisplay, QWidget):
         item, *_ = items
 
         # Set metadata early, even if instantiation fails
-        # self.metadata_widget.item_name = item
 
         try:
             by_name = self.item_search_widget.search_results_by_key("name")

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -459,12 +459,13 @@ class HappiDeviceComponentWidget(DesignerDisplay, QWidget):
         self.item_search_widget.button_choose.setVisible(False)
         if not self.show_device_components:
             self.device_tab_widget.removeTab(0)
+            self.setWindowTitle("Happi Item Search with Metadata")
 
     @QtCore.Slot(list)
     def _new_item_selection(self, items: List[str]) -> None:
         """New item selected from the happi search."""
         client = self.client
-        if not client or not items:
+        if client is None or not items:
             return
 
         def get_device() -> Optional[ophyd.Device]:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Show happi metadata when selecting devices
* Reuses the Item search/metadata/Component widget and just hides the component selector
    * In principle we could keep it visible, it would just slow things down unnecessarily since we wouldn't accept attribute selections there...

## Motivation and Context
* Code mentioned in #70 
* Fixes mistaken `client.__len__` call for a performance increase (`len(client)` implicitly researched the database)
* Re-uses cached metadata instead of hitting the happi client again

## How Has This Been Tested?
Interactively

## Screenshots (if appropriate):
<img width="1040" alt="image" src="https://user-images.githubusercontent.com/5139267/174664772-16ca5ab3-deae-41b0-9bb4-31ebb1451391.png">
