### PR TITLE
REF/ENH: track + display config/checklist/comparison/id in prepared comparisons

### DIFF
--- a/atef/check.py
+++ b/atef/check.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 class Result:
     severity: Severity = Severity.success
     reason: Optional[str] = None
-    exception: Optional[Exception] = None
 
     @classmethod
     def from_exception(cls, error: Exception) -> Result:
@@ -45,7 +44,6 @@ class Result:
         return cls(
             severity=severity,
             reason=reason,
-            exception=error,
         )
 
 

--- a/atef/check.py
+++ b/atef/check.py
@@ -265,12 +265,7 @@ class Comparison:
         if passed:
             return success
 
-        desc = self.describe()
-        if self.description:
-            desc = f"{identifier_prefix}{self.description} ({desc})"
-        else:
-            desc = f"{identifier_prefix}{desc}"
-
+        desc = f"{identifier_prefix}{self.describe()}"
         return Result(
             severity=self.severity_on_failure,
             reason=(
@@ -718,6 +713,27 @@ class PreparedComparisonException(Exception):
         self.path = path or []
 
 
+def _name_and_description(obj: Union[Comparison, Configuration]) -> str:
+    """
+    Get a combined name and description for a given item.
+
+    Parameters
+    ----------
+    obj : Union[Comparison, Configuration]
+        The comparison or configuration.
+
+    Returns
+    -------
+    str
+        The displayable name.
+    """
+    if obj.name and obj.description:
+        return f"{obj.name}: {obj.description}"
+    if obj.name:
+        return obj.name
+    return obj.description or ""
+
+
 @dataclass
 class PreparedComparison:
     """
@@ -848,9 +864,9 @@ class PreparedComparison:
                 for pvname in checklist_item.ids:
                     path = _filter_nones(
                         [
-                            config.name,
+                            _name_and_description(config),
                             checklist_item.name,
-                            comparison.name,
+                            _name_and_description(comparison),
                             pvname,
                         ]
                     )
@@ -900,9 +916,9 @@ class PreparedComparison:
                 for attr in checklist_item.ids:
                     path = _filter_nones(
                         [
-                            config.name,
+                            _name_and_description(config),
                             checklist_item.name,
-                            comparison.name,
+                            _name_and_description(comparison),
                             attr,
                         ]
                     )


### PR DESCRIPTION
## Description
Before, in a slightly-modified local test file (with admittedly nonsensical comparisons!):
```
✔ Success state settings (Check state settings)
├── ✔ Success: AT2L0:XTES:MMS:19:STATE:10:VELO < 1
└── ✔ Success: AT2L0:XTES:MMS:19:STATE:10:ACCL < 1
```

After:

```
✔ Success state settings (Check state settings)
└── Good vacuum checklist
    └── Good vacuum comparison
        ├── ✔ Success: AT2L0:XTES:MMS:19:STATE:10:VELO < 1
        └── ✔ Success: AT2L0:XTES:MMS:19:STATE:10:ACCL < 1
```

```
❌ Error state settings (Check state settings)
└── Good vacuum checklist
    └── Good vacuum comparison: Make sure we have some level of vacuum everywhere
        ├── ❌ Error: AT2L0:XTES:MMS:19:STATE:10:VELO < 1: value of 2.0
        └── ✔ Success: AT2L0:XTES:MMS:19:STATE:10:ACCL < 1
```

## Motivation and Context
Closes #109 

## How Has This Been Tested?
Interactively, so far

## Where Has This Been Documented?
Issue, discussion, and PR text