### PR TITLE
ENH: use splitter for tree/config display

### DIFF
--- a/atef/ui/config_tree.ui
+++ b/atef/ui/config_tree.ui
@@ -6,28 +6,36 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>649</width>
-    <height>818</height>
+    <width>874</width>
+    <height>481</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_3">
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <widget class="QTreeWidget" name="tree_widget">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
+     <property name="opaqueResize">
+      <bool>false</bool>
      </property>
-     <property name="columnCount">
-      <number>0</number>
-     </property>
+     <widget class="QTreeWidget" name="tree_widget">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="columnCount">
+       <number>0</number>
+      </property>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -240,6 +240,7 @@ class Tree(DesignerDisplay, QWidget):
 
     bridge: QDataclassBridge
     tree_widget: QTreeWidget
+    splitter: QtWidgets.QSplitter
 
     full_path: str
 
@@ -285,12 +286,18 @@ class Tree(DesignerDisplay, QWidget):
         item = self.tree_widget.currentItem()
         if item is self.last_selection:
             return
+
+        replace = bool(self.last_selection is not None)
         if self.last_selection is not None:
             self.last_selection.widget.setVisible(False)
         widget = item.widget
         if widget not in self.built_widgets:
-            self.layout().addWidget(widget)
             self.built_widgets.add(widget)
+
+        if replace:
+            self.splitter.replaceWidget(1, widget)
+        else:
+            self.splitter.addWidget(widget)
         widget.setVisible(True)
         self.last_selection = item
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This PR uses a `QSplitter` between the configuration Tree and check widgets.

## Motivation and Context
Closes #90 

The `atef config` tree, as in the master branch, is difficult to view in its entirety due to its layout settings.

## How Has This Been Tested?
Interactively.

## Where Has This Been Documented?
This PR text.

## Screenshots (if appropriate):

<img width="1109" alt="image" src="https://user-images.githubusercontent.com/5139267/173413632-3e90f274-d866-4231-95a5-f811cab83d4d.png">
