### PR TITLE
BUG: fix issue with running event filter after cleanup

### DIFF
--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1860,6 +1860,10 @@ class FrameOnEditFilter(QObject):
     not editing it.
     """
     def eventFilter(self, object: QLineEdit, event: QEvent) -> bool:
+        # Even if we install only on line edits, this can be passed a generic
+        # QWidget when we remove and clean up the line edit widget.
+        if not isinstance(object, QLineEdit):
+            return False
         if event.type() == QEvent.FocusIn:
             object.setFrame(True)
             object.setReadOnly(False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Check that we are dealing with a line edit in our line edit event filter before proceeding to the checks and style updates.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is an event filter on some of our edit fields that handles things like changing style when the user selects/deselects the widget. This is only installed on compatible object types, but it can also be called on generic `QWidget` objects that are suspiciously named `line_edit` after the line edit has been removed/cleaned up. You see an unimportant error message when removing some of these objects since `QWidget` doesn't have a `text` attribute, which is checked during this filter. The application continues to run as normal, since the only thing skipped is updating the style of a removed widget, but the error popup is annoying and potentially confusing.

I found this after a report that removing comparisons did not work, which I could not reproduce, but I did find this on the way.

Traceback:
```
Traceback (most recent call last):
  File "C:\Users\zlentz\Miniconda3\envs\dev\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\zlentz\Miniconda3\envs\dev\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\zlentz\Documents\VSCode\atef\atef\__main__.py", line 3, in <module>
    main()
  File "C:\Users\zlentz\Documents\VSCode\atef\atef\bin\main.py", line 94, in main
    func(**kwargs)
  File "C:\Users\zlentz\Documents\VSCode\atef\atef\bin\config.py", line 46, in main
    app.exec()
  File "C:\Users\zlentz\Documents\VSCode\atef\atef\widgets\config.py", line 1869, in eventFilter
    if object.text():
AttributeError: 'QWidget' object has no attribute 'text'
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
It'll go in the release notes, this is a bugfix.
I added a comment since it isn't immediately clear why this clause would be needed.

<!--
## Screenshots (if appropriate):
-->
