### PR TITLE
ENH: allow filename specification from command-line

### DIFF
--- a/atef/bin/config.py
+++ b/atef/bin/config.py
@@ -2,22 +2,45 @@
 `atef config` opens up a graphical config file editor.
 """
 import argparse
+import logging
+from typing import List, Optional
 
 from pydm import exception
 from qtpy.QtWidgets import QApplication
 
+from ..type_hints import AnyPath
 from ..widgets.config import Window
+
+logger = logging.getLogger(__name__)
 
 
 def build_arg_parser(argparser=None):
     if argparser is None:
         argparser = argparse.ArgumentParser()
+
+    argparser.add_argument(
+        "filenames",
+        metavar="filename",
+        type=str,
+        nargs="*",
+        help="Configuration filename",
+    )
+
     return argparser
 
 
-def main():
+def main(filenames: Optional[List[AnyPath]] = None):
     app = QApplication([])
-    main_window = Window()
+    main_window = Window(show_welcome=not filenames)
     main_window.show()
     exception.install()
+
+    for filename in filenames or []:
+        try:
+            main_window.open_file(filename=filename)
+        except FileNotFoundError:
+            logger.error(
+                "File specified on the command-line not found: %s", filename
+            )
+
     app.exec()

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -59,7 +59,7 @@ class Window(DesignerDisplay, QMainWindow):
     action_print_dataclass: QAction
     action_print_serialized: QAction
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, show_welcome: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
         self.setWindowTitle('atef config')
         self.action_new_file.triggered.connect(self.new_file)
@@ -68,7 +68,8 @@ class Window(DesignerDisplay, QMainWindow):
         self.action_save_as.triggered.connect(self.save_as)
         self.action_print_dataclass.triggered.connect(self.print_dataclass)
         self.action_print_serialized.triggered.connect(self.print_serialized)
-        QTimer.singleShot(0, self.welcome_user)
+        if show_welcome:
+            QTimer.singleShot(0, self.welcome_user)
 
     def welcome_user(self):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Allow for `atef config filename.json` to work

## Motivation and Context
Helpful for command-line usage.
Closes #33

## How Has This Been Tested?
Interactively.

## Where Has This Been Documented?
This PR text.