### PR TITLE
ENH: atef config helper additions for device/attribute selection

### DIFF
--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -15,7 +15,7 @@ from typing import (Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type,
 
 from apischema import deserialize, serialize
 from pydm.widgets.drawing import PyDMDrawingLine
-from qtpy import QtCore, QtWidgets
+from qtpy import QtWidgets
 from qtpy.QtCore import QEvent, QObject, QTimer
 from qtpy.QtCore import Signal as QSignal
 from qtpy.QtGui import QColor
@@ -1445,17 +1445,6 @@ class DeviceListWidget(StringListWithDialog):
         self._search_widget.edit_filter.setText(
             "|".join(to_select or []),
         )
-
-
-def find_widget_ancestor(widget: QtWidgets.QWidget, ancestor_cls: Type[QtCore.QObject]):
-    """Find an ancestor widget of the given type."""
-    ancestor = widget.parent()
-    while ancestor is not None:
-        if isinstance(ancestor, ancestor_cls):
-            return ancestor
-        ancestor = ancestor.parent()
-
-    return None
 
 
 class ComponentListWidget(StringListWithDialog):

--- a/atef/widgets/ophyd.py
+++ b/atef/widgets/ophyd.py
@@ -511,10 +511,6 @@ class OphydDeviceTableView(QtWidgets.QTableView):
     attributes_selected: ClassVar[QtCore.Signal] = QtCore.Signal(
         list  # List[OphydAttributeData]
     )
-    #: Signal indicating the attributes have been selected by the user.
-    attributes_selected_with_values: ClassVar[QtCore.Signal] = QtCore.Signal(
-        dict
-    )  # Dict[str, Any]
 
     def __init__(
         self,
@@ -722,6 +718,13 @@ class OphydDeviceTableWidget(DesignerDisplay, QtWidgets.QFrame):
                 )
 
         self.button_select_attrs.clicked.connect(select_attrs)
+
+        def select_single_attr(index: QtCore.QModelIndex) -> None:
+            data = self.device_table_view.get_data_from_proxy_index(index)
+            if data is not None:
+                self.attributes_selected.emit([data])
+
+        self.device_table_view.doubleClicked.connect(select_single_attr)
         self.device_table_view.attributes_selected.connect(
             self.attributes_selected.emit
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Automatically insert device names in the component selection window
* Double-click adds attributes to the list (in addition to the 'select' button functionality)
* "Suggest comparison" signal uses values from the control system (if available) to automatically add a comparison
    * The specifics of this could probably use some work
* Some refactors on the ophyd helper side of things in order to make the above feasible
    * Primarily: working directly with `OphydAttributeData` instead of just passing around names
    * Making `readback` data and units be stored separately, with the string conversion happening at model `data()` time

## Motivation and Context

Closes #73
Closes #87 
Closes #91 

## How Has This Been Tested?
Interactively. Could use more clicking around

## Where Has This Been Documented?
Issues