### PR TITLE
ENH: use a QListWidget and a multiline dialog to edit PV lists

### DIFF
--- a/atef/ui/id_and_comp.ui
+++ b/atef/ui/id_and_comp.ui
@@ -92,13 +92,6 @@
         <item>
          <layout class="QVBoxLayout" name="id_content"/>
         </item>
-        <item>
-         <widget class="QPushButton" name="add_id_button">
-          <property name="text">
-           <string>Add Identifier</string>
-          </property>
-         </widget>
-        </item>
        </layout>
       </widget>
      </item>

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1330,6 +1330,8 @@ class StringListWithDialog(DesignerDisplay, QWidget):
         new : str
             The new item to replace it with
         """
+        if old == new:
+            return
         if not self.allow_duplicates and new in self.data_list.get():
             return self._remove_item(old)
         self.data_list.put_to_index(
@@ -1348,7 +1350,20 @@ class StringListWithDialog(DesignerDisplay, QWidget):
         The goal is to replace each instance of old with each instance of
         new, in order.
         """
-        for old, new in zip_longest(old_items, new_items, fillvalue=None):
+        # Ignore items that exist in both lists
+        old_uniques = [item for item in old_items if item not in new_items]
+        new_uniques = [item for item in new_items if item not in old_items]
+        # Remove items from new if duplicates aren't allowed and they exist
+        if not self.allow_duplicates:
+            new_uniques = [
+                item for item in new_uniques if item not in self.data_list.get()
+            ]
+        # Add, remove, edit in place as necessary
+        # This will edit everything in place if the lists are equal length
+        # If old_uniques is longer, we'll remove when we exhaust new_uniques
+        # If new_uniques is longer, we'll add when we exhaust old_uniques
+        # TODO find a way to add these at the selected index
+        for old, new in zip_longest(old_uniques, new_uniques, fillvalue=None):
             if old is None:
                 self._add_item(new)
             elif new is None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Replace the tag-like editing of PVs with a QListWidget that is edited primarily with a multiline text edit.

When you click the + button, a multiline text edit appears. Anything you put into this box is added to the list.
When you select one or more existing lines and double-click, a multiline text edit appears with the lines you selected. You can add, edit, or remove items as you like. On confirmation the new lines will be compared to the old lines and we'll add or remove items as appropriate.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Usability fix- it's very annoying to edit and browse the PV lists now. This lets you copy paste big lists of PVs if you want.

closes #74 
closes #75 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

One oddity: the drag/drop here still needs to be implemented to update the data class. I think this probably affects the device/component widgets too, if someone tries to rearrange the list it will have no internal effect and therefore will not be saved.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/10647860/173128720-85119cb5-616f-4ef9-9db4-0bf435bf7142.png)
![image](https://user-images.githubusercontent.com/10647860/173128887-fbf7503f-4330-478d-aa5e-4c01df12bf16.png)
![image](https://user-images.githubusercontent.com/10647860/173128930-ab481e58-36eb-47c2-9677-3eedfeb3bc25.png)
