### PR TITLE
ENH: add archive viewer widget

### DIFF
--- a/atef/tests/test_archived_device.py
+++ b/atef/tests/test_archived_device.py
@@ -8,11 +8,15 @@ import pytest
 from ..archive_device import ArchivedValue, make_archived_device
 from . import conftest
 
+# skip these devices, subclassing is too involved to be automated
+SKIP_CLS = ['LightpathMixin', 'LightpathInOutCptMixin']
+
 all_pcdsdevice_classes = pytest.mark.parametrize(
     "cls",
     [
         pytest.param(cls, id=f"{cls.__module__}.{cls.__name__}")
-        for cls in pcdsdevices.tests.conftest.find_all_device_classes()
+        for cls
+        in pcdsdevices.tests.conftest.find_all_device_classes(skip=SKIP_CLS)
     ]
 )
 

--- a/atef/ui/archive_viewer_widget.ui
+++ b/atef/ui/archive_viewer_widget.ui
@@ -98,7 +98,14 @@
       <widget class="QLineEdit" name="input_field"/>
      </item>
      <item>
-      <widget class="QListWidget" name="string_list"/>
+      <widget class="QTableView" name="curve_list"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="redraw_button">
+       <property name="text">
+        <string>Redraw Curves</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/atef/ui/archive_viewer_widget.ui
+++ b/atef/ui/archive_viewer_widget.ui
@@ -57,11 +57,34 @@
         <widget class="QTableView" name="curve_list"/>
        </item>
        <item>
-        <widget class="QPushButton" name="redraw_button">
-         <property name="text">
-          <string>Redraw Curves</string>
+        <layout class="QHBoxLayout" name="list_ctrl_layout">
+         <property name="leftMargin">
+          <number>2</number>
          </property>
-        </widget>
+         <property name="topMargin">
+          <number>2</number>
+         </property>
+         <property name="rightMargin">
+          <number>2</number>
+         </property>
+         <property name="bottomMargin">
+          <number>2</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="redraw_button">
+           <property name="text">
+            <string>Redraw Curves</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="clear_button">
+           <property name="text">
+            <string>Clear Curves </string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </item>

--- a/atef/ui/archive_viewer_widget.ui
+++ b/atef/ui/archive_viewer_widget.ui
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>776</width>
+    <height>550</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="widget_layout" stretch="3,1">
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <layout class="QVBoxLayout" name="plot_layout">
+     <item>
+      <widget class="PyDMArchiverTimePlot" name="time_plot">
+       <property name="toolTip">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="button_layout">
+       <property name="leftMargin">
+        <number>5</number>
+       </property>
+       <property name="topMargin">
+        <number>5</number>
+       </property>
+       <property name="rightMargin">
+        <number>5</number>
+       </property>
+       <property name="bottomMargin">
+        <number>5</number>
+       </property>
+       <item>
+        <widget class="QPushButton" name="button_month">
+         <property name="text">
+          <string>1M</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="button_week">
+         <property name="text">
+          <string>1w</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="button_day">
+         <property name="text">
+          <string>1d</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="signal_layout">
+     <property name="leftMargin">
+      <number>5</number>
+     </property>
+     <property name="topMargin">
+      <number>5</number>
+     </property>
+     <property name="rightMargin">
+      <number>5</number>
+     </property>
+     <property name="bottomMargin">
+      <number>5</number>
+     </property>
+     <item>
+      <widget class="QLineEdit" name="input_field"/>
+     </item>
+     <item>
+      <widget class="QListWidget" name="string_list"/>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMTimePlot</class>
+   <extends>QGraphicsView</extends>
+   <header>pydm.widgets.timeplot</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMArchiverTimePlot</class>
+   <extends>PyDMTimePlot</extends>
+   <header>pydm.widgets.archiver_time_plot</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/archive_viewer_widget.ui
+++ b/atef/ui/archive_viewer_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>776</width>
-    <height>550</height>
+    <width>861</width>
+    <height>626</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -23,7 +23,10 @@
    <item>
     <widget class="PyDMArchiverTimePlot" name="time_plot">
      <property name="toolTip">
-      <string/>
+      <string>Right-click to open plot options</string>
+     </property>
+     <property name="toolTipDuration">
+      <number>5000</number>
      </property>
     </widget>
    </item>

--- a/atef/ui/archive_viewer_widget.ui
+++ b/atef/ui/archive_viewer_widget.ui
@@ -19,30 +19,18 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="widget_layout" stretch="3,1">
-   <property name="leftMargin">
-    <number>5</number>
-   </property>
-   <property name="topMargin">
-    <number>5</number>
-   </property>
-   <property name="rightMargin">
-    <number>5</number>
-   </property>
-   <property name="bottomMargin">
-    <number>5</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="2,1">
    <item>
-    <layout class="QVBoxLayout" name="plot_layout">
+    <widget class="PyDMArchiverTimePlot" name="time_plot">
+     <property name="toolTip">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="control_layout">
      <item>
-      <widget class="PyDMArchiverTimePlot" name="time_plot">
-       <property name="toolTip">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="button_layout">
+      <layout class="QVBoxLayout" name="signal_layout">
        <property name="leftMargin">
         <number>5</number>
        </property>
@@ -56,9 +44,48 @@
         <number>5</number>
        </property>
        <item>
-        <widget class="QPushButton" name="button_month">
+        <widget class="QLineEdit" name="input_field">
+         <property name="placeholderText">
+          <string>PV:Enter:To:Submit</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTableView" name="curve_list"/>
+       </item>
+       <item>
+        <widget class="QPushButton" name="redraw_button">
          <property name="text">
-          <string>1M</string>
+          <string>Redraw Curves</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>5</number>
+       </property>
+       <property name="topMargin">
+        <number>5</number>
+       </property>
+       <property name="rightMargin">
+        <number>5</number>
+       </property>
+       <property name="bottomMargin">
+        <number>5</number>
+       </property>
+       <item>
+        <widget class="QPushButton" name="button_day">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>1d</string>
          </property>
         </widget>
        </item>
@@ -70,42 +97,13 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="button_day">
+        <widget class="QPushButton" name="button_month">
          <property name="text">
-          <string>1d</string>
+          <string>1M</string>
          </property>
         </widget>
        </item>
       </layout>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QVBoxLayout" name="signal_layout">
-     <property name="leftMargin">
-      <number>5</number>
-     </property>
-     <property name="topMargin">
-      <number>5</number>
-     </property>
-     <property name="rightMargin">
-      <number>5</number>
-     </property>
-     <property name="bottomMargin">
-      <number>5</number>
-     </property>
-     <item>
-      <widget class="QLineEdit" name="input_field"/>
-     </item>
-     <item>
-      <widget class="QTableView" name="curve_list"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="redraw_button">
-       <property name="text">
-        <string>Redraw Curves</string>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>

--- a/atef/ui/config_window.ui
+++ b/atef/ui/config_window.ui
@@ -26,7 +26,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -47,8 +47,15 @@
     <addaction name="action_print_dataclass"/>
     <addaction name="action_print_serialized"/>
    </widget>
+   <widget class="QMenu" name="menuUtilities">
+    <property name="title">
+     <string>Utilities</string>
+    </property>
+    <addaction name="action_open_archive_viewer"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuDebug"/>
+   <addaction name="menuUtilities"/>
   </widget>
   <widget class="QStatusBar" name="status_bar"/>
   <action name="action_new_file">
@@ -84,6 +91,11 @@
   <action name="action_print_serialized">
    <property name="text">
     <string>Print Serialized</string>
+   </property>
+  </action>
+  <action name="action_open_archive_viewer">
+   <property name="text">
+    <string>Open Archive Viewer</string>
    </property>
   </action>
  </widget>

--- a/atef/ui/name_desc_tags_widget.ui
+++ b/atef/ui/name_desc_tags_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>148</height>
+    <height>161</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -55,6 +55,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QToolButton" name="action_button">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="name_label">
         <property name="text">
          <string>Name:</string>
@@ -68,6 +75,12 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
         </property>
        </widget>
       </item>
@@ -86,8 +99,23 @@
       </item>
       <item>
        <widget class="QLabel" name="extra_text_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="text">
          <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
         </property>
        </widget>
       </item>

--- a/atef/ui/ophyd_device_tree_widget.ui
+++ b/atef/ui/ophyd_device_tree_widget.ui
@@ -20,29 +20,6 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="2">
-    <widget class="QPushButton" name="button_update_data">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Read device data - readbacks and setpoints - from the control system.&lt;/p&gt;&lt;p&gt;This may require network access to the selected device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Update data</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3">
-    <widget class="OphydDeviceTableView" name="device_table_view">
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="verticalHeaderStretchLastSection">
-      <bool>false</bool>
-     </attribute>
-    </widget>
-   </item>
    <item row="2" column="1">
     <spacer name="horizontalSpacer">
      <property name="orientation">
@@ -55,6 +32,23 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="2" column="4">
+    <widget class="QPushButton" name="button_update_data">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Read device data - readbacks and setpoints - from the control system.&lt;/p&gt;&lt;p&gt;This may require network access to the selected device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Update data</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QPushButton" name="button_archive_view">
+     <property name="text">
+      <string>Archive Viewer</string>
+     </property>
+    </widget>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_filter">
@@ -72,7 +66,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
+   <item row="0" column="1" colspan="4">
     <widget class="QLineEdit" name="edit_filter">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -88,6 +82,32 @@
       <string>Select</string>
      </property>
     </widget>
+   </item>
+   <item row="1" column="0" colspan="5">
+    <widget class="OphydDeviceTableView" name="device_table_view">
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderStretchLastSection">
+      <bool>false</bool>
+     </attribute>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/atef/widgets/archive_viewer.py
+++ b/atef/widgets/archive_viewer.py
@@ -1,0 +1,149 @@
+"""
+Widget classes designed for PV archiver interaction
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import ClassVar, List, Optional
+
+from pydm.widgets.archiver_time_plot import PyDMArchiverTimePlot
+from qtpy import QtWidgets
+from qtpy.QtCore import QRegularExpression
+from qtpy.QtGui import QRegularExpressionValidator
+from qtpy.QtWidgets import QWidget
+
+from atef.widgets.core import DesignerDisplay
+
+logger = logging.getLogger(__name__)
+archive_viewer_singleton = None
+
+
+def get_archive_viewer() -> ArchiverViewerWidget:
+    """
+    Only allow one viewer to be open at a time.
+    Makes it unambiguous whether where to send PV's to.
+
+    Returns
+    -------
+    ArchiveViewerWidget
+        the widget instance
+    """
+    if archive_viewer_singleton:
+        return archive_viewer_singleton
+    else:
+        return ArchiverViewerWidget()
+
+
+class ArchiverViewerWidget(DesignerDisplay, QWidget):
+    """
+    Archiver time plot viewer
+    """
+    filename: ClassVar[str] = 'archive_viewer_widget.ui'
+
+    time_plot: PyDMArchiverTimePlot
+    button_month: QtWidgets.QPushButton
+    button_week: QtWidgets.QPushButton
+    button_day: QtWidgets.QPushButton
+    input_field: QtWidgets.QLineEdit
+    string_list: QtWidgets.QListWidget
+
+    def __init__(
+        self,
+        parent: Optional[QtWidgets.QWidget] = None,
+        pvs: Optional[List[str]] = None
+    ):
+        super().__init__(parent=parent)
+
+        # list_holder = ListHolder(
+        #     some_list=list(self.)
+        # )
+        # self.pv_list = QDataclassList.of_type(str)(
+        #     data=,
+        #     attr='some_list'
+        #     parent=self
+        # )
+        self._pv_list = pvs
+
+        # - look for correct archiver url, take one that pings or look for env var
+        # - connect string_list to plot
+        # - connect buttons to TimePlot
+        # - connect buttons on string lists?
+        # - set up validator on QLineEdit
+        self._setup_ui()
+        self._setup_range_buttons()
+
+    def _setup_ui(self):
+        # for pv in self._pv_list:
+        self.time_plot.addYChannel(
+            y_channel='ca://LM1K4:HRM_BHC:HUMID',
+            name='pv1',
+            useArchiveData=True
+        )
+        self._setup_pv_selector()
+        # pass
+
+    def _setup_range_buttons(self):
+        def _set_time_span_fn(s: float):
+            """_summary_
+
+            Parameters
+            ----------
+            s : float
+                The time span in seconds
+            """
+            def fn():
+                self.time_plot.setTimeSpan(s)
+                self.time_plot.updateXAxis()
+            return fn
+
+        self.button_day.clicked.connect(_set_time_span_fn(24*60*60))
+        self.button_week.clicked.connect(_set_time_span_fn(24*60*60*7))
+        self.button_month.clicked.connect(_set_time_span_fn(24*60*60*7*30))
+
+    def _setup_pv_selector(self):
+        # inputs get made into list items
+        # validate PV form, returnPressed unless valid
+        regexp = QRegularExpression(r'^\w+(:\w+)+$')
+        validator = QRegularExpressionValidator(regexp)
+        self.input_field.setValidator(validator)
+
+        def _add_item():
+            # grab and clear text
+            pv = self.input_field.text()
+            print(f'_add_item: {pv}')
+
+            # TO-DO: Further validation?  Check if PV exists?
+
+            # add item to list
+            QtWidgets.QListWidgetItem(pv, parent=self.string_list)
+
+        self.input_field.returnPressed.connect(_add_item)
+
+        def _update_curves():
+            # grab all the list items
+            pvs = [self.string_list.item(i).text()
+                   for i in range(self.string_list.count())]
+            print(pvs)
+
+            self.time_plot.clearCurves()
+
+            for pv in pvs:
+                self.time_plot.addYChannel(
+                    y_channel=f'ca://{pv}',
+                    name=f'{pv}',
+                    useArchiveData=True
+                )
+
+            # set up legend
+            for curve_item in self.time_plot._curves:
+                self.time_plot.addLegendItem(curve_item, curve_item.name())
+            self.time_plot.setShowLegend(True)
+
+        self.string_list.model().rowsInserted.connect(_update_curves)
+        self.string_list.model().rowsRemoved.connect(_update_curves)
+        # TO-DO: delete item from list ability
+        # TO-DO: contex_menu_policy helper (add, delete, bring to forground?)
+
+    # TO-DO: crosshair hover over plot
+    # TO-DO: scaling / dealing with different scales

--- a/atef/widgets/archive_viewer.py
+++ b/atef/widgets/archive_viewer.py
@@ -5,6 +5,7 @@ Widget classes designed for PV archiver interaction
 from __future__ import annotations
 
 import datetime
+import itertools
 import logging
 import os
 import urllib
@@ -27,6 +28,10 @@ symbol_map = {'None': None, 'circle': 'o', 'square': 's',
               'cross': '+', 'star': 'star'}
 style_map = {'solid': QtCore.Qt.SolidLine,
              'dash': QtCore.Qt.DashLine, 'dot': QtCore.Qt.DotLine}
+color_cycle = itertools.cycle(
+    [QtGui.QColor('red'), QtGui.QColor('blue'),
+     QtGui.QColor('green'), QtGui.QColor('white')]
+)
 
 
 def get_archive_viewer() -> ArchiverViewerWidget:
@@ -326,7 +331,7 @@ class PVModel(QtCore.QAbstractTableModel):
             QtCore.QModelIndex(), row, row
         )
         self.pvs.insert(
-            row, ['name', {'color': QtGui.QColor(255, 0, 0),
+            row, ['name', {'color': next(color_cycle),
                            'symbol': 'o',
                            'lineWidth': 2,
                            'lineStyle': QtCore.Qt.SolidLine}]

--- a/atef/widgets/archive_viewer.py
+++ b/atef/widgets/archive_viewer.py
@@ -5,10 +5,10 @@ Widget classes designed for PV archiver interaction
 from __future__ import annotations
 
 import logging
-from typing import ClassVar, List, Optional
+from typing import Any, ClassVar, List, Optional
 
 from pydm.widgets.archiver_time_plot import PyDMArchiverTimePlot
-from qtpy import QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import QRegularExpression
 from qtpy.QtGui import QRegularExpressionValidator
 from qtpy.QtWidgets import QWidget
@@ -46,12 +46,13 @@ class ArchiverViewerWidget(DesignerDisplay, QWidget):
     button_week: QtWidgets.QPushButton
     button_day: QtWidgets.QPushButton
     input_field: QtWidgets.QLineEdit
-    string_list: QtWidgets.QListWidget
+    curve_list: QtWidgets.QTableView
+    redraw_button: QtWidgets.QPushButton
 
     def __init__(
         self,
         parent: Optional[QtWidgets.QWidget] = None,
-        pvs: Optional[List[str]] = None
+        pvs: List[str] = []
     ):
         super().__init__(parent=parent)
 
@@ -64,28 +65,49 @@ class ArchiverViewerWidget(DesignerDisplay, QWidget):
         #     parent=self
         # )
         self._pv_list = pvs
+        for pv in pvs:
+            self.add_signal(pv)
 
         # - look for correct archiver url, take one that pings or look for env var
-        # - connect string_list to plot
-        # - connect buttons to TimePlot
+        # - connect curve_list to plot
         # - connect buttons on string lists?
         # - set up validator on QLineEdit
         self._setup_ui()
         self._setup_range_buttons()
 
     def _setup_ui(self):
-        # for pv in self._pv_list:
-        self.time_plot.addYChannel(
-            y_channel='ca://LM1K4:HRM_BHC:HUMID',
-            name='pv1',
-            useArchiveData=True
-        )
+
+        # set up table view
+        self.model = PVModel()
+        self.curve_list.setModel(self.model)
+
+        # set up delegates
+        # Color picker delegate
+        self.colorDelegate = ColorDelegate()
+        self.curve_list.setItemDelegateForColumn(1, self.colorDelegate)
+
+        # symbol delegate
+        self.symbolDelegate = SymbolDelegate()
+        self.curve_list.setItemDelegateForColumn(2, self.symbolDelegate)
+
+        # delete button in last column
+        self.deleteDelegate = DeleteDelegate()
+        # -1 doesn't work sadly
+        self.curve_list.setItemDelegateForColumn(3, self.deleteDelegate)
+        self.deleteDelegate.delete_request.connect(self.model.removeRow)
+
+        for pv in (self._pv_list or []):
+            self.add_signal(pv)
+
+        # set up list selector
         self._setup_pv_selector()
         # pass
 
     def _setup_range_buttons(self):
         def _set_time_span_fn(s: float):
-            """_summary_
+            """
+            Set the time span of the plot.
+            Currently only works if view-all has not been selected?...
 
             Parameters
             ----------
@@ -104,11 +126,12 @@ class ArchiverViewerWidget(DesignerDisplay, QWidget):
     def _setup_pv_selector(self):
         # inputs get made into list items
         # validate PV form, returnPressed unless valid
-        regexp = QRegularExpression(r'^\w+(:\w+)+$')
+        regexp = QRegularExpression(r'^\w+(:\w+)+(\.\w+)*$')
         validator = QRegularExpressionValidator(regexp)
         self.input_field.setValidator(validator)
 
         def _add_item():
+            """ slot for input_field submission """
             # grab and clear text
             pv = self.input_field.text()
             print(f'_add_item: {pv}')
@@ -116,34 +139,216 @@ class ArchiverViewerWidget(DesignerDisplay, QWidget):
             # TO-DO: Further validation?  Check if PV exists?
 
             # add item to list
-            QtWidgets.QListWidgetItem(pv, parent=self.string_list)
+            self.curve_list.model().appendCurve(pv)
 
         self.input_field.returnPressed.connect(_add_item)
 
-        def _update_curves():
-            # grab all the list items
-            pvs = [self.string_list.item(i).text()
-                   for i in range(self.string_list.count())]
-            print(pvs)
-
-            self.time_plot.clearCurves()
-
-            for pv in pvs:
-                self.time_plot.addYChannel(
-                    y_channel=f'ca://{pv}',
-                    name=f'{pv}',
-                    useArchiveData=True
-                )
-
-            # set up legend
-            for curve_item in self.time_plot._curves:
-                self.time_plot.addLegendItem(curve_item, curve_item.name())
-            self.time_plot.setShowLegend(True)
-
-        self.string_list.model().rowsInserted.connect(_update_curves)
-        self.string_list.model().rowsRemoved.connect(_update_curves)
+        # self.curve_list.model().rowsInserted.connect(self._update_curves)
+        # self.curve_list.model().rowsRemoved.connect(self._update_curves)
         # TO-DO: delete item from list ability
         # TO-DO: contex_menu_policy helper (add, delete, bring to forground?)
 
+    def _update_curves(self):
+        # grab all the list items
+        pv_data = self.curve_list.model().pvs
+        print(pv_data)
+
+        self.time_plot.clearCurves()
+
+        for pv in pv_data:
+            self.time_plot.addYChannel(
+                y_channel=f'ca://{pv[0]}',
+                name=f'{pv[0]}',
+                symbol=pv[1]['symbol'],
+                color=pv[1]['color'],
+                useArchiveData=True
+            )
+
+        self.time_plot.setShowLegend(True)
+
     # TO-DO: crosshair hover over plot
     # TO-DO: scaling / dealing with different scales
+
+    def add_signal(self, pv: str) -> None:
+        """
+        Add a signal to the widget and update the plots.
+
+        Parameters
+        ----------
+        pv : str
+            the PV to add
+        """
+        # add item to list
+        index_1 = self.model.createIndex(0, 0)
+        index_2 = self.model.createIndex(0, 3)
+        self.curve_list.model().insertRow(0, index_1)
+        # TO-DO: Need to validate the pv's here, ouside of just the input fields
+        self.model.pvs[0] = [pv, {'color': QtGui.QColor(255, 0, 0), 'symbol': 'o'}]
+        self.model.dataChanged.emit(index_1, index_2)
+        self._update_curves()
+
+
+# class PVModel(QtGui.QStandardItemModel):
+class PVModel(QtCore.QAbstractTableModel):
+    def __init__(self, *args, pvs=[], **kwargs):
+        # standard item model needs to be init with columns and rows
+        # fill out here and feed into super
+        super().__init__(*args, **kwargs)
+        self.pvs: List[List[str, dict]] = pvs or []
+        self.headers = ['PV Name', 'color', 'symbol', 'remove']
+        # self.setHorizontalHeaderLabels(self.headers)
+
+    def data(self, index, role):
+        if index.column() == 0:
+            # name column, no edit permissions
+            if role == QtCore.Qt.DisplayRole:
+                return self.pvs[index.row()][0]
+        elif index.column() == 3:
+            if role == QtCore.Qt.DisplayRole:
+                return 'delete?'
+        else:
+            # data column.  Each column gets its own data delegate
+            if role == QtCore.Qt.DisplayRole:
+                name, data = self.pvs[index.row()]
+                return data[self.headers[index.column()]]
+            if role in (QtCore.Qt.EditRole, QtCore.Qt.BackgroundRole):
+                return self.pvs[index.row()][1][self.headers[index.column()]]
+
+    def rowCount(self, index): return len(self.pvs)
+
+    def columnCount(self, index): return len(self.headers)
+
+    def headerData(
+        self,
+        section: int,
+        orientation: QtCore.Qt.Orientation,
+        role: int
+    ) -> Any:
+        if role != QtCore.Qt.DisplayRole:
+            return None
+
+        if orientation == QtCore.Qt.Horizontal:
+            return self.headers
+        else:
+            return list(range(len(self.pvs)))
+
+    def flags(self, index):
+        if (index.column() != 0):
+            return QtCore.Qt.ItemIsEditable | QtCore.Qt.ItemIsEnabled
+        else:
+            return QtCore.Qt.ItemIsEnabled
+
+    def removeRow(
+        self,
+        row: int,
+        parent: QtCore.QModelIndex = QtCore.QModelIndex()
+    ) -> bool:
+        """ augment existing implementation """
+        self.beginRemoveRows(parent, row, row)
+        del self.pvs[row]
+        self.endRemoveRows()
+
+    def setData(self, index, value, role=QtCore.Qt.EditRole):
+        """ Edit the data """
+        self.pvs[index.row()][1][self.headers[index.column()]] = value
+        # one index changed, so top_left == bottom_right
+        self.dataChanged.emit(index, index)
+        return True
+
+    def appendCurve(
+        self,
+        pv_name: str,
+        color: QtGui.QColor = QtGui.QColor(255, 0, 0),
+        symbol: str = 'o'
+    ):
+        print(f'appendCurve({pv_name}')
+        curr_len = len(self.pvs)
+        print(curr_len)
+        # index = self.createIndex(0,curr_len)
+        index = QtCore.QModelIndex()
+        self.beginInsertRows(index, 0, curr_len+1)
+        self.pvs.append((pv_name, {'color': color, 'symbol': symbol}))
+        # self.dataChanged.emit(index, index)
+        self.endInsertRows()
+        # self.layoutChanged.emit()
+
+    def insertRow(
+        self,
+        row: int,
+        parent: QtCore.QModelIndex = QtCore.QModelIndex()
+    ) -> bool:
+        self.beginInsertRows(
+            QtCore.QModelIndex(), row, row + self.rowCount(parent)
+        )
+        self.pvs.insert(
+            row, ['name', {'color': QtGui.QColor(255, 0, 0), 'symbol': 's'}]
+        )
+        self.endInsertRows()
+        return True
+
+
+class ColorDelegate(QtWidgets.QStyledItemDelegate):
+    def createEditor(
+        self,
+        parent: QtWidgets.QWidget,
+        option,
+        index: QtCore.QModelIndex
+    ) -> QtWidgets.QWidget:
+        picker = QtWidgets.QColorDialog()
+        return picker
+
+    def setModelData(
+        self,
+        editor: QtWidgets.QColorDialog,
+        model: QtCore.QAbstractItemModel,
+        index: QtCore.QModelIndex
+    ) -> None:
+        # no parent allows pop-out
+        color = editor.currentColor()
+        if color.isValid():
+            model.setData(index, color, QtCore.Qt.EditRole)
+
+
+class SymbolDelegate(QtWidgets.QStyledItemDelegate):
+    def createEditor(
+        self,
+        parent: QtWidgets.QWidget,
+        option,
+        index: QtCore.QModelIndex
+    ) -> QtWidgets.QWidget:
+        combo = QtWidgets.QComboBox(parent=parent)
+        combo.insertItems(0, ['', 'o', 's', 't', 'h'])
+        return combo
+
+    def setModelData(
+        self,
+        editor: QtWidgets.QComboBox,
+        model: QtCore.QAbstractItemModel,
+        index: QtCore.QModelIndex
+    ) -> None:
+        value = editor.currentText()
+        model.setData(index, value, QtCore.Qt.EditRole)
+
+
+class DeleteDelegate(QtWidgets.QStyledItemDelegate):
+    delete_request = QtCore.Signal(int)
+
+    def createEditor(
+        self,
+        parent: QtWidgets.QWidget,
+        option,
+        index: QtCore.QModelIndex
+    ) -> QtWidgets.QWidget:
+        del_button = QtWidgets.QPushButton('delete', parent)
+        del_button.clicked.connect(
+            lambda _, row=index.row(): self.delete_request.emit(row)
+        )
+        return del_button
+
+    def updateEditorGeometry(
+        self,
+        editor: QtWidgets.QWidget,
+        option,
+        index: QtCore.QModelIndex
+    ) -> None:
+        editor.setGeometry(option.rect)

--- a/atef/widgets/archive_viewer.py
+++ b/atef/widgets/archive_viewer.py
@@ -474,12 +474,13 @@ class PVModel(QtCore.QAbstractTableModel):
         row: int,
         parent: QtCore.QModelIndex = QtCore.QModelIndex()
     ) -> bool:
-        """_summary_
+        """
+        Inserts a row into the model, initializing data fields where possible
 
         Parameters
         ----------
         row : int
-            locationto insert row at
+            location to insert row at
         parent : QtCore.QModelIndex, optional
             the parent index, by default QtCore.QModelIndex()
 
@@ -526,7 +527,7 @@ class PVModel(QtCore.QAbstractTableModel):
 
         # add item to list
         index_1 = self.createIndex(0, 0)
-        index_2 = self.createIndex(0, 3)
+        index_2 = self.createIndex(0, len(self.headers) - 1)
         self.insertRow(0, index_1)
         self.pvs[0][0] = pv
         if dev_attr:

--- a/atef/widgets/archive_viewer.py
+++ b/atef/widgets/archive_viewer.py
@@ -535,11 +535,6 @@ class PVModel(QtCore.QAbstractTableModel):
         # don't insert if already present
         if pv in [row[0] for row in self.pvs]:
             logger.debug(f'{pv} already in model.  Skipping add')
-            QtWidgets.QMessageBox.information(
-                self.parent(),
-                'Duplicate PV',
-                'PV already exists in list, skipping add'
-            )
             return False
 
         # add item to list

--- a/atef/widgets/archive_viewer.py
+++ b/atef/widgets/archive_viewer.py
@@ -86,11 +86,6 @@ class ArchiverError(Exception):
     ...
 
 
-# TO-DO: crosshair hover over plot?
-#   -> time_plot.enableCrosshair
-# TO-DO: scaling / dealing with different scales between curves
-# TO-DO: Make redraw retain scale.
-# TO-DO: set tooltips
 class ArchiverViewerWidget(DesignerDisplay, QWidget):
     """
     Archiver time plot viewer

--- a/atef/widgets/archive_viewer.py
+++ b/atef/widgets/archive_viewer.py
@@ -89,8 +89,6 @@ class ArchiverError(Exception):
 # TO-DO: crosshair hover over plot?
 #   -> time_plot.enableCrosshair
 # TO-DO: scaling / dealing with different scales between curves
-# TO-DO: Turn off autoscale.  Set to 1 day automatically
-# TO-DO: make buttons work after manual zoom
 # TO-DO: Make redraw retain scale.
 # TO-DO: set tooltips
 class ArchiverViewerWidget(DesignerDisplay, QWidget):
@@ -184,8 +182,7 @@ class ArchiverViewerWidget(DesignerDisplay, QWidget):
             def fn():
                 now = datetime.datetime.today()
                 prev = now - datetime.timedelta(seconds=s)
-                self.time_plot.setMaxXRange(now.timestamp())
-                self.time_plot.setMinXRange(prev.timestamp())
+                self.time_plot.setXRange(prev.timestamp(), now.timestamp())
                 self.time_plot.updateXAxis()
             return fn
 

--- a/atef/widgets/archive_viewer.py
+++ b/atef/widgets/archive_viewer.py
@@ -8,6 +8,7 @@ import datetime
 import itertools
 import logging
 import os
+import re
 import urllib
 from typing import Any, ClassVar, Dict, List, Optional
 
@@ -136,7 +137,13 @@ class ArchiverViewerWidget(DesignerDisplay, QWidget):
             # ensure the port has been added for pydm
             # this handling needs work, but should suffice for now
             if not archiver_url.endswith(':17668'):
-                archiver_url += ':17668'
+                port_re = re.search(r'(:\d+)$', archiver_url)
+                if port_re and (port_re[0] != ':17668'):
+                    logger.warning(f'PYDM_ARCHIVER_URL ({archiver_url}) does '
+                                   'not end with port 17668, replacing port')
+                    archiver_url = archiver_url.replace(port_re[0], ':17668')
+                else:
+                    archiver_url += ':17668'
                 os.environ['PYDM_ARCHIVER_URL'] = archiver_url
 
         # EpicsArchive wants a stripped down url
@@ -291,7 +298,7 @@ class ArchiverViewerWidget(DesignerDisplay, QWidget):
                 self,
                 'Invalid PV',
                 'Fewer than 3 datapoints from last two days found in '
-                'archiver app, skipping add'
+                f'archiver app for pv ({pv}), skipping add'
             )
             return
 

--- a/atef/widgets/archive_viewer.py
+++ b/atef/widgets/archive_viewer.py
@@ -17,7 +17,7 @@ from pydm.widgets.archiver_time_plot import PyDMArchiverTimePlot
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import QRegularExpression, Qt
 from qtpy.QtGui import QRegularExpressionValidator
-from qtpy.QtWidgets import QWidget
+from qtpy.QtWidgets import QStyle, QWidget
 
 from atef.widgets.core import DesignerDisplay
 
@@ -115,6 +115,7 @@ class ArchiverViewerWidget(DesignerDisplay, QWidget):
     input_field: QtWidgets.QLineEdit
     curve_list: QtWidgets.QTableView
     redraw_button: QtWidgets.QPushButton
+    clear_button: QtWidgets.QPushButton
 
     def __init__(
         self,
@@ -195,7 +196,12 @@ class ArchiverViewerWidget(DesignerDisplay, QWidget):
         self._setup_pv_selector()
 
         self.redraw_button.clicked.connect(self._update_curves)
+        self.clear_button.clicked.connect(self._clear_curves)
 
+        ricon = self.style().standardIcon(QStyle.SP_BrowserReload)
+        self.redraw_button.setIcon(ricon)
+        cicon = self.style().standardIcon(QStyle.SP_DialogDiscardButton)
+        self.clear_button.setIcon(cicon)
         # set up time range buttons
         self._setup_range_buttons()
 
@@ -273,6 +279,13 @@ class ArchiverViewerWidget(DesignerDisplay, QWidget):
             logger.debug('left axis does not exist to rename')
 
         self.time_plot.setShowLegend(True)
+
+    def _clear_curves(self):
+        """ Clears the curves in the model and updates the plot """
+        for i in range(len(self.model.pvs)):
+            self.model.removeRow(i)
+
+        self._update_curves()
 
     def add_signal(self, pv: str, dev_attr: Optional[str] = None) -> None:
         """

--- a/atef/widgets/archive_viewer.py
+++ b/atef/widgets/archive_viewer.py
@@ -294,13 +294,10 @@ class ArchiverViewerWidget(DesignerDisplay, QWidget):
         # check if data exists
         data = self.get_pv_data_snippet(pv)
         if data and len(data['data']) < 3:
-            QtWidgets.QMessageBox.information(
-                self,
-                'Invalid PV',
+            logger.warning(
                 'Fewer than 3 datapoints from last two days found in '
-                f'archiver app for pv ({pv}), skipping add'
+                f'archiver app for pv ({pv})'
             )
-            return
 
         success = self.model.add_signal(pv, dev_attr=dev_attr)
 

--- a/atef/widgets/config/data.py
+++ b/atef/widgets/config/data.py
@@ -19,7 +19,8 @@ from qtpy.QtWidgets import (QCheckBox, QComboBox, QFrame, QHBoxLayout, QLabel,
 
 from atef.check import Comparison, Equals, Value
 from atef.config import (Configuration, ConfigurationGroup,
-                         DeviceConfiguration, GroupResultMode, PVConfiguration)
+                         DeviceConfiguration, GroupResultMode, PVConfiguration,
+                         ToolConfiguration)
 from atef.enums import Severity
 from atef.qt_helpers import QDataclassBridge, QDataclassList
 from atef.reduce import ReduceMethod
@@ -244,7 +245,8 @@ class NameDescTagsWidget(DesignerDisplay, NameMixin, DataWidget):
 
     def init_viewer(self, attr: str, config: Configuration) -> None:
         """ Set up the archive viewer button """
-        if hasattr(config, 'by_attr') or hasattr(config, 'by_pv'):
+        if ((hasattr(config, 'by_attr') or hasattr(config, 'by_pv'))
+                and not isinstance(config, ToolConfiguration)):
             icon = self.style().standardIcon(QStyle.SP_FileDialogContentsView)
             self.action_button.setIcon(icon)
             self.action_button.setToolTip('Open Archive Viewer with '

--- a/atef/widgets/config/data.py
+++ b/atef/widgets/config/data.py
@@ -168,6 +168,7 @@ class NameDescTagsWidget(DesignerDisplay, NameMixin, DataWidget):
         # if there's a pv, show the button for archive widget.
         # info would be filled in after init... don't show at start
         self.action_button.hide()
+        self._viewer_initialized = False
 
     def init_desc(self) -> None:
         """
@@ -234,6 +235,7 @@ class NameDescTagsWidget(DesignerDisplay, NameMixin, DataWidget):
         self.tags_content.addWidget(tags_list)
 
         def add_tag() -> None:
+            print('add_tag')
             if tags_list.widgets and not tags_list.widgets[-1].line_edit.text().strip():
                 # Don't add another tag if we haven't filled out the last one
                 return
@@ -245,6 +247,10 @@ class NameDescTagsWidget(DesignerDisplay, NameMixin, DataWidget):
 
     def init_viewer(self, attr: str, config: Configuration) -> None:
         """ Set up the archive viewer button """
+        if self._viewer_initialized:
+            # make sure this only happens once per instance
+            return
+
         if ((hasattr(config, 'by_attr') or hasattr(config, 'by_pv'))
                 and not isinstance(config, ToolConfiguration)):
             icon = self.style().standardIcon(QStyle.SP_FileDialogContentsView)
@@ -253,7 +259,7 @@ class NameDescTagsWidget(DesignerDisplay, NameMixin, DataWidget):
                                           'relevant signals')
             self.action_button.show()
 
-        def open_viewer(*args, **kwargs):
+        def open_arch_viewer(*args, **kwargs):
             # only query PV info once requested.  grabbing devices and
             # their relevant PVs can be time consuming
             pv_list = get_relevant_pvs(attr, config)
@@ -268,10 +274,12 @@ class NameDescTagsWidget(DesignerDisplay, NameMixin, DataWidget):
                 return
             widget = get_archive_viewer()
             for pv, dev_attr in pv_list:
-                widget.add_signal(pv, dev_attr=dev_attr)
+                widget.add_signal(pv, dev_attr=dev_attr, update_curves=False)
+            widget.update_curves()
             widget.show()
 
-        self.action_button.clicked.connect(open_viewer)
+        self.action_button.clicked.connect(open_arch_viewer)
+        self._viewer_initialized = True
 
 
 class TagsWidget(QWidget):

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -139,7 +139,7 @@ class AtefItem(QTreeWidgetItem):
 
 class PageWidget(QWidget):
     """
-    Base class for widgets that coorespond to a tree node.
+    Base class for widgets that correspond to a tree node.
 
     Contains utilities for navigating and manipulating
     the tree and for loading data widgets into placeholders.
@@ -1499,6 +1499,8 @@ class ComparisonPage(DesignerDisplay, PageWidget):
                     break
         desc = describe_comparison_context(attr=attr, config=config)
         self.name_desc_tags_widget.extra_text_label.setText(desc)
+        self.name_desc_tags_widget.extra_text_label.setToolTip(desc)
+        self.name_desc_tags_widget.init_viewer(attr, config)
 
     def setup_any_comparison(self) -> None:
         """

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -17,6 +17,7 @@ from atef.config import (Configuration, DeviceConfiguration, PVConfiguration,
                          ToolConfiguration)
 from atef.qt_helpers import QDataclassList, QDataclassValue
 from atef.tools import Ping
+from atef.widgets.archive_viewer import get_archive_viewer
 from atef.widgets.core import DesignerDisplay
 from atef.widgets.happi import HappiDeviceComponentWidget
 from atef.widgets.ophyd import OphydAttributeData, OphydAttributeDataSummary
@@ -372,6 +373,16 @@ class ComponentListWidget(StringListWithDialog):
                 high=summary.maximum,
             )
             self.suggest_comparison.emit(comparison)
+
+        def open_arch_viewer():
+            widget = get_archive_viewer()
+            self._arch = widget
+            widget.show()
+            # widget.activateWindow()
+
+        menu.addSection("Open Archive Data viewer")
+        archive_viewer_all = menu.addAction("View all selected")
+        archive_viewer_all.triggered.connect(open_arch_viewer)
 
         menu.addSection("Add all selected")
         add_without_action = menu.addAction("Add selected without comparison")

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -375,10 +375,10 @@ class ComponentListWidget(StringListWithDialog):
             self.suggest_comparison.emit(comparison)
 
         def open_arch_viewer():
-            widget = get_archive_viewer()
-            self._arch = widget
-            widget.show()
-            # widget.activateWindow()
+            arch_widget = get_archive_viewer()
+            for datum in data:
+                arch_widget.add_signal(datum.pvname)
+            arch_widget.show()
 
         menu.addSection("Open Archive Data viewer")
         archive_viewer_all = menu.addAction("View all selected")

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -382,7 +382,8 @@ class ComponentListWidget(StringListWithDialog):
             arch_widget.show()
 
         menu.addSection("Open Archive Data viewer")
-        archive_viewer_all = menu.addAction("View all selected")
+        archive_viewer_all = menu.addAction("View all selected in "
+                                            "Archive Viewer")
         archive_viewer_all.triggered.connect(open_arch_viewer)
 
         menu.addSection("Add all selected")

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -377,7 +377,14 @@ class ComponentListWidget(StringListWithDialog):
         def open_arch_viewer():
             arch_widget = get_archive_viewer()
             for datum in data:
-                dev_attr = '.'.join((datum.signal.parent.name, datum.attr))
+                try:
+                    parent_dev = (datum.signal.parent
+                                  or datum.signal.biological_parent)
+                    dev_attr = '.'.join((parent_dev.name, datum.attr))
+                except Exception as e:
+                    logger.debug('unable to resolve full device-attribute '
+                                 f'string: {e}')
+                    dev_attr = 'N/A'
                 arch_widget.add_signal(datum.pvname, dev_attr=dev_attr)
             arch_widget.show()
 

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -311,7 +311,7 @@ class ComponentListWidget(StringListWithDialog):
 
     def _open_component_chooser(self, to_select: Optional[List[str]] = None) -> None:
         """
-        Hook: User requested adding/editing a componen.
+        Hook: User requested adding/editing a component.
 
         Parameters
         ----------

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -385,7 +385,10 @@ class ComponentListWidget(StringListWithDialog):
                     logger.debug('unable to resolve full device-attribute '
                                  f'string: {e}')
                     dev_attr = 'N/A'
-                arch_widget.add_signal(datum.pvname, dev_attr=dev_attr)
+                arch_widget.add_signal(
+                    datum.pvname, dev_attr=dev_attr, update_curves=False
+                )
+                arch_widget.update_curves()
             arch_widget.show()
 
         menu.addSection("Open Archive Data viewer")

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -377,7 +377,8 @@ class ComponentListWidget(StringListWithDialog):
         def open_arch_viewer():
             arch_widget = get_archive_viewer()
             for datum in data:
-                arch_widget.add_signal(datum.pvname)
+                dev_attr = '.'.join((datum.signal.parent.name, datum.attr))
+                arch_widget.add_signal(datum.pvname, dev_attr=dev_attr)
             arch_widget.show()
 
         menu.addSection("Open Archive Data viewer")

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -18,6 +18,7 @@ from qtpy.QtWidgets import (QAction, QFileDialog, QMainWindow, QMessageBox,
 
 from atef.config import ConfigurationFile
 
+from ..archive_viewer import get_archive_viewer
 from ..core import DesignerDisplay
 from .page import AtefItem, ConfigurationGroupPage, link_page
 
@@ -42,6 +43,7 @@ class Window(DesignerDisplay, QMainWindow):
     action_save_as: QAction
     action_print_dataclass: QAction
     action_print_serialized: QAction
+    action_open_archive_viewer: QAction
 
     def __init__(self, *args, show_welcome: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
@@ -52,6 +54,9 @@ class Window(DesignerDisplay, QMainWindow):
         self.action_save_as.triggered.connect(self.save_as)
         self.action_print_dataclass.triggered.connect(self.print_dataclass)
         self.action_print_serialized.triggered.connect(self.print_serialized)
+        self.action_open_archive_viewer.triggered.connect(
+            self.open_archive_viewer
+        )
         if show_welcome:
             QTimer.singleShot(0, self.welcome_user)
 
@@ -205,6 +210,11 @@ class Window(DesignerDisplay, QMainWindow):
         The parameters are open as to accept inputs from any signal.
         """
         pprint(self.serialize_tree(self.get_current_tree()))
+
+    def open_archive_viewer(self, *args, **kwargs):
+        """ Open the archive viewer """
+        widget = get_archive_viewer()
+        widget.show()
 
 
 class Tree(DesignerDisplay, QWidget):

--- a/atef/widgets/ophyd.py
+++ b/atef/widgets/ophyd.py
@@ -17,6 +17,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import Qt
 
 from ..qt_helpers import copy_to_clipboard
+from .archive_viewer import get_archive_viewer
 from .core import DesignerDisplay
 
 logger = logging.getLogger(__name__)
@@ -734,6 +735,7 @@ class OphydDeviceTableWidget(DesignerDisplay, QtWidgets.QFrame):
     device_table_view: OphydDeviceTableView
     button_update_data: QtWidgets.QPushButton
     button_select_attrs: QtWidgets.QPushButton
+    button_archive_view: QtWidgets.QPushButton
 
     def __init__(
         self,
@@ -794,6 +796,8 @@ class OphydDeviceTableWidget(DesignerDisplay, QtWidgets.QFrame):
             self.attributes_selected.emit
         )
 
+        self.button_archive_view.clicked.connect(self._open_archive_viewer)
+
     def _create_context_menu(self):
         """Handler for when the device table view is right clicked."""
         attrs = self.device_table_view.selected_attribute_data
@@ -815,6 +819,18 @@ class OphydDeviceTableWidget(DesignerDisplay, QtWidgets.QFrame):
             self._custom_menu.exec_(top_left)
         else:
             self.attributes_selected.emit(attrs)
+
+    def _open_archive_viewer(self):
+        """ Handler for opening Archive Viewer Widget """
+        data = self.device_table_view.selected_attribute_data
+        if not data:
+            return
+
+        arch_widget = get_archive_viewer()
+        for datum in data:
+            dev_attr = '.'.join((datum.signal.parent.name, datum.attr))
+            arch_widget.add_signal(datum.pvname, dev_attr=dev_attr)
+        arch_widget.show()
 
     def closeEvent(self, ev: QtGui.QCloseEvent):
         super().closeEvent(ev)

--- a/atef/widgets/ophyd.py
+++ b/atef/widgets/ophyd.py
@@ -823,8 +823,6 @@ class OphydDeviceTableWidget(DesignerDisplay, QtWidgets.QFrame):
     def _open_archive_viewer(self):
         """ Handler for opening Archive Viewer Widget """
         data = self.device_table_view.selected_attribute_data
-        if not data:
-            return
 
         arch_widget = get_archive_viewer()
         for datum in data:

--- a/atef/widgets/ophyd.py
+++ b/atef/widgets/ophyd.py
@@ -693,9 +693,10 @@ class OphydDeviceTableView(QtWidgets.QTableView):
     @property
     def selected_attribute_data(self) -> List[OphydAttributeData]:
         """The OphydAttributeData items that correspond to the selection."""
+        unique_indexes = {ind.row(): ind for ind in self.selectedIndexes()}
         data = [
             self.get_data_from_proxy_index(index)
-            for index in self.selectedIndexes()
+            for index in unique_indexes.values()
         ]
         return [datum for datum in data if datum is not None]
 

--- a/atef/widgets/procedure.py
+++ b/atef/widgets/procedure.py
@@ -254,7 +254,7 @@ class DescriptionStepWidget(StepWidgetBase, QtWidgets.QFrame):
 
 class ExpandableFrame(QtWidgets.QFrame):
     """
-    A `QtWidgets.QFrame` that can be toggled with a mouse clik.
+    A `QtWidgets.QFrame` that can be toggled with a mouse click.
 
     Contains a QVBoxLayout layout which can have one or more user-provided
     widgets.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -40,6 +40,7 @@ test:
       - atef
     requires:
       - pytest
+      - pcdsdevices
 
 about:
   home: https://github.com/pcdshub/atef


### PR DESCRIPTION
## Description
Adds an archive appliance viewer widget to help during check creation.  Leverages PydmArchiverTimePlot

Includes neat features (read: time sinks) like:
- a neat table view that holds pv curve information (symbol, color, etc.  More to come)
- basic `archapp.EpicsArchive` validation on PV input
- integration with existing context Ophyd/Happi device context menus 

## Motivation and Context
#69 
closes #130 along the way

## How Has This Been Tested?
interactively 

## Where Has This Been Documented?
Lots of comments as I learn more about qt
this PR. 

(Opening from the happi/ophyd component selector)
<img width="1722" alt="image" src="https://user-images.githubusercontent.com/35379409/201449479-ea9be94b-ae74-426a-bf64-fcd44539bab4.png">

(opening from main window)
<img width="454" alt="image" src="https://user-images.githubusercontent.com/35379409/201449524-c9a4e5aa-d334-48c0-a381-cf7d6137b879.png">

(opening from comparison page, opens all signals related to the comparison)
<img width="479" alt="image" src="https://user-images.githubusercontent.com/35379409/201449567-fe4e9169-7988-417b-b37f-b1d296f84d70.png">


<img width="861" alt="image" src="https://user-images.githubusercontent.com/35379409/200662524-49958e4b-4f53-44ed-992a-298740203580.png">

Double clicking on items in the table brings up edit windows
color picker: 
<img width="549" alt="image" src="https://user-images.githubusercontent.com/35379409/199134394-6de463b6-9a66-4a71-b7da-ce4bd0ba86e9.png">

symbol combobox
<img width="103" alt="image" src="https://user-images.githubusercontent.com/35379409/199134432-a6988444-a0b8-44f1-9f53-f4e290fff2d2.png">
