### PR TITLE
ENH: Context menus for Happi, Ophyd and string list widgets

### DIFF
--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -16,8 +16,8 @@ from typing import (Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type,
 from apischema import deserialize, serialize
 from pydm.widgets.drawing import PyDMDrawingLine
 from qtpy import QtWidgets
-from qtpy.QtCore import QEvent, QObject, Qt, QTimer
-from qtpy.QtCore import Signal as QSignal, QPoint
+from qtpy.QtCore import QEvent, QObject, QPoint, Qt, QTimer
+from qtpy.QtCore import Signal as QSignal
 from qtpy.QtGui import QClipboard, QColor, QGuiApplication, QPalette
 from qtpy.QtWidgets import (QAction, QCheckBox, QComboBox, QFileDialog,
                             QFormLayout, QHBoxLayout, QInputDialog, QLabel,

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -1448,9 +1448,9 @@ class StringListWithDialog(DesignerDisplay, QWidget):
 
         def copy_selected():
             items = self.list_strings.selectedItems()
-            if len(items) > 0:
-                QGuiApplication.clipboard().setText(items[0].text(),
-                                                    QClipboard.Mode.Clipboard)
+            text = '\n'.join([x.text() for x in items])
+            if len(text) > 0:
+                QGuiApplication.clipboard().setText(text, QClipboard.Mode.Clipboard)
 
         copy = menu.addAction('&Copy')
         copy.triggered.connect(copy_selected)

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -17,7 +17,7 @@ from apischema import deserialize, serialize
 from pydm.widgets.drawing import PyDMDrawingLine
 from qtpy import QtWidgets
 from qtpy.QtCore import QEvent, QObject, Qt, QTimer
-from qtpy.QtCore import Signal as QSignal
+from qtpy.QtCore import Signal as QSignal, QPoint
 from qtpy.QtGui import QClipboard, QColor, QGuiApplication, QPalette
 from qtpy.QtWidgets import (QAction, QCheckBox, QComboBox, QFileDialog,
                             QFormLayout, QHBoxLayout, QInputDialog, QLabel,
@@ -1431,7 +1431,7 @@ class StringListWithDialog(DesignerDisplay, QWidget):
             else:
                 self._edit_item(old, new)
 
-    def _show_context_menu(self, pos):
+    def _show_context_menu(self, pos: QPoint):
         """
         Displays a context menu that provides copy & remove actions
         to the user
@@ -1441,6 +1441,9 @@ class StringListWithDialog(DesignerDisplay, QWidget):
         pos : QPoint
             Position to display the menu at
         """
+        if len(self.list_strings.selectedItems()) <= 0:
+            return
+
         menu = QMenu(self)
 
         def copy_selected():

--- a/atef/widgets/config.py
+++ b/atef/widgets/config.py
@@ -16,15 +16,15 @@ from typing import (Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type,
 from apischema import deserialize, serialize
 from pydm.widgets.drawing import PyDMDrawingLine
 from qtpy import QtWidgets
-from qtpy.QtCore import QEvent, QObject, QTimer, Qt
+from qtpy.QtCore import QEvent, QObject, Qt, QTimer
 from qtpy.QtCore import Signal as QSignal
-from qtpy.QtGui import QColor, QPalette, QClipboard, QGuiApplication
+from qtpy.QtGui import QClipboard, QColor, QGuiApplication, QPalette
 from qtpy.QtWidgets import (QAction, QCheckBox, QComboBox, QFileDialog,
                             QFormLayout, QHBoxLayout, QInputDialog, QLabel,
-                            QLayout, QLineEdit, QMainWindow, QMessageBox,
-                            QPlainTextEdit, QPushButton, QStyle, QTabWidget,
-                            QToolButton, QTreeWidget, QTreeWidgetItem,
-                            QVBoxLayout, QWidget, QMenu)
+                            QLayout, QLineEdit, QMainWindow, QMenu,
+                            QMessageBox, QPlainTextEdit, QPushButton, QStyle,
+                            QTabWidget, QToolButton, QTreeWidget,
+                            QTreeWidgetItem, QVBoxLayout, QWidget)
 
 from .. import util
 from ..check import (Comparison, Equals, Greater, GreaterOrEqual, Less,

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -202,7 +202,7 @@ class HappiSearchWidget(DesignerDisplay, QWidget):
         self.menu = QtWidgets.QMenu(self)
         index: QtCore.QModelIndex = self.happi_list_view.indexAt(pos)
 
-        if index is not None:
+        if index is not None and index.data() is not None:
             # Add action to add the selected device
             add_action = self.menu.addAction(f'&Add Device: {index.data()}')
 

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -201,7 +201,17 @@ class HappiSearchWidget(DesignerDisplay, QWidget):
         """Context menu for the happi list view."""
         self.menu = QtWidgets.QMenu(self)
         index: QtCore.QModelIndex = self.happi_list_view.indexAt(pos)
+
         if index is not None:
+            # Add action to add the selected device
+            add_action = self.menu.addAction(f'&Add Device: {index.data()}')
+
+            def items_added():
+                self.happi_items_chosen.emit([index.data()])
+
+            add_action.triggered.connect(items_added)
+
+            # Add action to copy the text
             def copy(*_):
                 copy_to_clipboard(index.data())
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

This PR adds various context menus to atef. The Happi, Ophyd and string list widgets all got extended context menus. 

For the `HappiSearchWidget`, I added an "Add device" entry to the context menu that emits the `happi_items_chosen` signal. In atef, that means you can right click a device and "Add device" instead of double clicking it to add it to the device list.

For `OphydDeviceTableView`, a context menu helper was added, which is used to create the base `QMenu` that the standard table view actions are added to. `OphydDeviceTableWidget` adds a context menu helper to display the same menu that's displayed when you click the `Select` button at the bottom.

`StringListWithDialog` got a simple context menu that has "Copy" and "Remove" actions. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Context menus are just more intuitive and quicker to work with than the discrete add/remove/select `QPushButtons`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by clicking around in the UI.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

Some of these might be hard to read because of my system theme :) 

Ophyd signal selection
![image](https://user-images.githubusercontent.com/19717056/179295737-4a5b9839-7a6f-4e07-bb50-507d4c9ce102.png)

Happi widget
![image](https://user-images.githubusercontent.com/19717056/179296013-5e27cd13-c0de-41ef-af26-d3c29adaf5cf.png)

String list
![image](https://user-images.githubusercontent.com/19717056/179297544-2fb8f750-9cb4-4bd2-844f-5aebb0a007e8.png)
