### PR TITLE
TST: skip lightpath mixins in test_switch_control_layer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         exclude: '^(conda-recipe/meta.yaml)$'
     -   id: debug-statements
 
--   repo: https://gitlab.com/pycqa/flake8.git
+-   repo: https://github.com/pycqa/flake8.git
     rev: 3.9.0
     hooks:
     -   id: flake8

--- a/atef/tests/test_archived_device.py
+++ b/atef/tests/test_archived_device.py
@@ -8,11 +8,15 @@ import pytest
 from ..archive_device import ArchivedValue, make_archived_device
 from . import conftest
 
+# skip these devices, subclassing is too involved to be automated
+SKIP_CLS = ['LightpathMixin', 'LightpathInOutCptMixin']
+
 all_pcdsdevice_classes = pytest.mark.parametrize(
     "cls",
     [
         pytest.param(cls, id=f"{cls.__module__}.{cls.__name__}")
-        for cls in pcdsdevices.tests.conftest.find_all_device_classes()
+        for cls
+        in pcdsdevices.tests.conftest.find_all_device_classes(skip=SKIP_CLS)
     ]
 )
 


### PR DESCRIPTION
## Description
Skips lightpath mixin classes that subclass device, but cannot be simply subclassed, allowing tests to pass.

Now possible thanks to https://github.com/pcdshub/pcdsdevices/pull/1077

## Motivation and Context
closes #133 
This will hold up ci until it's merged, and is a small enough fix to push through

## How Has This Been Tested?
tests pass locally

## Where Has This Been Documented?
This PR