### PR TITLE
ENH: Restore correct background color when locking/unlocking edits

### DIFF
--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -905,7 +905,7 @@ class OverviewRow(ConfigTextMixin, DesignerDisplay, QWidget):
             color = self.palette().color(QPalette.ColorRole.Base)
             self.setStyleSheet(
                 f"QLineEdit, QPlainTextEdit {{ background: rgba({color.red()},"
-                f"{color.green()}, {color.blue()}) }}"
+                f"{color.green()}, {color.blue()}, {color.alpha()}) }}"
             )
             if not self.name_edit.text():
                 self.delete_button.setEnabled(True)

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -902,10 +902,10 @@ class OverviewRow(ConfigTextMixin, DesignerDisplay, QWidget):
             self.delete_button.setEnabled(False)
         else:
             self.desc_edit.setFrameShape(self.desc_edit.StyledPanel)
-            color = self.palette().color(QPalette.ColorRole.AlternateBase)
+            color = self.palette().color(QPalette.ColorRole.Base)
             self.setStyleSheet(
                 f"QLineEdit, QPlainTextEdit {{ background: rgba({color.red()},"
-                f"{color.green()}, {color.blue()}, 255) }}"
+                f"{color.green()}, {color.blue()}) }}"
             )
             if not self.name_edit.text():
                 self.delete_button.setEnabled(True)

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -18,7 +18,7 @@ from pydm.widgets.drawing import PyDMDrawingLine
 from qtpy import QtWidgets
 from qtpy.QtCore import QEvent, QObject, QTimer
 from qtpy.QtCore import Signal as QSignal
-from qtpy.QtGui import QColor
+from qtpy.QtGui import QColor, QPalette
 from qtpy.QtWidgets import (QAction, QCheckBox, QComboBox, QFileDialog,
                             QFormLayout, QHBoxLayout, QInputDialog, QLabel,
                             QLayout, QLineEdit, QMainWindow, QMessageBox,
@@ -902,8 +902,10 @@ class OverviewRow(ConfigTextMixin, DesignerDisplay, QWidget):
             self.delete_button.setEnabled(False)
         else:
             self.desc_edit.setFrameShape(self.desc_edit.StyledPanel)
+            color = self.palette().color(QPalette.ColorRole.AlternateBase)
             self.setStyleSheet(
-                "QLineEdit, QPlainTextEdit { background: white }"
+                f"QLineEdit, QPlainTextEdit {{ background: rgba({color.red()},"
+                f"{color.green()}, {color.blue()}, 255) }}"
             )
             if not self.name_edit.text():
                 self.delete_button.setEnabled(True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

When switching between locked & unlocked states for the overview name/description, the background color changes to white to indicate that the widget is editable. On dark themes this makes it unreadable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On dark themes, the text would become unreadable when switching between locked and edit mode for the overviews.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by clicking lock/unlock

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

n/a

## Screenshots

Unlocked editing. Before this change, the background color of the QLineEdits would be pure white. 
![image](https://user-images.githubusercontent.com/19717056/178552954-a957c523-c070-4852-be57-f8f110f0ccb5.png)

Locked
![image](https://user-images.githubusercontent.com/19717056/178553024-de0bf5bf-6d76-4b91-9d2e-ab7eff627590.png)
