### PR TITLE
MNT: refactor active checkouts to have Prepared variants

### DIFF
--- a/atef/bin/check.py
+++ b/atef/bin/check.py
@@ -16,10 +16,11 @@ import rich.console
 import rich.tree
 
 from ..cache import DataCache, _SignalCache, get_signal_cache
-from ..check import Comparison, Result, Severity
+from ..check import Comparison, Severity
 from ..config import (AnyConfiguration, AnyPreparedConfiguration,
                       ConfigurationFile, FailedConfiguration,
                       PreparedComparison, PreparedFile, PreparedGroup)
+from ..result import Result
 from ..util import ophyd_cleanup
 
 logger = logging.getLogger(__name__)

--- a/atef/config.py
+++ b/atef/config.py
@@ -14,19 +14,18 @@ import ophyd
 import yaml
 from ophyd.signal import ConnectionTimeoutError
 
+from atef.result import _summarize_result_severity
+
 from . import serialization, tools, util
 from .cache import DataCache
-from .check import Comparison, Result, incomplete
+from .check import Comparison
 from .enums import GroupResultMode, Severity
 from .exceptions import PreparedComparisonException
+from .result import Result, incomplete_result
 from .type_hints import AnyPath
 from .yaml_support import init_yaml_support
 
 logger = logging.getLogger(__name__)
-
-
-def incomplete_result():
-    return incomplete
 
 
 @dataclass
@@ -325,41 +324,6 @@ class FailedConfiguration:
     result: Result
     #: Exception that was caught, if available.
     exception: Optional[Exception] = None
-
-
-def _summarize_result_severity(
-    mode: GroupResultMode,
-    results: List[Union[Result, Exception, None]]
-) -> Severity:
-    """
-    Summarize all results based on the configured mode.
-
-    Parameters
-    ----------
-    mode : GroupResultMode
-        The mode to apply to the results.
-    results : list of (Result, Exception, or None)
-        The list of results.
-
-    Returns
-    -------
-    Severity
-        The calculated severity.
-    """
-    if any(result is None or isinstance(result, Exception) for result in results):
-        return Severity.error
-
-    severities = [
-        result.severity for result in results if isinstance(result, Result)
-    ]
-
-    if mode == GroupResultMode.all_:
-        return util.get_maximum_severity(severities)
-
-    if mode == GroupResultMode.any_:
-        return util.get_minimum_severity(severities)
-
-    return Severity.internal_error
 
 
 @dataclass

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -16,20 +16,15 @@ import yaml
 from bluesky import RunEngine
 
 from atef.cache import DataCache
-from atef.check import Result, incomplete
-from atef.config import (ConfigurationFile, PreparedFile,
-                         _summarize_result_severity, run_passive_step)
+from atef.config import ConfigurationFile, PreparedFile, run_passive_step
 from atef.enums import GroupResultMode, Severity
+from atef.result import Result, _summarize_result_severity, incomplete_result
 from atef.type_hints import AnyPath
 from atef.yaml_support import init_yaml_support
 
 from . import serialization
 
 logger = logging.getLogger(__name__)
-
-
-def incomplete_result():
-    return incomplete
 
 
 class BlueskyState:

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -532,7 +532,7 @@ class PreparedPassiveStep(PreparedProcedureStep):
     async def _run(self) -> Result:
         """ Load, prepare, and run the passive step """
         if not self.prepared_passive_file:
-            return
+            return Result(severity=Severity.error, reason='No passive checkout to run')
         return await run_passive_step(self.prepared_passive_file)
 
     @classmethod

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -1,14 +1,27 @@
+"""
+Dataclasses for describing active checkout procedures.  These dataclasses come in
+normal (edit) and Prepared (run) variants
+
+Edit variants hold data needed to specify the step.
+Prepared variants hold a reference to their originating edit-step, along with
+Result objects and a .run() method.
+
+Adding a step requires:
+- write the edit-variant
+- add the edit-variant to the AnyProcedure type hint
+- write the run-variant, along with its ._run() and .from_origin() methods
+- add the step to PreparedProcedure.from_origin classmethod case statement
+"""
 from __future__ import annotations
 
-import asyncio
 import dataclasses
 import datetime
 import json
 import logging
 import pathlib
 from dataclasses import dataclass, field
-from typing import (Any, Dict, Generator, Literal, Optional, Sequence, Union,
-                    cast)
+from typing import (Any, Dict, Generator, List, Literal, Optional, Sequence,
+                    Union, cast)
 
 import apischema
 import databroker
@@ -71,68 +84,10 @@ class ProcedureStep:
     description: Optional[str] = None
     #: The hierarchical parent of this step.
     parent: Optional[ProcedureGroup] = None
-    #: overall result of running the step
-    combined_result: Result = field(default_factory=incomplete_result)
-    #: confirmation by the user that result matches expectations
-    verify_result: Result = field(default_factory=incomplete_result)
     #: verification requirements, is human verification required?
     verify_required: bool = True
-    #: whether or not the step completed successfully
-    step_result: Result = field(default_factory=incomplete_result)
     #: step success requirements, does the step need to complete?
     step_success_required: bool = True
-
-    def _run(self) -> Result:
-        """ Run the comparison.  To be implemented in subclass. """
-        raise NotImplementedError()
-
-    def run(self) -> Result:
-        """ Run the step and return the result """
-        try:
-            result = self._run()
-        except Exception as ex:
-            result = Result(
-                severity=Severity.internal_error,
-                reason=str(ex)
-            )
-
-        # stash step result
-        self.step_result = result
-        # return the overall result, including verification
-        return self.result
-
-    @property
-    def result(self) -> Result:
-        """
-        Combines the step result and verification result based on settings
-
-        Returns
-        -------
-        Result
-            The result of this step
-        """
-        results = []
-        reason = ''
-        if self.verify_required:
-            results.append(self.verify_result)
-            if self.verify_result.severity != Severity.success:
-                reason += f'Not Verified ({self.verify_result.reason}),'
-            else:
-                reason += f'Verified ({self.verify_result.reason})'
-
-        if self.step_success_required:
-            results.append(self.step_result)
-            if self.step_result.severity != Severity.success:
-                reason += f'Not Successful ({self.step_result.reason})'
-
-        if not results:
-            # Nothing required, auto-success
-            self.combined_result = Result()
-            return self.combined_result
-
-        severity = _summarize_result_severity(GroupResultMode.all_, results)
-        self.combined_result = Result(severity=severity, reason=reason)
-        return self.combined_result
 
     def allow_verify(self) -> bool:
         """
@@ -145,9 +100,7 @@ class ProcedureStep:
 @dataclass
 class DescriptionStep(ProcedureStep):
     """A simple title or descriptive step in the procedure."""
-    def _run(self) -> Result:
-        """ Always a successful result, allowing verification """
-        return Result()
+    pass
 
 
 @dataclass
@@ -233,18 +186,6 @@ class PassiveStep(ProcedureStep):
     """A step that runs a passive checkout file"""
     filepath: pathlib.Path = field(default_factory=pathlib.Path)
 
-    def _run(self) -> Result:
-        """ Load, prepare, and run the passive step """
-        config = ConfigurationFile.from_filename(self.filepath)
-
-        prepared_config = PreparedFile.from_config(file=config,
-                                                   cache=DataCache())
-
-        # run passive checkout.  Will need to set up asyncio loop
-        result = asyncio.run(run_passive_step(prepared_config))
-
-        return result
-
 
 @dataclass
 class ProcedureGroup(ProcedureStep):
@@ -258,17 +199,6 @@ class ProcedureGroup(ProcedureStep):
             yield step
             if isinstance(step, ProcedureGroup):
                 yield from step.walk_steps()
-
-    def run(self) -> Result:
-        results = []
-        for step in self.steps:
-            results.append(step.run())
-
-        severity = _summarize_result_severity(GroupResultMode.all_, results)
-        result = Result(severity=severity)
-
-        self.step_result = result
-        return self.result
 
 
 AnyProcedure = Union[
@@ -328,24 +258,256 @@ class ProcedureFile:
         init_yaml_support()
         return yaml.dump(self.to_json())
 
-    def compare(self) -> Result:
-        return self.root.compare()
+
+######################
+# Prepared Dataclasses
+######################
 
 
-def run_procedure(
-    process: ProcedureFile,
-):
-    """
-    Run a procedure given a ProcedureFile.
+@dataclass
+class PreparedProcedureFile:
+    #: Corresponding ProcedureFile information
+    file: ProcedureFile
+    #: Procedure steps defined in the top-level file
+    root: PreparedProcedureGroup
 
-    Gross skeleton code I am organizing my thoughts
-    """
-    for step in process.walk_steps():
-        print(step)
-        # check that the step has been completed
+    @classmethod
+    def from_origin(
+        cls,
+        file: ProcedureFile,
+    ) -> PreparedProcedureFile:
+        """
+        Prepare a ProcedureFile for running
 
-        # if verified
-        step.verify = True
-        step.result = Result()
+        Parameters
+        ----------
+        file : ProcedureFile
+            the procedure file instance
+        """
+        prepared_root = PreparedProcedureGroup.from_origin(group=file.root)
 
-    return process
+        prep_proc_file = PreparedProcedureFile(
+            file=file,
+            root=prepared_root
+        )
+
+        prepared_root.parent = prep_proc_file
+        return prep_proc_file
+
+    async def run(self) -> Result:
+        return await self.root.run()
+
+
+@dataclass
+class FailedStep:
+    """ A step that failed to be prepared for running. """
+    #: The data cache to use for the preparation step.
+    parent: Optional[PreparedProcedureGroup]
+    #: Configuration instance.
+    step: AnyProcedure
+    #: overall result of running the step
+    combined_result: Result
+    #: confirmation by the user that result matches expectations
+    verify_result: Result = field(default_factory=incomplete_result)
+    #: whether or not the step completed successfully
+    step_result: Result = field(default_factory=incomplete_result)
+    #: Exception that was caught, if available.
+    exception: Optional[Exception] = None
+
+    @property
+    def result(self) -> Result:
+        return self.combined_result
+
+
+@dataclass
+class PreparedProcedureStep:
+    #: name of this comparison
+    name: Optional[str] = None
+    #: original procedure step, of which this is the prepared version
+    origin: ProcedureStep = field(default_factory=ProcedureStep)
+    #: hierarchical parent of this step
+    parent: Optional[PreparedProcedureGroup] = None
+
+    #: overall result of running the step
+    combined_result: Result = field(default_factory=incomplete_result)
+    #: confirmation by the user that result matches expectations
+    verify_result: Result = field(default_factory=incomplete_result)
+    #: whether or not the step completed successfully
+    step_result: Result = field(default_factory=incomplete_result)
+
+    @property
+    def result(self) -> Result:
+        """
+        Combines the step result and verification result based on settings
+
+        Returns
+        -------
+        Result
+            The result of this step
+        """
+        results = []
+        reason = ''
+        if self.origin.verify_required:
+            results.append(self.verify_result)
+            if self.verify_result.severity != Severity.success:
+                reason += f'Not Verified ({self.verify_result.reason})'
+            else:
+                reason += f'Verified ({self.verify_result.reason})'
+
+        if self.origin.step_success_required:
+            results.append(self.step_result)
+            if self.step_result.severity != Severity.success:
+                reason += f', Not Successful ({self.step_result.reason})'
+
+        if not results:
+            # Nothing required, auto-success
+            self.combined_result = Result()
+            return self.combined_result
+
+        severity = _summarize_result_severity(GroupResultMode.all_, results)
+        self.combined_result = Result(severity=severity, reason=reason)
+        return self.combined_result
+
+    async def _run(self) -> Result:
+        """ Run the step.  To be implemented in subclass. """
+        raise NotImplementedError()
+
+    async def run(self) -> Result:
+        """ Run the step and return the result """
+        try:
+            result = await self._run()
+        except Exception as ex:
+            result = Result(
+                severity=Severity.internal_error,
+                reason=str(ex)
+            )
+
+        # stash step result
+        self.step_result = result
+        # return the overall result, including verification
+        return self.result
+
+    @classmethod
+    def from_origin(
+        cls,
+        step: AnyProcedure,
+        parent: Optional[PreparedProcedureGroup] = None
+    ) -> PreparedProcedureStep:
+        try:
+            print(type(step))
+            if isinstance(step, DescriptionStep):
+                return PreparedDescriptionStep.from_origin(
+                    step=step, parent=parent
+                )
+            if isinstance(step, ProcedureGroup):
+                return PreparedProcedureGroup.from_origin(
+                    group=step, parent=parent
+                )
+            if isinstance(step, PassiveStep):
+                return PreparedPassiveStep.from_origin(
+                    step=step, parent=parent
+                )
+            raise NotImplementedError(f"Step type unsupported: {type(step)}")
+        except Exception as ex:
+            return FailedStep(
+                step=step,
+                parent=parent,
+                exception=ex,
+                combined_result=Result(
+                    severity=Severity.internal_error,
+                    reason=(
+                        f"Failed to instantiate step: {ex}."
+                        f"Step is: {step.name} ({step.description or ''!r})"
+                    )
+                )
+            )
+
+
+@dataclass
+class PreparedProcedureGroup(PreparedProcedureStep):
+    #: hierarchical parent of this step
+    parent: Optional[Union[PreparedProcedureFile, PreparedProcedureGroup]] = field(
+        default=None, repr=False
+    )
+    steps: List[AnyProcedure] = field(default_factory=list)
+    prepare_failures: List[FailedStep] = field(default_factory=list)
+
+    @classmethod
+    def from_origin(
+        cls,
+        group: ProcedureGroup,
+        parent: Optional[PreparedProcedureGroup | PreparedProcedureFile] = None,
+    ) -> PreparedProcedureGroup:
+        prepared = cls(origin=group, parent=parent, steps=[])
+
+        for step in group.steps:
+            prep_step = PreparedProcedureStep.from_origin(
+                step=cast(AnyProcedure, step),
+                parent=prepared
+            )
+            if isinstance(prep_step, FailedStep):
+                prepared.prepare_failures.append(prep_step)
+            else:
+                prepared.steps.append(prep_step)
+
+        return prepared
+
+    async def run(self) -> Result:
+        """ Run all steps and return a combined result """
+        results = []
+        for step in self.steps:
+            results.append(await step.run())
+
+        if self.prepare_failures:
+            result = Result(
+                severity=Severity.error,
+                reason='At least one step failed to initialize'
+            )
+        else:
+            severity = _summarize_result_severity(GroupResultMode.all_, results)
+            result = Result(severity=severity)
+
+        self.step_result = result
+        return self.result
+
+
+@dataclass
+class PreparedDescriptionStep(PreparedProcedureStep):
+    async def _run(self):
+        return Result()
+
+    @classmethod
+    def from_origin(
+        cls,
+        step: DescriptionStep,
+        parent: Optional[PreparedProcedureGroup]
+    ) -> PreparedDescriptionStep:
+        return cls(origin=step, parent=parent)
+
+
+@dataclass
+class PreparedPassiveStep(PreparedProcedureStep):
+    prepared_passive_config: Optional[PreparedFile] = None
+
+    async def _run(self) -> Result:
+        """ Load, prepare, and run the passive step """
+        config = ConfigurationFile.from_filename(self.origin.filepath)
+
+        prepared_config = PreparedFile.from_config(file=config,
+                                                   cache=DataCache())
+        self.prepared_passive_config = prepared_config
+        return await run_passive_step(prepared_config)
+
+    @classmethod
+    def from_origin(
+        cls,
+        step: PassiveStep,
+        parent: Optional[PreparedProcedureGroup]
+    ):
+        passive_file = ConfigurationFile.from_filename(step.filepath)
+        prep_passive_file = PreparedFile.from_config(file=passive_file)
+        return cls(
+            origin=step,
+            prepared_passive_config=prep_passive_file,
+            parent=parent
+        )

--- a/atef/report.py
+++ b/atef/report.py
@@ -20,13 +20,13 @@ from reportlab.platypus.frames import Frame
 from reportlab.platypus.paragraph import Paragraph
 from reportlab.platypus.tableofcontents import TableOfContents
 
-from atef.check import Result
 from atef.config import (PreparedComparison, PreparedConfiguration,
                          PreparedDeviceConfiguration, PreparedFile,
                          PreparedGroup, PreparedPVConfiguration,
                          PreparedSignalComparison, PreparedToolComparison,
                          PreparedToolConfiguration)
 from atef.enums import Severity
+from atef.result import Result
 
 h1 = PS(name='Heading1', fontSize=16, leading=20)
 

--- a/atef/result.py
+++ b/atef/result.py
@@ -1,0 +1,91 @@
+"""
+Results for comparisons or procedures.  This module holds the lynchpin Result
+class, as well as accompanying helper functions
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+from atef import exceptions, util
+from atef.enums import GroupResultMode, Severity
+from atef.exceptions import PreparedComparisonException
+
+
+@dataclass(frozen=True)
+class Result:
+    severity: Severity = Severity.success
+    reason: Optional[str] = None
+
+    @classmethod
+    def from_exception(cls, error: Exception) -> Result:
+        """Convert an error exception to a Result."""
+        severity = Severity.internal_error
+        if isinstance(error, exceptions.ConfigFileHappiError):
+            reason = f"Failed to load: {error.dev_name}"
+        elif isinstance(error, PreparedComparisonException):
+            if error.comparison is not None:
+                severity = error.comparison.severity_on_failure
+            reason = (
+                f"Failed to prepare comparison {error.name!r} for "
+                f"{error.identifier!r}: {error}"
+            )
+        else:
+            reason = f"Failed to load: {type(error).__name__}: {error}"
+
+        return cls(
+            severity=severity,
+            reason=reason,
+        )
+
+
+def incomplete_result():
+    return Result(severity=Severity.warning, reason='step incomplete')
+
+
+def successful_result():
+    return Result()
+
+
+def combine_results(results: List[Result]) -> Result:
+    """
+    Combines results into a single result.
+    Takes the highest severity, and currently all the reasons
+    """
+    severity = util.get_maximum_severity([r.severity for r in results])
+    reason = str([r.reason for r in results]) or ''
+
+    return Result(severity=severity, reason=reason)
+
+
+def _summarize_result_severity(
+    mode: GroupResultMode,
+    results: List[Union[Result, Exception, None]]
+) -> Severity:
+    """
+    Summarize all results based on the configured mode.
+    Parameters
+    ----------
+    mode : GroupResultMode
+        The mode to apply to the results.
+    results : list of (Result, Exception, or None)
+        The list of results.
+    Returns
+    -------
+    Severity
+        The calculated severity.
+    """
+    if any(result is None or isinstance(result, Exception) for result in results):
+        return Severity.error
+
+    severities = [
+        result.severity for result in results if isinstance(result, Result)
+    ]
+
+    if mode == GroupResultMode.all_:
+        return util.get_maximum_severity(severities)
+
+    if mode == GroupResultMode.any_:
+        return util.get_minimum_severity(severities)
+
+    return Severity.internal_error

--- a/atef/result.py
+++ b/atef/result.py
@@ -4,7 +4,8 @@ class, as well as accompanying helper functions
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
 from typing import List, Optional, Union
 
 from atef import exceptions, util
@@ -16,6 +17,7 @@ from atef.exceptions import PreparedComparisonException
 class Result:
     severity: Severity = Severity.success
     reason: Optional[str] = None
+    timestamp: datetime = field(default_factory=datetime.utcnow, compare=False)
 
     @classmethod
     def from_exception(cls, error: Exception) -> Result:

--- a/atef/result.py
+++ b/atef/result.py
@@ -15,6 +15,11 @@ from atef.exceptions import PreparedComparisonException
 
 @dataclass(frozen=True)
 class Result:
+    """
+    The result of a check or step.  Contains a severity enum and reason.
+    The timestamp field should not be specified at creation, as it will be
+    automatically filled.
+    """
     severity: Severity = Severity.success
     reason: Optional[str] = None
     timestamp: datetime = field(default_factory=datetime.utcnow, compare=False)
@@ -53,6 +58,16 @@ def combine_results(results: List[Result]) -> Result:
     """
     Combines results into a single result.
     Takes the highest severity, and currently all the reasons
+
+    Parameters
+    ----------
+    results : List[Result]
+        a list of Results to combine
+
+    Returns
+    -------
+    Result
+        the combined Result
     """
     severity = util.get_maximum_severity([r.severity for r in results])
     reason = str([r.reason for r in results]) or ''
@@ -66,12 +81,14 @@ def _summarize_result_severity(
 ) -> Severity:
     """
     Summarize all results based on the configured mode.
+
     Parameters
     ----------
     mode : GroupResultMode
         The mode to apply to the results.
     results : list of (Result, Exception, or None)
         The list of results.
+
     Returns
     -------
     Severity

--- a/atef/tests/configs/active_test.json
+++ b/atef/tests/configs/active_test.json
@@ -1,63 +1,27 @@
 {
   "version": 0,
   "root": {
-    "name": "active_all",
-    "description": "Basic active checkout",
+    "name": "root",
+    "description": null,
     "parent": null,
-    "combined_result": {
-      "severity": 1,
-      "reason": "step incomplete"
-    },
-    "verify_result": {
-      "severity": 1,
-      "reason": "step incomplete"
-    },
     "verify_required": true,
-    "step_result": {
-      "severity": 1,
-      "reason": "step incomplete"
-    },
     "step_success_required": true,
     "steps": [
       {
         "DescriptionStep": {
-          "name": "desc_title",
-          "description": "description for description step",
+          "name": "fdsa",
+          "description": null,
           "parent": null,
-          "combined_result": {
-            "severity": 1,
-            "reason": "step incomplete"
-          },
-          "verify_result": {
-            "severity": 1,
-            "reason": "step incomplete"
-          },
           "verify_required": true,
-          "step_result": {
-            "severity": 1,
-            "reason": "step incomplete"
-          },
-          "step_success_required": false
+          "step_success_required": true
         }
       },
       {
         "PassiveStep": {
-          "name": "passive_title",
+          "name": "fdsa",
           "description": null,
           "parent": null,
-          "combined_result": {
-            "severity": 1,
-            "reason": "step incomplete"
-          },
-          "verify_result": {
-            "severity": 1,
-            "reason": "step incomplete"
-          },
           "verify_required": true,
-          "step_result": {
-            "severity": 1,
-            "reason": "step incomplete"
-          },
           "step_success_required": true,
           "filepath": "."
         }

--- a/atef/tests/configs/active_test.json
+++ b/atef/tests/configs/active_test.json
@@ -2,15 +2,15 @@
   "version": 0,
   "root": {
     "name": "root",
-    "description": null,
+    "description": "sample active test checkout",
     "parent": null,
     "verify_required": true,
     "step_success_required": true,
     "steps": [
       {
         "DescriptionStep": {
-          "name": "fdsa",
-          "description": null,
+          "name": "desc_title",
+          "description": "description for description step",
           "parent": null,
           "verify_required": true,
           "step_success_required": true
@@ -18,8 +18,8 @@
       },
       {
         "PassiveStep": {
-          "name": "fdsa",
-          "description": null,
+          "name": "passive_title",
+          "description": "description for passive step",
           "parent": null,
           "verify_required": true,
           "step_success_required": true,

--- a/atef/tests/conftest.py
+++ b/atef/tests/conftest.py
@@ -1,7 +1,7 @@
 import contextlib
 import datetime
 import pathlib
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import pydm
 import pydm.exception
@@ -12,6 +12,23 @@ from ..archive_device import ArchivedValue, ArchiverHelper
 
 TEST_PATH = pathlib.Path(__file__).parent.resolve()
 CONFIG_PATH = TEST_PATH / "configs"
+
+
+def passive_checkout_configs() -> List[pathlib.Path]:
+    filenames = ['lfe.json', 'all_fields.json', 'ping_localhost.json']
+    config_paths = [CONFIG_PATH / fn for fn in filenames]
+    return config_paths
+
+
+def active_checkout_configs() -> List[pathlib.Path]:
+    filenames = ['active_test.json']
+    config_paths = [CONFIG_PATH / fn for fn in filenames]
+    return config_paths
+
+
+PASSIVE_CONFIG_PATHS = passive_checkout_configs()
+ACTIVE_CONFIG_PATHS = active_checkout_configs()
+ALL_CONFIG_PATHS = PASSIVE_CONFIG_PATHS + ACTIVE_CONFIG_PATHS
 
 
 class MockEpicsArch:

--- a/atef/tests/conftest.py
+++ b/atef/tests/conftest.py
@@ -31,6 +31,21 @@ ACTIVE_CONFIG_PATHS = active_checkout_configs()
 ALL_CONFIG_PATHS = PASSIVE_CONFIG_PATHS + ACTIVE_CONFIG_PATHS
 
 
+@pytest.fixture(params=PASSIVE_CONFIG_PATHS)
+def passive_config_path(request) -> pathlib.Path:
+    return request.param
+
+
+@pytest.fixture(params=ACTIVE_CONFIG_PATHS)
+def active_config_path(request) -> pathlib.Path:
+    return request.param
+
+
+@pytest.fixture(params=ALL_CONFIG_PATHS)
+def all_config_path(request) -> pathlib.Path:
+    return request.param
+
+
 class MockEpicsArch:
     """
     Mock archapp.EpicsArch.

--- a/atef/tests/test_comparison.py
+++ b/atef/tests/test_comparison.py
@@ -1,8 +1,8 @@
 import pytest
 
 from .. import check
-from ..check import (Comparison, Equals, NotEquals, PrimitiveType, Result,
-                     Severity)
+from ..check import Comparison, Equals, NotEquals, PrimitiveType, Severity
+from ..result import Result
 
 
 def _parametrize(comparison, *value_and_result):

--- a/atef/tests/test_comparison_device.py
+++ b/atef/tests/test_comparison_device.py
@@ -6,12 +6,13 @@ import ophyd.sim
 import pytest
 
 from .. import cache, check, reduce, util
-from ..check import Comparison, Result, Severity
+from ..check import Comparison, Severity
 from ..config import (ConfigurationFile, ConfigurationGroup,
                       DeviceConfiguration, PreparedDeviceConfiguration,
                       PreparedFile, PreparedPVConfiguration, PVConfiguration,
                       get_result_from_comparison)
 from ..exceptions import PreparedComparisonException
+from ..result import Result
 
 
 async def check_device(

--- a/atef/tests/test_comparison_tools.py
+++ b/atef/tests/test_comparison_tools.py
@@ -7,8 +7,9 @@ import pytest
 
 from .. import check, config, tools
 from ..cache import DataCache
-from ..check import Result, Severity
 from ..config import Comparison, PreparedToolConfiguration, ToolConfiguration
+from ..enums import Severity
+from ..result import Result
 
 
 async def check_tool(

--- a/atef/tests/test_configuration.py
+++ b/atef/tests/test_configuration.py
@@ -1,0 +1,15 @@
+import asyncio
+
+import pytest
+
+from atef.config import ConfigurationFile, PreparedFile
+
+from .conftest import PASSIVE_CONFIG_PATHS
+
+
+@pytest.mark.parametrize('config_path', PASSIVE_CONFIG_PATHS)
+def test_prepared_config(config_path):
+    # Quick smoke test to make sure we can prepare our configs
+    config_file = ConfigurationFile.from_filename(config_path)
+    prepared_file = PreparedFile.from_config(config_file)
+    asyncio.run(prepared_file.compare())

--- a/atef/tests/test_configuration.py
+++ b/atef/tests/test_configuration.py
@@ -1,15 +1,11 @@
-import asyncio
-
 import pytest
 
 from atef.config import ConfigurationFile, PreparedFile
 
-from .conftest import PASSIVE_CONFIG_PATHS
 
-
-@pytest.mark.parametrize('config_path', PASSIVE_CONFIG_PATHS)
-def test_prepared_config(config_path):
+@pytest.mark.asyncio
+async def test_prepared_config(passive_config_path):
     # Quick smoke test to make sure we can prepare our configs
-    config_file = ConfigurationFile.from_filename(config_path)
+    config_file = ConfigurationFile.from_filename(passive_config_path)
     prepared_file = PreparedFile.from_config(config_file)
-    asyncio.run(prepared_file.compare())
+    await prepared_file.compare()

--- a/atef/tests/test_procedure.py
+++ b/atef/tests/test_procedure.py
@@ -1,8 +1,8 @@
 import pytest
 
-from atef.check import Result
 from atef.enums import Severity
 from atef.procedure import DescriptionStep, ProcedureStep
+from atef.result import Result
 
 pass_result = Result()
 fail_result = Result(severity=Severity.error)

--- a/atef/tests/test_procedure.py
+++ b/atef/tests/test_procedure.py
@@ -1,5 +1,4 @@
 import asyncio
-import pathlib
 
 import pytest
 
@@ -7,6 +6,7 @@ from atef.enums import Severity
 from atef.procedure import (DescriptionStep, PreparedProcedureFile,
                             PreparedProcedureStep, ProcedureFile)
 from atef.result import Result
+from atef.tests.conftest import ACTIVE_CONFIG_PATHS
 
 pass_result = Result()
 fail_result = Result(severity=Severity.error)
@@ -67,20 +67,10 @@ def test_description_step_results():
     assert prep_desc_step.step_result == pass_result
 
 
-@pytest.fixture
-def active_test_config() -> pathlib.Path:
-    filename = 'active_test.json'
-    test_config_path = pathlib.Path(__file__).parent / 'configs'
-    return test_config_path / filename
-
-
-def test_prepared_procedure(active_test_config):
-    procedure_file = ProcedureFile.from_filename(filename=active_test_config)
+@pytest.mark.parametrize('active_config', ACTIVE_CONFIG_PATHS)
+def test_prepared_procedure(active_config):
+    procedure_file = ProcedureFile.from_filename(filename=active_config)
     # monkeypatch passive step to have
-    # TODO make this more general for future sample active checkouts
-    procedure_file.root.steps[1].filepath = (
-        active_test_config.parent / 'all_fields.json'
-    )
     # simple smoke test
     ppf = PreparedProcedureFile.from_origin(file=procedure_file)
     asyncio.run(ppf.run())

--- a/atef/tests/test_procedure.py
+++ b/atef/tests/test_procedure.py
@@ -78,7 +78,9 @@ def test_prepared_procedure(active_test_config):
     procedure_file = ProcedureFile.from_filename(filename=active_test_config)
     # monkeypatch passive step to have
     # TODO make this more general for future sample active checkouts
-    procedure_file.root.steps[1].filepath = active_test_config.parent / 'all_fields.json'
+    procedure_file.root.steps[1].filepath = (
+        active_test_config.parent / 'all_fields.json'
+    )
     # simple smoke test
     ppf = PreparedProcedureFile.from_origin(file=procedure_file)
     asyncio.run(ppf.run())

--- a/atef/tests/test_procedure.py
+++ b/atef/tests/test_procedure.py
@@ -1,12 +1,9 @@
-import asyncio
-
 import pytest
 
 from atef.enums import Severity
 from atef.procedure import (DescriptionStep, PreparedProcedureFile,
                             PreparedProcedureStep, ProcedureFile)
 from atef.result import Result
-from atef.tests.conftest import ACTIVE_CONFIG_PATHS
 
 pass_result = Result()
 fail_result = Result(severity=Severity.error)
@@ -58,19 +55,19 @@ def test_procedure_step_results(
     assert (expected.reason or '') in (prep_pstep.result.reason or '')
 
 
-def test_description_step_results():
+@pytest.mark.asyncio
+async def test_description_step_results():
     """ Pass if DescriptionStep step_result always passes """
     desc_step = DescriptionStep()
     prep_desc_step = PreparedProcedureStep.from_origin(desc_step)
-    asyncio.run(prep_desc_step.run())
+    await prep_desc_step.run()
     # step phase of the description step always passes
     assert prep_desc_step.step_result == pass_result
 
 
-@pytest.mark.parametrize('active_config', ACTIVE_CONFIG_PATHS)
-def test_prepared_procedure(active_config):
-    procedure_file = ProcedureFile.from_filename(filename=active_config)
-    # monkeypatch passive step to have
+@pytest.mark.asyncio
+async def test_prepared_procedure(active_config_path):
+    procedure_file = ProcedureFile.from_filename(filename=active_config_path)
     # simple smoke test
     ppf = PreparedProcedureFile.from_origin(file=procedure_file)
-    asyncio.run(ppf.run())
+    await ppf.run()

--- a/atef/tools.py
+++ b/atef/tools.py
@@ -9,8 +9,9 @@ from dataclasses import dataclass, field
 from typing import Any, ClassVar, Dict, List, Mapping, Sequence, TypeVar, Union
 
 from . import serialization
-from .check import Result, Severity
+from .check import Severity
 from .exceptions import ToolDependencyMissingException
+from .result import Result
 
 T = TypeVar("T", bound="Tool")
 

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -28,8 +28,8 @@ import typhos.display
 from qtpy import QtCore, QtWidgets
 from qtpy.QtCore import Qt
 
-from atef.check import Result
 from atef.config import ConfigurationFile
+from atef.result import Result, incomplete_result
 from atef.widgets.config.data_base import DataWidget
 from atef.widgets.config.run_base import create_tree_items
 from atef.widgets.config.utils import ConfigTreeModel, TreeItem
@@ -37,8 +37,7 @@ from atef.widgets.core import DesignerDisplay
 
 from ...procedure import (DescriptionStep, DisplayOptions, PassiveStep,
                           PlanOptions, PlanStep, ProcedureGroup, ProcedureStep,
-                          PydmDisplayStep, TyphosDisplayStep,
-                          incomplete_result)
+                          PydmDisplayStep, TyphosDisplayStep)
 
 # TODO:  CodeStep, ConfigurationCheckStep,
 

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -32,7 +32,9 @@ from atef.check import (AnyComparison, AnyValue, Comparison, Equals, Greater,
 from atef.config import (Configuration, ConfigurationGroup,
                          DeviceConfiguration, PVConfiguration,
                          ToolConfiguration)
-from atef.procedure import (DescriptionStep, PassiveStep, ProcedureGroup,
+from atef.procedure import (DescriptionStep, PassiveStep,
+                            PreparedDescriptionStep, PreparedPassiveStep,
+                            PreparedProcedureStep, ProcedureGroup,
                             ProcedureStep)
 from atef.tools import Ping, PingResult, Tool, ToolResult
 from atef.widgets.config.data_active import (GeneralProcedureWidget,
@@ -1675,9 +1677,9 @@ class RunStepPage(DesignerDisplay, PageWidget):
     run_check_placeholder: QWidget
     run_check: RunCheck
 
-    run_widget_map: ClassVar[Dict[ProcedureStep, DataWidget]] = {
-        DescriptionStep: DescriptionRunWidget,
-        PassiveStep: PassiveRunWidget
+    run_widget_map: ClassVar[Dict[PreparedProcedureStep, DataWidget]] = {
+        PreparedDescriptionStep: DescriptionRunWidget,
+        PreparedPassiveStep: PassiveRunWidget
     }
 
     def __init__(self, *args, data, **kwargs):

--- a/atef/widgets/config/run_active.py
+++ b/atef/widgets/config/run_active.py
@@ -1,6 +1,7 @@
 """
 Widgets for config gui's active-checkout run mode.
-Widgets should map onto edit widgets from atef.widgets.config.data_active
+Widgets should map onto edit widgets from atef.widgets.config.data_active, and
+take a subclass of PreparedProcedureStep as their ``data``.
 """
 
 import asyncio
@@ -11,7 +12,7 @@ import qtawesome
 from qtpy import QtWidgets
 
 from atef.config import ConfigurationFile, PreparedFile, run_passive_step
-from atef.procedure import DescriptionStep, PassiveStep
+from atef.procedure import PreparedDescriptionStep, PreparedPassiveStep
 from atef.widgets.config.data_base import DataWidget
 from atef.widgets.config.run_base import create_tree_items
 from atef.widgets.config.utils import ConfigTreeModel, TreeItem
@@ -34,13 +35,13 @@ class PassiveRunWidget(DesignerDisplay, DataWidget):
     tree_view: QtWidgets.QTreeView
     refresh_button: QtWidgets.QPushButton
 
-    def __init__(self, *args, data: PassiveStep, **kwargs):
+    def __init__(self, *args, data: PreparedPassiveStep, **kwargs):
         super().__init__(*args, data=data, **kwargs)
-        if not self.bridge.filepath.get():
+        if not self.bridge.origin.get().filepath:
             logger.warning('no passive step to run')
             return
 
-        fp = pathlib.Path(self.bridge.filepath.get())
+        fp = pathlib.Path(self.bridge.origin.get().filepath)
         if not fp.is_file():
             return
         self.config_file = ConfigurationFile.from_filename(fp)
@@ -90,10 +91,10 @@ class DescriptionRunWidget(DesignerDisplay, DataWidget):
     title_label: QtWidgets.QLabel
     desc_label: QtWidgets.QLabel
 
-    def __init__(self, *args, data: DescriptionStep, **kwargs):
+    def __init__(self, *args, data: PreparedDescriptionStep, **kwargs):
         super().__init__(*args, data=data, **kwargs)
         self._setup_ui()
 
     def _setup_ui(self) -> None:
-        self.title_label.setText(self.bridge.name.get())
-        self.desc_label.setText(self.bridge.description.get())
+        self.title_label.setText(self.bridge.origin.get().name)
+        self.desc_label.setText(self.bridge.origin.get().description)

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -22,7 +22,7 @@ from atef.config import (AnyPreparedConfiguration, Configuration,
 from atef.enums import Severity
 from atef.procedure import (PreparedProcedureFile, PreparedProcedureGroup,
                             PreparedProcedureStep, ProcedureFile,
-                            ProcedureGroup, ProcedureStep, walk_steps)
+                            ProcedureStep, walk_steps)
 from atef.result import Result, combine_results
 from atef.widgets.config.utils import TreeItem
 from atef.widgets.core import DesignerDisplay
@@ -117,7 +117,7 @@ def disable_widget(widget: QWidget) -> QWidget:
     return widget
 
 
-def infer_step_type(config: Union[PreparedComparison, ProcedureStep]) -> str:
+def infer_step_type(config: Union[PreparedComparison, PreparedProcedureStep]) -> str:
     # TODO: find a better way to decide the step type
     if hasattr(config, 'compare'):
         return 'passive'
@@ -169,8 +169,29 @@ def get_relevant_configs_comps(
 
 def get_prepared_step(
     prepared_file: PreparedProcedureFile,
-    step: Union[ProcedureStep, ProcedureGroup]
-) -> List[Union[PreparedProcedureStep, PreparedProcedureGroup]]:
+    step: ProcedureStep
+) -> List[PreparedProcedureStep]:
+    """
+    Gather all PreparedProcedureStep dataclasses the correspond to the original
+    ProcedureStep.
+
+    Only relevant for active checkouts.
+
+    Parameters
+    ----------
+    prepared_file : PreparedProcedureFile
+        the PreparedProcedureFile to search through
+    step : Union[ProcedureStep, ProcedureGroup]
+        the step to match
+
+    Returns
+    -------
+    List[Union[PreparedProcedureStep, PreparedProcedureGroup]]
+        the PreparedProcedureSteps related to ``step``
+    """
+    # As of the writing of this docstring, this helper is only expected to return
+    # lists of length 1.  However in order to match the passive checkout workflow,
+    # we still return a list of relevant steps.
     matched_steps = []
     for pstep in walk_steps(prepared_file.root):
         if pstep.origin == step:

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -15,13 +15,14 @@ from qtpy.QtWidgets import (QDialogButtonBox, QLabel, QLayout, QLineEdit,
                             QMenu, QPushButton, QSpacerItem, QStyle,
                             QToolButton, QVBoxLayout, QWidget, QWidgetAction)
 
-from atef.check import Comparison, Result
+from atef.check import Comparison
 from atef.config import (AnyPreparedConfiguration, Configuration,
                          ConfigurationFile, PreparedComparison,
                          PreparedConfiguration, PreparedFile)
 from atef.enums import Severity
 from atef.procedure import ProcedureFile, ProcedureStep
-from atef.widgets.config.utils import TreeItem, combine_results
+from atef.result import Result, combine_results
+from atef.widgets.config.utils import TreeItem
 from atef.widgets.core import DesignerDisplay
 
 # avoid circular imports

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -157,11 +157,11 @@ def get_relevant_configs_comps(
     matched_c = []
 
     for config in prepared_file.walk_groups():
-        if config.config == original_c:
+        if config.config is original_c:
             matched_c.append(config)
 
     for comp in prepared_file.walk_comparisons():
-        if comp.comparison == original_c:
+        if comp.comparison is original_c:
             matched_c.append(comp)
 
     return matched_c
@@ -194,7 +194,7 @@ def get_prepared_step(
     # we still return a list of relevant steps.
     matched_steps = []
     for pstep in walk_steps(prepared_file.root):
-        if pstep.origin == step:
+        if pstep.origin is step:
             matched_steps.append(pstep)
     return matched_steps
 

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -15,14 +15,14 @@ from qtpy.QtGui import (QBrush, QClipboard, QColor, QGuiApplication, QPainter,
 from qtpy.QtWidgets import QCheckBox, QInputDialog, QLineEdit, QMenu, QWidget
 
 from atef import util
-from atef.check import Comparison, Equals, Range, Result
+from atef.check import Comparison, Equals, Range
 from atef.config import (Configuration, DeviceConfiguration,
                          PreparedComparison, PreparedConfiguration,
-                         PreparedFile, PVConfiguration, ToolConfiguration,
-                         incomplete_result)
+                         PreparedFile, PVConfiguration, ToolConfiguration)
 from atef.enums import Severity
 from atef.procedure import ProcedureFile, ProcedureStep, walk_steps
 from atef.qt_helpers import QDataclassList, QDataclassValue
+from atef.result import combine_results, incomplete_result
 from atef.tools import Ping
 from atef.widgets.archive_viewer import get_archive_viewer
 from atef.widgets.core import DesignerDisplay
@@ -904,18 +904,6 @@ class MultiInputDialog(QtWidgets.QDialog):
             info[unspaced_key] = value or self.init_values[unspaced_key]
 
         return info
-
-
-def combine_results(results: List[Result]) -> Result:
-    """
-    Combines results into a single result.
-
-    Takes the highest severity, and currently all the reasons
-    """
-    severity = util.get_maximum_severity([r.severity for r in results])
-    reason = str([r.reason for r in results]) or ''
-
-    return Result(severity=severity, reason=reason)
 
 
 def clear_results(config_file: PreparedFile | ProcedureFile) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- Refactors the `Result` fields and and `.run()` methods for active checkout dataclasses into `Prepared*` procedure step dataclasses
- Moves the `Result` dataclass and related helpers into its own submodule.  Refactors accordingly
- Updates window and RunTree logic to reflect these changes
- Adds timestamp field to `Result` dataclass.  This field does not need to be specified at instantiation, and will be auto-filled.  This will also be ignored during comparisons between `Result` objects

## Motivation and Context
After some slack conversations, we decided that it was best to keep any transient information separated from the checkout specification.  This makes active checkouts mirror the structure of passive checkouts.  
It is expected that there will be information worth holding onto while running the checkout.  The first case of this is obviously the `Result` object, but as more steps are added this list may expand (sub-step results, images/metadata, etc)

## How Has This Been Tested?
Added a quick smoke test, I should add more

## Where Has This Been Documented?
Docstrings, this PR
