### PR TITLE
ENH: use row selection mode in Ophyd and Happi table views

### DIFF
--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -12,7 +12,7 @@ import ophyd
 from happi.qt.model import (HappiDeviceListView, HappiDeviceTreeView,
                             HappiViewMixin)
 from qtpy import QtCore, QtGui, QtWidgets
-from qtpy.QtWidgets import QWidget, QTableView
+from qtpy.QtWidgets import QTableView, QWidget
 
 from ..qt_helpers import ThreadWorker, copy_to_clipboard
 from .core import DesignerDisplay

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -12,7 +12,7 @@ import ophyd
 from happi.qt.model import (HappiDeviceListView, HappiDeviceTreeView,
                             HappiViewMixin)
 from qtpy import QtCore, QtGui, QtWidgets
-from qtpy.QtWidgets import QWidget
+from qtpy.QtWidgets import QWidget, QTableView
 
 from ..qt_helpers import ThreadWorker, copy_to_clipboard
 from .core import DesignerDisplay
@@ -360,6 +360,8 @@ class HappiItemMetadataView(DesignerDisplay, QtWidgets.QWidget):
 
         self.table_view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.table_view.customContextMenuRequested.connect(self._table_context_menu)
+
+        self.table_view.setSelectionBehavior(QTableView.SelectionBehavior.SelectRows)
 
     def _table_context_menu(self, pos: QtCore.QPoint) -> None:
         """Context menu when the key/value table is right-clicked."""

--- a/atef/widgets/ophyd.py
+++ b/atef/widgets/ophyd.py
@@ -571,6 +571,8 @@ class OphydDeviceTableView(QtWidgets.QTableView):
 
         self.sortByColumn(0, Qt.AscendingOrder)
 
+        self.setSelectionBehavior(self.SelectionBehavior.SelectRows)
+
         # Set the property last
         self.device = device
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Use row selection mode in the happi and ophyd table views instead of the individual table cell mode.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Row selection mode in these table views makes more sense since the data is related to the rest of the row. 90% of the motivation here is personal preference though, @klauer indicated that row selection mode seemed better too, so I'm not alone in this regard.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by clicking around the table views.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

Selection by rows!!!
![image](https://user-images.githubusercontent.com/19717056/179291708-b6b41581-4789-4367-944e-f690b1c9b411.png)

