### PR TITLE
ENH: add a Set-Value active checkout step

### DIFF
--- a/atef/cache.py
+++ b/atef/cache.py
@@ -21,20 +21,20 @@ _CacheSignalType = TypeVar("_CacheSignalType", bound=ophyd.Signal)
 
 
 logger = logging.getLogger(__name__)
-_signal_cache: Optional[_SignalCache[ophyd.EpicsSignalRO]] = None
+_signal_cache: Optional[_SignalCache[ophyd.EpicsSignal]] = None
 
 
-def get_signal_cache() -> _SignalCache[ophyd.EpicsSignalRO]:
+def get_signal_cache() -> _SignalCache[ophyd.EpicsSignal]:
     """Get the global EpicsSignal cache."""
     global _signal_cache
     if _signal_cache is None:
-        _signal_cache = _SignalCache[ophyd.EpicsSignalRO](ophyd.EpicsSignalRO)
+        _signal_cache = _SignalCache[ophyd.EpicsSignal](ophyd.EpicsSignal)
     return _signal_cache
 
 
 @dataclass
 class _SignalCache(Mapping[str, _CacheSignalType]):
-    signal_type_cls: Type[ophyd.EpicsSignalRO]
+    signal_type_cls: Type[ophyd.EpicsSignal]
     pv_to_signal: Dict[str, _CacheSignalType] = field(default_factory=dict)
 
     def __getitem__(self, pv: str) -> _CacheSignalType:
@@ -115,7 +115,7 @@ def _freeze(data):
 @dataclass
 class DataCache:
     signal_data: Dict[ophyd.Signal, Dict[DataKey, Any]] = field(default_factory=dict)
-    signals: _SignalCache[ophyd.EpicsSignalRO] = field(
+    signals: _SignalCache[ophyd.EpicsSignal] = field(
         default_factory=get_signal_cache
     )
     tool_data: Dict[ToolKey, Any] = field(

--- a/atef/check.py
+++ b/atef/check.py
@@ -423,7 +423,7 @@ class Greater(Comparison):
     value: Number = 0
 
     def describe(self) -> str:
-        return f"> {self.value}"
+        return f"> {self.value}: {self.description}"
 
     def _compare(self, value: Number) -> bool:
         return value > self.value
@@ -435,7 +435,7 @@ class GreaterOrEqual(Comparison):
     value: Number = 0
 
     def describe(self) -> str:
-        return f">= {self.value}"
+        return f">= {self.value}: {self.description}"
 
     def _compare(self, value: Number) -> bool:
         return value >= self.value
@@ -447,7 +447,7 @@ class Less(Comparison):
     value: Number = 0
 
     def describe(self) -> str:
-        return f"< {self.value}"
+        return f"< {self.value}: {self.description}"
 
     def _compare(self, value: Number) -> bool:
         return value < self.value
@@ -459,7 +459,7 @@ class LessOrEqual(Comparison):
     value: Number = 0
 
     def describe(self) -> str:
-        return f"<= {self.value}"
+        return f"<= {self.value}: {self.description}"
 
     def _compare(self, value: Number) -> bool:
         return value <= self.value

--- a/atef/config.py
+++ b/atef/config.py
@@ -1238,6 +1238,49 @@ class PreparedSignalComparison(PreparedComparison):
             parent=parent,
         )
 
+    @classmethod
+    def from_signal(
+        cls,
+        signal: ophyd.Signal,
+        comparison: Comparison,
+        name: Optional[str] = None,
+        parent: Optional[PreparedPVConfiguration] = None,
+        cache: Optional[DataCache] = None,
+    ) -> PreparedSignalComparison:
+        """
+        Create a PreparedSignalComparison from a signal directly
+
+        Parameters
+        ----------
+        signal : ophyd.Signal
+            The signal to compare
+        comparison : Comparison
+            The comparison instance to run on the PV.
+        name : str, optional
+            The name of this comparison.
+        parent : PreparedPVConfiguration, optional
+            The parent configuration, if available.
+        cache : DataCache, optional
+            The data cache instance, if available.  If unspecified, a new data
+            cache will be instantiated.
+
+        Returns
+        -------
+        PreparedSignalComparison
+        """
+        if cache is None:
+            cache = DataCache()
+
+        return cls(
+            identifier=signal.name,
+            device=None,
+            signal=signal,
+            comparison=comparison,
+            name=name,
+            cache=cache,
+            parent=parent,
+        )
+
 
 @dataclass
 class PreparedToolComparison(PreparedComparison):

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -152,7 +152,7 @@ class Target:
     #: EPICS PV
     pv: Optional[str] = None
 
-    def to_signal(self) -> ophyd.EpicsSignal:
+    def to_signal(self) -> Optional[ophyd.EpicsSignal]:
         """
         Return the signal described by this Target.  First attempts to use the
         device + attr information to look up the signal in happi, falling back
@@ -186,7 +186,7 @@ class ValueToTarget(Target):
     value: Optional[PrimitiveType] = None
 
     # ophyd.Signal.set() parameters
-    #: connection timeout
+    #: write timeout
     timeout: Optional[float] = None
     #: settle time
     settle_time: Optional[float] = None
@@ -672,8 +672,7 @@ class PreparedSetValueStep(PreparedProcedureStep):
 
     def walk_comparisons(self) -> Generator[PreparedComparison, None, None]:
         """ Yields PreparedComparisons in this ProcedureStep """
-        for prep_comp in self.prepared_criteria:
-            yield prep_comp
+        yield from self.prepared_criteria
 
     async def _run(self) -> Result:
         """
@@ -850,7 +849,7 @@ class PreparedValueToSignal:
 
         pvts = cls(
             name=origin.name,
-            signal=origin.to_signal(),
+            signal=signal,
             value=origin.value,
             origin=origin,
         )

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -770,8 +770,8 @@ class PreparedSetValueStep(PreparedProcedureStep):
             signal = comp_to_target.to_signal()
             comp = comp_to_target.comparison
             try:
-                prep_comp = PreparedSignalComparison.from_pvname(
-                    pvname=signal.pvname, comparison=comp
+                prep_comp = PreparedSignalComparison.from_signal(
+                    signal=signal, comparison=comp
                 )
                 prep_step.prepared_criteria.append(prep_comp)
             except Exception as ex:

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -37,7 +37,7 @@ from atef.config import (ConfigurationFile, PreparedComparison, PreparedFile,
 from atef.enums import GroupResultMode, Severity
 from atef.exceptions import PreparedComparisonException
 from atef.result import Result, _summarize_result_severity, incomplete_result
-from atef.type_hints import AnyPath, PrimitiveType
+from atef.type_hints import AnyPath, Number, PrimitiveType
 from atef.yaml_support import init_yaml_support
 
 from . import serialization
@@ -193,9 +193,9 @@ class ValueToTarget(Target):
 
     # ophyd.Signal.set() parameters
     #: write timeout
-    timeout: Optional[float] = None
+    timeout: Optional[Number] = None
     #: settle time
-    settle_time: Optional[float] = None
+    settle_time: Optional[Number] = None
 
 
 @dataclass

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -154,12 +154,18 @@ class Target:
 
     def to_signal(self) -> ophyd.EpicsSignal:
         """ attempt to use happi first, failing that use stored PV info"""
-        if self.device and self.attr:
-            device = util.get_happi_device_by_name(self.device)
-            signal = getattr(device, self.attr)
-        elif self.pv:
-            signal = ophyd.EpicsSignal(self.pv)
-        else:
+        try:
+            if self.device and self.attr:
+                device = util.get_happi_device_by_name(self.device)
+                signal = getattr(device, self.attr)
+            elif self.pv:
+                signal = ophyd.EpicsSignal(self.pv)
+            else:
+                logger.debug('unable to create signal: insufficient information'
+                             'to specify signal')
+                return
+        except Exception as ex:
+            logger.debug(f'unable to create signal: ({ex})')
             return
 
         return signal

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -31,7 +31,7 @@ from bluesky import RunEngine
 
 from atef import util
 from atef.check import Comparison
-from atef.config import (ConfigurationFile, PreparedFile,
+from atef.config import (ConfigurationFile, PreparedComparison, PreparedFile,
                          PreparedSignalComparison, run_passive_step)
 from atef.enums import GroupResultMode, Severity
 from atef.exceptions import PreparedComparisonException
@@ -630,6 +630,11 @@ class PreparedSetValueStep(PreparedProcedureStep):
     prepared_criteria: Optional[List[PreparedSignalComparison]] = field(
         default_factory=list
     )
+
+    def walk_comparisons(self) -> Generator[PreparedComparison, None, None]:
+        """ Yields PreparedComparisons in this ProcedureStep """
+        for prep_comp in self.prepared_criteria:
+            yield prep_comp
 
     async def _run(self) -> Result:
         """

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -769,6 +769,9 @@ class PreparedValueToSignal:
         cls,
         origin: ValueToTarget
     ) -> PreparedValueToSignal:
+        signal = origin.to_signal()
+        if signal is None:
+            raise ValueError('Target specification invalid')
         pvts = cls(
             name=origin.name,
             signal=origin.to_signal(),

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -506,7 +506,7 @@ class PreparedProcedureStep:
                 combined_result=Result(
                     severity=Severity.internal_error,
                     reason=(
-                        f"Failed to instantiate step: {ex}."
+                        f"Failed to instantiate step: {ex}. "
                         f"Step is: {step.name} ({step.description or ''!r})"
                     )
                 )
@@ -728,7 +728,7 @@ class PreparedSetValueStep(PreparedProcedureStep):
             except Exception as ex:
                 prep_comp_exc = PreparedComparisonException(
                     exception=ex,
-                    identifier=signal.pvname,
+                    identifier=getattr(signal, 'pvname', ''),
                     message='Failed to initialize comparison',
                     comparison=comp,
                     name=comp.name
@@ -771,7 +771,8 @@ class PreparedValueToSignal:
     ) -> PreparedValueToSignal:
         signal = origin.to_signal()
         if signal is None:
-            raise ValueError('Target specification invalid')
+            raise ValueError(f'Target specification invalid: {origin}')
+
         pvts = cls(
             name=origin.name,
             signal=origin.to_signal(),

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -176,7 +176,7 @@ class Target:
                     signal_cache = get_signal_cache()
                 signal = signal_cache[self.pv]
             else:
-                logger.debug('unable to create signal, insufficient information'
+                logger.debug('unable to create signal, insufficient information '
                              'to specify signal')
                 return
         except Exception as ex:

--- a/atef/qt_helpers.py
+++ b/atef/qt_helpers.py
@@ -93,7 +93,10 @@ class QDataclassBridge(QObject):
             dtype = args[0]
         elif origin is Union and (type(None) in args):
             # Optional, strip Union and recurse
-            self.set_field_from_data(name, args[0], data)
+            if len(args[:-1]) > 1:
+                self.set_field_from_data(name, Union[args[:-1]], data)  # noqa
+            else:
+                self.set_field_from_data(name, args[0], data)
             return
         else:
             # some complex Union? e.g. Union[str, int, bool, float]

--- a/atef/qt_helpers.py
+++ b/atef/qt_helpers.py
@@ -187,7 +187,6 @@ class QDataclassValue(QDataclassElem):
         value : any primitive type
         """
         setattr(self.data, self.attr, value)
-        print(f'{type(self)}: {value} - {type(self.get())}')
         self.changed_value.emit(self.get())
         self.updated.emit()
 

--- a/atef/qt_helpers.py
+++ b/atef/qt_helpers.py
@@ -33,7 +33,7 @@ class QDataclassBridge(QObject):
 
     Would allow you to access:
     bridge.field.put(3)
-    bridge.field.value_changed.connect(my_slot)
+    bridge.field.changed_value.connect(my_slot)
     bridge.others.append(OtherClass(4))
 
     This does not recursively dive down the tree of subdataclasses.

--- a/atef/tests/configs/active_test.json
+++ b/atef/tests/configs/active_test.json
@@ -42,7 +42,29 @@
               "value": 55.0
             }
           ],
-          "success_criteria": [],
+          "success_criteria": [
+            {
+              "name": null,
+              "device": null,
+              "attr": null,
+              "pv": null,
+              "comparison": {
+                "Equals": {
+                  "name": "equal_check",
+                  "description": "equal_check_desc",
+                  "invert": false,
+                  "reduce_period": null,
+                  "reduce_method": "average",
+                  "string": null,
+                  "severity_on_failure": 2,
+                  "if_disconnected": 2,
+                  "value": 0.0,
+                  "rtol": null,
+                  "atol": null
+                }
+              }
+            }
+          ],
           "continue_on_fail": false,
           "require_action_success": true
         }

--- a/atef/tests/configs/active_test.json
+++ b/atef/tests/configs/active_test.json
@@ -25,6 +25,19 @@
           "step_success_required": true,
           "filepath": "."
         }
+      },
+      {
+        "SetValueStep": {
+          "name": "set_value_title",
+          "description": null,
+          "parent": null,
+          "verify_required": true,
+          "step_success_required": true,
+          "actions": [],
+          "success_criteria": [],
+          "continue_on_fail": false,
+          "require_action_success": true
+        }
       }
     ]
   }

--- a/atef/tests/configs/active_test.json
+++ b/atef/tests/configs/active_test.json
@@ -38,8 +38,8 @@
               "name": null,
               "device": null,
               "attr": null,
-              "pv": "AT2L0:XTES:MMS:01",
-              "value": 55.0
+              "pv": "MY:PREFIX:dt",
+              "value": 1.0
             }
           ],
           "success_criteria": [
@@ -47,7 +47,7 @@
               "name": null,
               "device": null,
               "attr": null,
-              "pv": null,
+              "pv": "MY:PREFIX:dt",
               "comparison": {
                 "Equals": {
                   "name": "equal_check",
@@ -58,7 +58,7 @@
                   "string": null,
                   "severity_on_failure": 2,
                   "if_disconnected": 2,
-                  "value": 0.0,
+                  "value": 1.0,
                   "rtol": null,
                   "atol": null
                 }

--- a/atef/tests/configs/active_test.json
+++ b/atef/tests/configs/active_test.json
@@ -33,7 +33,15 @@
           "parent": null,
           "verify_required": true,
           "step_success_required": true,
-          "actions": [],
+          "actions": [
+            {
+              "name": null,
+              "device": null,
+              "attr": null,
+              "pv": "AT2L0:XTES:MMS:01",
+              "value": 55.0
+            }
+          ],
           "success_criteria": [],
           "continue_on_fail": false,
           "require_action_success": true

--- a/atef/tests/configs/active_test.json
+++ b/atef/tests/configs/active_test.json
@@ -39,7 +39,9 @@
               "device": null,
               "attr": null,
               "pv": "MY:PREFIX:dt",
-              "value": 1.0
+              "value": 1.0,
+              "timeout": 20.0,
+              "settle_time": 5.0
             }
           ],
           "success_criteria": [

--- a/atef/tests/configs/active_test.json
+++ b/atef/tests/configs/active_test.json
@@ -29,13 +29,13 @@
       {
         "SetValueStep": {
           "name": "set_value_title",
-          "description": null,
+          "description": "set_value_desc",
           "parent": null,
           "verify_required": true,
           "step_success_required": true,
           "actions": [
             {
-              "name": null,
+              "name": "set to 1",
               "device": null,
               "attr": null,
               "pv": "MY:PREFIX:dt",
@@ -53,7 +53,7 @@
               "comparison": {
                 "Equals": {
                   "name": "equal_check",
-                  "description": "equal_check_desc",
+                  "description": "a simple verify",
                   "invert": false,
                   "reduce_period": null,
                   "reduce_method": "average",
@@ -67,7 +67,7 @@
               }
             }
           ],
-          "continue_on_fail": false,
+          "halt_on_fail": true,
           "require_action_success": true
         }
       }

--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -210,6 +210,7 @@ def test_config_window_save_load(qtbot: QtBot, tmp_path: pathlib.Path):
         assert source_lines == dest_lines
 
 
+@pytest.mark.skip
 def test_edit_run_toggle(qtbot: QtBot, test_configs: list[os.PathLike]):
     """ Smoke test run-mode for all sample configs """
     from ..widgets.config.window import Window

--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -218,7 +218,7 @@ def test_config_window_save_load(qtbot: QtBot, tmp_path: pathlib.Path):
         assert source_lines == dest_lines
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test doesn't work in Github Actions.")
+# @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test doesn't work in Github Actions.")
 @pytest.mark.parametrize('config', [0, 1, 2], indirect=True)
 def test_edit_run_toggle(qtbot: QtBot, config: os.PathLike):
     """ Smoke test run-mode for all sample configs """

--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -28,9 +28,6 @@ def config(request, test_configs):
     return test_configs[i]
 
 
-IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
-
-
 parametrized_groups = pytest.mark.parametrize(
     "group",
     [
@@ -218,7 +215,6 @@ def test_config_window_save_load(qtbot: QtBot, tmp_path: pathlib.Path):
         assert source_lines == dest_lines
 
 
-# @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test doesn't work in Github Actions.")
 @pytest.mark.parametrize('config', [0, 1, 2], indirect=True)
 def test_edit_run_toggle(qtbot: QtBot, config: os.PathLike):
     """ Smoke test run-mode for all sample configs """

--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -215,7 +215,7 @@ def test_config_window_save_load(qtbot: QtBot, tmp_path: pathlib.Path):
         assert source_lines == dest_lines
 
 
-@pytest.mark.parametrize('config', [0, 1, 2], indirect=True)
+@pytest.mark.parametrize('config', [1, 2], indirect=True)
 def test_edit_run_toggle(qtbot: QtBot, config: os.PathLike):
     """ Smoke test run-mode for all sample configs """
     window = Window(show_welcome=False)

--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -28,6 +28,9 @@ def config(request, test_configs):
     return test_configs[i]
 
 
+IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+
+
 parametrized_groups = pytest.mark.parametrize(
     "group",
     [
@@ -215,7 +218,7 @@ def test_config_window_save_load(qtbot: QtBot, tmp_path: pathlib.Path):
         assert source_lines == dest_lines
 
 
-@pytest.mark.skip(reason='inconsistent segfaults on CI, passes locally, (04/17/23)')
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test doesn't work in Github Actions.")
 @pytest.mark.parametrize('config', [0, 1, 2], indirect=True)
 def test_edit_run_toggle(qtbot: QtBot, config: os.PathLike):
     """ Smoke test run-mode for all sample configs """

--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -215,7 +215,8 @@ def test_config_window_save_load(qtbot: QtBot, tmp_path: pathlib.Path):
         assert source_lines == dest_lines
 
 
-@pytest.mark.parametrize('config', [1, 2], indirect=True)
+@pytest.mark.skip(reason='inconsistent segfaults on CI, passes locally, (04/17/23)')
+@pytest.mark.parametrize('config', [0, 1, 2], indirect=True)
 def test_edit_run_toggle(qtbot: QtBot, config: os.PathLike):
     """ Smoke test run-mode for all sample configs """
     window = Window(show_welcome=False)

--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -9,6 +9,7 @@ from pytestqt.qtbot import QtBot
 
 from ..procedure import (DescriptionStep, DisplayOptions, ProcedureGroup,
                          PydmDisplayStep, TyphosDisplayStep)
+from ..widgets.config.window import Window
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,12 @@ def test_configs() -> list[pathlib.Path]:
     test_config_path = pathlib.Path(__file__).parent / 'configs'
     config_paths = [test_config_path / fn for fn in filenames]
     return config_paths
+
+
+@pytest.fixture
+def config(request, test_configs):
+    i = request.param
+    return test_configs[i]
 
 
 parametrized_groups = pytest.mark.parametrize(
@@ -184,7 +191,6 @@ def test_config_window_basic(qtbot: QtBot):
     """
     Pass if the config gui can open
     """
-    from ..widgets.config.window import Window
     window = Window(show_welcome=False)
     qtbot.addWidget(window)
 
@@ -193,7 +199,6 @@ def test_config_window_save_load(qtbot: QtBot, tmp_path: pathlib.Path):
     """
     Pass if the config gui can open a file and save the same file back
     """
-    from ..widgets.config.window import Window
     window = Window(show_welcome=False)
     qtbot.addWidget(window)
     test_configs = pathlib.Path(__file__).parent / 'configs'
@@ -210,14 +215,12 @@ def test_config_window_save_load(qtbot: QtBot, tmp_path: pathlib.Path):
         assert source_lines == dest_lines
 
 
-@pytest.mark.skip
-def test_edit_run_toggle(qtbot: QtBot, test_configs: list[os.PathLike]):
+@pytest.mark.parametrize('config', [0, 1, 2], indirect=True)
+def test_edit_run_toggle(qtbot: QtBot, config: os.PathLike):
     """ Smoke test run-mode for all sample configs """
-    from ..widgets.config.window import Window
     window = Window(show_welcome=False)
+    window.open_file(filename=str(config))
+    toggle = window.tab_widget.widget(0).toggle
+    toggle.setChecked(True)
+    toggle.setChecked(False)
     qtbot.addWidget(window)
-    for idx, filename in enumerate(test_configs):
-        window.open_file(filename=str(filename))
-        toggle = window.tab_widget.widget(idx).toggle
-        toggle.setChecked(True)
-        toggle.setChecked(False)

--- a/atef/ui/action_row_run_widget.ui
+++ b/atef/ui/action_row_run_widget.ui
@@ -36,12 +36,6 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>50</width>
-       <height>0</height>
-      </size>
-     </property>
      <property name="toolTip">
       <string/>
      </property>

--- a/atef/ui/action_row_run_widget.ui
+++ b/atef/ui/action_row_run_widget.ui
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>598</width>
+    <height>45</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QLabel" name="name_label">
+     <property name="text">
+      <string>action_name</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="target_label">
+     <property name="text">
+      <string>target</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMDrawingLine" name="arrow">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>50</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="arrowEndPoint" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="arrowStartPoint" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="value_label">
+     <property name="text">
+      <string>value</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="status_label_placeholder" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>25</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMDrawingLine</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/action_row_widget.ui
+++ b/atef/ui/action_row_widget.ui
@@ -76,30 +76,34 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="value_input_placeholder" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>50</width>
-       <height>0</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="value_button_box">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Apply</set>
-     </property>
-     <property name="centerButtons">
-      <bool>true</bool>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="input_layout">
+     <item>
+      <widget class="QWidget" name="value_input_placeholder" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="value_button_box">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Apply</set>
+       </property>
+       <property name="centerButtons">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QToolButton" name="delete_button">

--- a/atef/ui/action_row_widget.ui
+++ b/atef/ui/action_row_widget.ui
@@ -93,12 +93,27 @@
    </item>
    <item>
     <layout class="QHBoxLayout" name="input_layout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetMaximumSize</enum>
+     </property>
      <item>
       <widget class="QWidget" name="value_input_placeholder" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
          <width>50</width>
          <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>400</width>
+         <height>16777215</height>
         </size>
        </property>
       </widget>
@@ -106,7 +121,7 @@
      <item>
       <widget class="QDialogButtonBox" name="value_button_box">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -127,6 +142,19 @@
       <string>...</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/atef/ui/action_row_widget.ui
+++ b/atef/ui/action_row_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>459</width>
+    <width>598</width>
     <height>43</height>
    </rect>
   </property>
@@ -53,7 +53,7 @@
    <item>
     <widget class="PyDMDrawingLine" name="arrow">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -82,6 +82,22 @@
        <width>50</width>
        <height>0</height>
       </size>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="value_button_box">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/atef/ui/action_row_widget.ui
+++ b/atef/ui/action_row_widget.ui
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>459</width>
+    <height>43</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QToolButton" name="child_button">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="name_edit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="placeholderText">
+      <string>action name</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="target_button">
+     <property name="text">
+      <string>select a target</string>
+     </property>
+     <property name="popupMode">
+      <enum>QToolButton::InstantPopup</enum>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonTextOnly</enum>
+     </property>
+     <property name="arrowType">
+      <enum>Qt::DownArrow</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMDrawingLine" name="arrow">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>50</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="arrowEndPoint" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="arrowStartPoint" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="value_input_placeholder" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>50</width>
+       <height>0</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="delete_button">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMDrawingLine</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/action_row_widget.ui
+++ b/atef/ui/action_row_widget.ui
@@ -84,10 +84,10 @@
       <string/>
      </property>
      <property name="arrowEndPoint" stdset="0">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="arrowStartPoint" stdset="0">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
     </widget>
    </item>

--- a/atef/ui/action_row_widget.ui
+++ b/atef/ui/action_row_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>598</width>
-    <height>43</height>
+    <height>45</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -47,6 +47,22 @@
      </property>
      <property name="arrowType">
       <enum>Qt::DownArrow</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="setting_button">
+     <property name="text">
+      <string>...</string>
+     </property>
+     <property name="popupMode">
+      <enum>QToolButton::InstantPopup</enum>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonIconOnly</enum>
+     </property>
+     <property name="arrowType">
+      <enum>Qt::NoArrow</enum>
      </property>
     </widget>
    </item>

--- a/atef/ui/add_row_widget.ui
+++ b/atef/ui/add_row_widget.ui
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>376</width>
+    <height>43</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QToolButton" name="add_button">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="row_label">
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/check_row_run_widget.ui
+++ b/atef/ui/check_row_run_widget.ui
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>598</width>
+    <height>43</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QToolButton" name="child_button">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="name_label">
+     <property name="text">
+      <string>check_name</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="target_label">
+     <property name="text">
+      <string>target</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="check_summary_label">
+     <property name="text">
+      <string>unconfigured check</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="status_label_placeholder" native="true">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>25</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/check_row_widget.ui
+++ b/atef/ui/check_row_widget.ui
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>598</width>
+    <height>43</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QToolButton" name="child_button">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="name_edit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="placeholderText">
+      <string>check name</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="target_button">
+     <property name="text">
+      <string>select a target</string>
+     </property>
+     <property name="popupMode">
+      <enum>QToolButton::InstantPopup</enum>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonTextOnly</enum>
+     </property>
+     <property name="arrowType">
+      <enum>Qt::DownArrow</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QToolButton" name="delete_button">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/check_row_widget.ui
+++ b/atef/ui/check_row_widget.ui
@@ -64,6 +64,13 @@
     </spacer>
    </item>
    <item>
+    <widget class="QLabel" name="check_summary_label">
+     <property name="text">
+      <string>unconfigured check</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QToolButton" name="delete_button">
      <property name="text">
       <string>...</string>

--- a/atef/ui/check_row_widget.ui
+++ b/atef/ui/check_row_widget.ui
@@ -57,7 +57,7 @@
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>40</width>
+       <width>50</width>
        <height>20</height>
       </size>
      </property>
@@ -76,6 +76,19 @@
       <string>...</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/atef/ui/pv_configuration_page.ui
+++ b/atef/ui/pv_configuration_page.ui
@@ -151,6 +151,15 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="horizontalScrollBarPolicy">
+           <enum>Qt::ScrollBarAlwaysOn</enum>
+          </property>
+          <property name="autoScrollMargin">
+           <number>16000</number>
+          </property>
+          <property name="horizontalScrollMode">
+           <enum>QAbstractItemView::ScrollPerPixel</enum>
+          </property>
           <attribute name="horizontalHeaderStretchLastSection">
            <bool>true</bool>
           </attribute>

--- a/atef/ui/pv_configuration_page.ui
+++ b/atef/ui/pv_configuration_page.ui
@@ -151,15 +151,6 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOn</enum>
-          </property>
-          <property name="autoScrollMargin">
-           <number>16000</number>
-          </property>
-          <property name="horizontalScrollMode">
-           <enum>QAbstractItemView::ScrollPerPixel</enum>
-          </property>
           <attribute name="horizontalHeaderStretchLastSection">
            <bool>true</bool>
           </attribute>

--- a/atef/ui/set_value_edit_widget.ui
+++ b/atef/ui/set_value_edit_widget.ui
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableWidget" name="actions_table">
+     <property name="dragEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="dragDropOverwriteMode">
+      <bool>false</bool>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::InternalMove</enum>
+     </property>
+     <property name="columnCount">
+      <number>1</number>
+     </property>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Actions</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="checks_table">
+     <property name="columnCount">
+      <number>1</number>
+     </property>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Checks</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="settings_label">
+     <property name="text">
+      <string>Specific Settings</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <property name="topMargin">
+      <number>5</number>
+     </property>
+     <item>
+      <widget class="QRadioButton" name="action_success_radio_button">
+       <property name="text">
+        <string>step success require action success</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="step_failure_radio_button">
+       <property name="text">
+        <string>halt exection on action failure</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/set_value_edit_widget.ui
+++ b/atef/ui/set_value_edit_widget.ui
@@ -15,48 +15,16 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTableWidget" name="actions_table">
-     <property name="dragEnabled">
-      <bool>true</bool>
-     </property>
-     <property name="dragDropOverwriteMode">
-      <bool>false</bool>
-     </property>
-     <property name="dragDropMode">
-      <enum>QAbstractItemView::InternalMove</enum>
-     </property>
-     <property name="columnCount">
-      <number>1</number>
-     </property>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Actions</string>
-      </property>
-     </column>
-    </widget>
+    <widget class="QWidget" name="actions_table_placeholder" native="true"/>
    </item>
    <item>
-    <widget class="QTableWidget" name="checks_table">
-     <property name="columnCount">
-      <number>1</number>
+    <widget class="QWidget" name="checks_table_placeholder" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Checks</string>
-      </property>
-     </column>
     </widget>
    </item>
    <item>

--- a/atef/ui/set_value_edit_widget.ui
+++ b/atef/ui/set_value_edit_widget.ui
@@ -36,20 +36,17 @@
    </item>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_2">
-     <property name="topMargin">
-      <number>5</number>
-     </property>
      <item>
-      <widget class="QRadioButton" name="action_success_radio_button">
+      <widget class="QCheckBox" name="req_action_success_checkbox">
        <property name="text">
-        <string>step success require action success</string>
+        <string>step success requires all actions to complete</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QRadioButton" name="step_failure_radio_button">
+      <widget class="QCheckBox" name="halt_on_fail_checkbox">
        <property name="text">
-        <string>halt exection on action failure</string>
+        <string>halt step exection on first action failure</string>
        </property>
       </widget>
      </item>

--- a/atef/ui/set_value_run_widget.ui
+++ b/atef/ui/set_value_run_widget.ui
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableWidget" name="actions_table">
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Actions</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="checks_table">
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Checks</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/step_page.ui
+++ b/atef/ui/step_page.ui
@@ -79,14 +79,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="label_10">
-     <property name="text">
-      <string>General Settings</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QWidget" name="general_procedure_placeholder" native="true"/>
+    <widget class="QFrame" name="general_procedure_placeholder"/>
    </item>
    <item>
     <widget class="QWidget" name="bottom_spacer" native="true">

--- a/atef/ui/target_entry_widget.ui
+++ b/atef/ui/target_entry_widget.ui
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>564</width>
+    <height>43</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QLineEdit" name="pv_edit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="placeholderText">
+      <string>enter a PV ⏎</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="signal_button">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>pick a device.signal</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="target_button_box">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Reset</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/target_entry_widget.ui
+++ b/atef/ui/target_entry_widget.ui
@@ -15,36 +15,34 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <widget class="QLineEdit" name="pv_edit">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>200</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="placeholderText">
-      <string>enter a PV ⏎</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QPushButton" name="signal_button">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>pick a device.signal</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="target_layout">
+     <item>
+      <widget class="QLineEdit" name="pv_edit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="placeholderText">
+        <string>enter a PV ⏎</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="signal_button">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>pick a device.signal</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="target_button_box">

--- a/atef/ui/target_entry_widget.ui
+++ b/atef/ui/target_entry_widget.ui
@@ -24,7 +24,7 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>100</width>
+       <width>200</width>
        <height>0</height>
       </size>
      </property>

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -25,12 +25,12 @@ import qtawesome
 import typhos
 import typhos.cli
 import typhos.display
-from ophyd import EpicsSignal
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QDialogButtonBox
 
 from atef import util
+from atef.cache import get_signal_cache
 from atef.check import Equals
 from atef.config import ConfigurationFile
 from atef.qt_helpers import QDataclassElem
@@ -875,7 +875,8 @@ class TargetEntryWidget(DesignerDisplay, QtWidgets.QWidget):
             self.data_updated.emit()
             return
 
-        sig = EpicsSignal(self.pv_edit.text())
+        signal_cache = get_signal_cache()
+        sig = signal_cache[self.pv_edit.text()]
         try:
             sig.wait_for_connection()
         except TimeoutError:

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -31,6 +31,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QDialogButtonBox
 
 from atef import util
+from atef.check import Equals
 from atef.config import ConfigurationFile
 from atef.result import Result, incomplete_result
 from atef.widgets.config.data_base import DataWidget, SimpleRowWidget
@@ -666,6 +667,7 @@ class SetValueEditWidget(DesignerDisplay, DataWidget):
             self.update_list(self.actions_table, self.bridge.actions)
         )
         self.insert_widget(self.actions_table, self.actions_table_placeholder)
+
         self.checks_table = TableWidgetWithAddRow(
             add_row_text='Add new check',
             title_text='Checks',
@@ -885,6 +887,7 @@ class ActionRowWidget(TargetRowWidget):
         super().__init__(data=data, **kwargs)
 
     def setup_ui(self):
+        """ Called by TargetRowWidget.__init__ """
         super().setup_ui()
         self.child_button.hide()
         apply_button = self.value_button_box.button(QDialogButtonBox.Apply)
@@ -922,7 +925,7 @@ class ActionRowWidget(TargetRowWidget):
             self.edit_widget.setText(str(self.bridge.value.get()))
             self.edit_widget.setToolTip(str(self.bridge.value.get()))
 
-        # slot for value update on ReturnPress
+        # slot for value update on apply button press
         def update_value():
             self.bridge.value.put(dtype(self.edit_widget.text()))
             self.value_button_box.hide()
@@ -958,5 +961,11 @@ class ActionRowWidget(TargetRowWidget):
 class CheckRowWidget(TargetRowWidget):
     filename = 'check_row_widget.ui'
 
-    def __init__(self, data=ComparisonToTarget, **kwargs):
+    check_summary_label: QtWidgets.QLabel
+
+    def __init__(self, data: Optional[ComparisonToTarget] = None, **kwargs):
+        if data is None:
+            data = ComparisonToTarget(name='untitled_check', comparison=Equals())
         super().__init__(data=data, **kwargs)
+
+        self.name_edit.hide()

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -687,7 +687,6 @@ class SetValueEditWidget(DesignerDisplay, DataWidget):
             self.checks_table.add_row(data=check)
 
         self.checks_table.cellClicked.connect(self.update_all_desc)
-        self.checks_table.table_updated.connect(lambda: print('table updated'))
 
         # checkboxes
         self.bridge.halt_on_fail.changed_value.connect(

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -909,7 +909,13 @@ class ActionRowWidget(TargetRowWidget):
             self.insert_widget(self.edit_widget, self.value_input_placeholder)
             self.value_button_box.hide()
             return
-        dtype = type(sig.get())
+
+        try:
+            curr_value = sig.get()
+        except TimeoutError:
+            curr_value = 'signal not available'
+
+        dtype = type(curr_value)
         self.edit_widget = QtWidgets.QLineEdit()
 
         if dtype is int:
@@ -920,7 +926,7 @@ class ActionRowWidget(TargetRowWidget):
             validator = None
 
         self.edit_widget.setValidator(validator)
-        self.edit_widget.setPlaceholderText(f'({sig.get()}) ⏎')
+        self.edit_widget.setPlaceholderText(f'({curr_value}) ⏎')
         if self.bridge.value.get() is not None:
             self.edit_widget.setText(str(self.bridge.value.get()))
             self.edit_widget.setToolTip(str(self.bridge.value.get()))

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -897,10 +897,11 @@ class TargetEntryWidget(DesignerDisplay, QtWidgets.QWidget):
             widget.device_widget.attributes_selected.connect(widget.close)
 
             # prevent multiple selection
-            self._search_widget = widget
+            self._search_widget: QtWidgets.QWidget = widget
 
         self._search_widget.show()
         self._search_widget.activateWindow()
+        self._search_widget.setWindowState(Qt.WindowActive)
         # TODO: figure out how to make QMenu not hide / reshow after opening
         # not really possible to do from this widget, which doesn't know about
         # the menu it is being spawned from...
@@ -979,6 +980,12 @@ class ActionRowWidget(TargetRowWidget):
         self.update_input_placeholder()
 
         self.setup_setting_button()
+
+    def on_name_edit_text_changed(self, **kwargs) -> None:
+        """ overwrite this to adjust minimum length"""
+        match_line_edit_text_width(self.name_edit, minimum=100)
+        if not self.name_edit.hasFocus():
+            self.adjust_edit_filter()
 
     def update_target(self) -> None:
         super().update_target()

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -846,7 +846,10 @@ class TargetEntryWidget(DesignerDisplay, QtWidgets.QWidget):
         try:
             sig.wait_for_connection()
         except TimeoutError:
-            logger.error(f'Could not connect to PV: {self.pv_edit.text()}')
+            QtWidgets.QMessageBox.information(
+                self,
+                f'Could not connect to PV: {self.pv_edit.text()}. Resetting target'
+            )
             self.reset_fields()
             return
 

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -687,12 +687,12 @@ class SetValueEditWidget(DesignerDisplay, DataWidget):
             self.checks_table.add_row(data=check)
 
         # update descriptions on selection change for check table
-        def update_all_desc():
+        def update_all_desc(*args, **kwargs):
             for ind in range(self.checks_table.rowCount()):
                 row_widget: CheckRowWidget = self.checks_table.cellWidget(ind, 0)
                 row_widget.update_summary()
 
-        self.checks_table.itemSelectionChanged.connect(update_all_desc)
+        self.checks_table.cellClicked.connect(update_all_desc)
 
         # checkboxes
         self.bridge.halt_on_fail.changed_value.connect(
@@ -973,6 +973,9 @@ class ActionRowWidget(TargetRowWidget):
         self.child_button.hide()
         apply_button = self.value_button_box.button(QDialogButtonBox.Apply)
         apply_button.setText('')
+        apply_button.setToolTip('Click here to confirm value')
+
+        self.setting_button.setToolTip('Configure action settings')
         self.update_input_placeholder()
 
         self.setup_setting_button()

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -818,8 +818,9 @@ class TargetEntryWidget(DesignerDisplay, QtWidgets.QWidget):
 
     def confirm_signal(self):
         # signal button is used
-        if self.pv_edit.text() is None:
+        if self.pv_edit.text() == '':
             self.data_updated.emit()
+            return
 
         sig = EpicsSignal(self.pv_edit.text())
         try:
@@ -840,6 +841,7 @@ class TargetEntryWidget(DesignerDisplay, QtWidgets.QWidget):
             # look at connecting widget.attributes_selected -> List[OphydAttributeData]
             widget.device_widget.attributes_selected.connect(self.set_signal)
             widget.device_widget.attributes_selected.connect(widget.close)
+
             # prevent multiple selection
             self._search_widget = widget
 
@@ -933,7 +935,11 @@ class ActionRowWidget(TargetRowWidget):
 
         # slot for value update on apply button press
         def update_value():
-            self.bridge.value.put(dtype(self.edit_widget.text()))
+            text = self.edit_widget.text()
+            if text == '':
+                # nothing input, don't try to set any values
+                return
+            self.bridge.value.put(dtype(text))
             self.value_button_box.hide()
             self.edit_widget.setFrame(False)
 

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -1071,8 +1071,8 @@ class ActionRowWidget(TargetRowWidget):
     def setup_setting_button(self) -> None:
         """ Set up the settings QToolButton menu for additional settings"""
         # set up settings button
-        init_dict = {'timeout': self.data.timeout or 0.0,
-                     'settle_time': self.data.settle_time or 0.0}
+        init_dict = {'timeout': self.data.timeout or -1.0,
+                     'settle_time': self.data.settle_time or -1.0}
         self.setting_button.setIcon(qtawesome.icon('msc.settings'))
         self.setting_widget = MultiInputDialog(init_values=init_dict)
         setting_action = QtWidgets.QWidgetAction(self.setting_button)
@@ -1085,8 +1085,11 @@ class ActionRowWidget(TargetRowWidget):
         # close menu on ok button click
         def ok_slot():
             info = self.setting_widget.get_info()
-            self.bridge.timeout.put(info['timeout'])
-            self.bridge.settle_time.put(info['settle_time'])
+            for key, value in info.items():
+                if value == -1:
+                    getattr(self.bridge, key).put(None)
+                else:
+                    getattr(self.bridge, key).put(value)
             self.setting_widget.show()
             self.setting_menu.hide()
 

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -874,6 +874,7 @@ class TargetEntryWidget(DesignerDisplay, QtWidgets.QWidget):
         except TimeoutError:
             QtWidgets.QMessageBox.information(
                 self,
+                'Failed to set target',
                 f'Could not connect to PV: {self.pv_edit.text()}. Resetting target'
             )
             self.reset_fields()

--- a/atef/widgets/config/data_base.py
+++ b/atef/widgets/config/data_base.py
@@ -7,6 +7,7 @@ import logging
 from typing import ClassVar, Dict, List, Protocol, Tuple
 from weakref import WeakValueDictionary
 
+import qtawesome
 from qtpy.QtWidgets import (QFrame, QHBoxLayout, QLabel, QLayout, QLineEdit,
                             QMessageBox, QPlainTextEdit, QStyle, QToolButton,
                             QVBoxLayout, QWidget)
@@ -481,3 +482,19 @@ class SimpleRowWidget(NameMixin, DataWidget):
         match_line_edit_text_width(self.name_edit)
         if not self.name_edit.hasFocus():
             self.adjust_edit_filter()
+
+
+class AddRowWidget(DesignerDisplay, QWidget):
+    """
+    A simple row widget with an add button.  To be used when space is precious
+    Connect a new-row slot to the add_button signal to create new rows
+    """
+    filename = 'add_row_widget.ui'
+
+    add_button: QToolButton
+    row_label: QLabel
+
+    def __init__(self, *args, text='Add new row', **kwargs):
+        super().__init__(*args, **kwargs)
+        self.add_button.setIcon(qtawesome.icon('ri.add-circle-line'))
+        self.row_label.setText(text)

--- a/atef/widgets/config/data_base.py
+++ b/atef/widgets/config/data_base.py
@@ -7,7 +7,6 @@ import logging
 from typing import ClassVar, Dict, List, Protocol, Tuple
 from weakref import WeakValueDictionary
 
-import qtawesome
 from qtpy.QtWidgets import (QFrame, QHBoxLayout, QLabel, QLayout, QLineEdit,
                             QMessageBox, QPlainTextEdit, QStyle, QToolButton,
                             QVBoxLayout, QWidget)
@@ -482,19 +481,3 @@ class SimpleRowWidget(NameMixin, DataWidget):
         match_line_edit_text_width(self.name_edit)
         if not self.name_edit.hasFocus():
             self.adjust_edit_filter()
-
-
-class AddRowWidget(DesignerDisplay, QWidget):
-    """
-    A simple row widget with an add button.  To be used when space is precious
-    Connect a new-row slot to the add_button signal to create new rows
-    """
-    filename = 'add_row_widget.ui'
-
-    add_button: QToolButton
-    row_label: QLabel
-
-    def __init__(self, *args, text='Add new row', **kwargs):
-        super().__init__(*args, **kwargs)
-        self.add_button.setIcon(qtawesome.icon('ri.add-circle-line'))
-        self.row_label.setText(text)

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -608,6 +608,7 @@ class ConfigurationGroupPage(DesignerDisplay, PageWidget):
                 self.add_config_row(config=config)
             self.setup_done = True
         self.setup_name_desc_tags_link()
+        self.setup_cleanup()
 
     def add_config_row(
         self,
@@ -738,6 +739,7 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
             data_widget=self.device_config_widget,
         )
         self.setup_name_desc_tags_link()
+        self.setup_cleanup()
 
     def add_comparison_row(
         self,
@@ -936,6 +938,7 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
             data_widget=self.pv_configuration_widget,
         )
         self.setup_name_desc_tags_link()
+        self.setup_cleanup()
 
     def add_comparison_row(
         self,
@@ -1146,6 +1149,7 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
                 self.tool_names[tool.__name__] = tool
             self.tool_select_combo.activated.connect(self.new_tool_selected)
         self.setup_name_desc_tags_link()
+        self.setup_cleanup()
 
     def add_comparison_row(
         self,
@@ -1400,6 +1404,7 @@ class ProcedureGroupPage(DesignerDisplay, PageWidget):
                 self.add_config_row(config=config)
             self.setup_done = True
         self.setup_name_desc_tags_link()
+        self.setup_cleanup()
 
     def add_config_row(
         self,

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -79,6 +79,11 @@ def link_page(item: AtefItem, widget: PageWidget) -> None:
     widget.assign_tree_item(item)
 
 
+def replace_in_list(old: Any, new: Any, item_list: List[Any]):
+    index = item_list.index(old)
+    item_list[index] = new
+
+
 class AtefItem(QTreeWidgetItem):
     """
     A QTreeWidget item with some convenience methods.
@@ -853,14 +858,6 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
 
         Also finds the row widget and replaces it with a new row widget.
         """
-        def replace_in_list(
-            old: Comparison,
-            new: Comparison,
-            comparison_list: List[Comparison],
-        ):
-            index = comparison_list.index(old)
-            comparison_list[index] = new
-
         try:
             replace_in_list(
                 old=old_comparison,
@@ -1052,14 +1049,6 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
 
         Also finds the row widget and replaces it with a new row widget.
         """
-        def replace_in_list(
-            old: Comparison,
-            new: Comparison,
-            comparison_list: List[Comparison],
-        ):
-            index = comparison_list.index(old)
-            comparison_list[index] = new
-
         try:
             replace_in_list(
                 old=old_comparison,
@@ -1268,14 +1257,6 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
 
         Also finds the row widget and replaces it with a new row widget.
         """
-        def replace_in_list(
-            old: Comparison,
-            new: Comparison,
-            comparison_list: List[Comparison],
-        ):
-            index = comparison_list.index(old)
-            comparison_list[index] = new
-
         try:
             replace_in_list(
                 old=old_comparison,
@@ -1519,14 +1500,6 @@ class ProcedureGroupPage(DesignerDisplay, PageWidget):
         comp_item : AtefItem
             AtefItem holding the old comparison and widget
         """
-        def replace_in_list(
-            old: ProcedureStep,
-            new: ProcedureStep,
-            step_list: List[ProcedureStep]
-        ):
-            index = step_list.index(old)
-            step_list[index] = new
-
         replace_in_list(old_step, new_step, self.data.steps)
 
         # go through rows
@@ -1806,23 +1779,31 @@ class StepPage(DesignerDisplay, PageWidget):
             table: TableWidgetWithAddRow = self.specific_procedure_widget.checks_table
             row_widget_cls = CheckRowWidget
             row_data_cls = ComparisonToTarget
+            data_list = self.data.success_criteria
+            comp_list = [comptotarget.comparison for comptotarget in data_list]
+            index = comp_list.index(old_comparison)
 
         found_row = None
         for row_index in range(table.rowCount()):
             widget = table.cellWidget(row_index, 0)
             if widget.data.comparison is old_comparison:
                 found_row = row_index
-                # prev_attr_index = widget.attr_combo.currentIndex()
                 break
         if found_row is None:
             return
-        comp_row = row_widget_cls(data=row_data_cls(comparison=new_comparison))
+
+        # replace in dataclass
+        new_data = row_data_cls(comparison=new_comparison)
+        data_list[index] = new_data
+        comp_row = row_widget_cls(data=new_data)
+
         self.setup_row_buttons(
             row_widget=comp_row,
             item=comp_item,
             table=table,
         )
         table.setCellWidget(found_row, 0, comp_row)
+        self.update_subpages()
 
     def remove_table_data(self, data: Any):
         if isinstance(self.data, SetValueStep):
@@ -2040,6 +2021,7 @@ class ComparisonPage(DesignerDisplay, PageWidget):
                 self.specific_combo.setCurrentText(type_name)
                 return
         comparison = cast_dataclass(data=self.data, new_type=new_type)
+        print(self.parent_tree_item.widget)
         self.parent_tree_item.widget.replace_comparison(
             old_comparison=self.data,
             new_comparison=comparison,
@@ -2185,14 +2167,6 @@ class ComparisonPage(DesignerDisplay, PageWidget):
 
         This is only valid when our data type is AnyComparison
         """
-        def replace_in_list(
-            old: Comparison,
-            new: Comparison,
-            comparison_list: List[Comparison],
-        ):
-            index = comparison_list.index(old)
-            comparison_list[index] = new
-
         replace_in_list(
             old=old_comparison,
             new=new_comparison,

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -1819,14 +1819,24 @@ class RunStepPage(DesignerDisplay, PageWidget):
         self.insert_widget(self.run_check, self.run_check_placeholder)
         # gather run_widget
         run_widget_cls = self.run_widget_map[type(data)]
-        run_widget = run_widget_cls(data=data)
+        self.run_widget = run_widget_cls(data=data)
 
-        self.insert_widget(run_widget, self.run_widget_placeholder)
+        self.insert_widget(self.run_widget, self.run_widget_placeholder)
 
-        if type(data) == PreparedPassiveStep:
-            self.run_check.run_button.clicked.connect(run_widget.run_config)
-        elif type(data) == PreparedSetValueStep:
-            self.run_check.run_button.clicked.connect(run_widget.update_statuses)
+        if isinstance(data, PreparedPassiveStep):
+            self.run_check.run_button.clicked.connect(self.run_widget.run_config)
+        elif isinstance(data, PreparedSetValueStep):
+            self.run_check.run_button.clicked.connect(self.run_widget.update_statuses)
+
+    def link_children(self):
+        if isinstance(self.data, PreparedSetValueStep):
+            # set up children
+            child_items = self.tree_item.takeChildren()
+            n_rows = self.run_widget.checks_table.rowCount()
+            for row_ind, item in zip(range(n_rows), child_items):
+                row_widget = self.run_widget.checks_table.cellWidget(row_ind, 0)
+                self.setup_child_button(row_widget.child_button, item)
+                self.tree_item.addChild(item)
 
 
 PAGE_MAP = {

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -1764,6 +1764,19 @@ class StepPage(DesignerDisplay, PageWidget):
             item=item,
         )
 
+        # setup callback to update description if comparison page changes
+        # item.widget will be a ComparisonPage
+        # gets a bit invasive here, assumes links between ComparisonPage and
+        # the atef item have been made
+        desc_update_slot = self.specific_procedure_widget.update_all_desc
+        comp_page_widget = item.widget.specific_comparison_widget
+        # subscribe to the relevant comparison signals
+        for field in ('value', 'low', 'high', 'description'):
+            if hasattr(comp_page_widget.bridge, field):
+                getattr(comp_page_widget.bridge, field).changed_value.connect(
+                    desc_update_slot
+                )
+
     def replace_comparison(
         self,
         old_comparison: Comparison,
@@ -2021,7 +2034,6 @@ class ComparisonPage(DesignerDisplay, PageWidget):
                 self.specific_combo.setCurrentText(type_name)
                 return
         comparison = cast_dataclass(data=self.data, new_type=new_type)
-        print(self.parent_tree_item.widget)
         self.parent_tree_item.widget.replace_comparison(
             old_comparison=self.data,
             new_comparison=comparison,

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -34,15 +34,16 @@ from atef.config import (Configuration, ConfigurationGroup,
                          ToolConfiguration)
 from atef.procedure import (ComparisonToTarget, DescriptionStep, PassiveStep,
                             PreparedDescriptionStep, PreparedPassiveStep,
-                            PreparedProcedureStep, ProcedureGroup,
-                            ProcedureStep, SetValueStep)
+                            PreparedProcedureStep, PreparedSetValueStep,
+                            ProcedureGroup, ProcedureStep, SetValueStep)
 from atef.tools import Ping, PingResult, Tool, ToolResult
 from atef.widgets.config.data_active import (CheckRowWidget,
                                              GeneralProcedureWidget,
                                              PassiveEditWidget,
                                              SetValueEditWidget)
 from atef.widgets.config.run_active import (DescriptionRunWidget,
-                                            PassiveRunWidget)
+                                            PassiveRunWidget,
+                                            SetValueRunWidget)
 from atef.widgets.config.run_base import RunCheck
 
 from ..core import DesignerDisplay
@@ -1808,7 +1809,8 @@ class RunStepPage(DesignerDisplay, PageWidget):
 
     run_widget_map: ClassVar[Dict[PreparedProcedureStep, DataWidget]] = {
         PreparedDescriptionStep: DescriptionRunWidget,
-        PreparedPassiveStep: PassiveRunWidget
+        PreparedPassiveStep: PassiveRunWidget,
+        PreparedSetValueStep: SetValueRunWidget,
     }
 
     def __init__(self, *args, data, **kwargs):
@@ -2009,7 +2011,7 @@ class ComparisonPage(DesignerDisplay, PageWidget):
                 parent_widget.name_desc_tags_widget.extra_text_label.text()
             )
             return
-        if isinstance(parent_widget, StepPage):
+        if isinstance(parent_widget, (StepPage, RunStepPage)):
             # No-op to let this be used in active checkouts without
             # passive checkout config files in the parent widget
             return

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -862,7 +862,7 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
             replace_in_list(
                 old=old_comparison,
                 new=new_comparison,
-                comparison_list=self.data.shared,
+                item_list=self.data.shared,
             )
         except ValueError:
             for comp_list in self.data.by_attr.values():
@@ -870,7 +870,7 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
                     replace_in_list(
                         old=old_comparison,
                         new=new_comparison,
-                        comparison_list=comp_list,
+                        item_list=comp_list,
                     )
                 except ValueError:
                     continue
@@ -1053,7 +1053,7 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
             replace_in_list(
                 old=old_comparison,
                 new=new_comparison,
-                comparison_list=self.data.shared,
+                item_list=self.data.shared,
             )
         except ValueError:
             for comp_list in self.data.by_pv.values():
@@ -1061,7 +1061,7 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
                     replace_in_list(
                         old=old_comparison,
                         new=new_comparison,
-                        comparison_list=comp_list,
+                        item_list=comp_list,
                     )
                 except ValueError:
                     continue
@@ -1261,7 +1261,7 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
             replace_in_list(
                 old=old_comparison,
                 new=new_comparison,
-                comparison_list=self.data.shared,
+                item_list=self.data.shared,
             )
         except ValueError:
             for comp_list in self.data.by_attr.values():
@@ -1269,7 +1269,7 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
                     replace_in_list(
                         old=old_comparison,
                         new=new_comparison,
-                        comparison_list=comp_list,
+                        item_list=comp_list,
                     )
                 except ValueError:
                     continue
@@ -2182,7 +2182,7 @@ class ComparisonPage(DesignerDisplay, PageWidget):
         replace_in_list(
             old=old_comparison,
             new=new_comparison,
-            comparison_list=self.data.comparisons,
+            item_list=self.data.comparisons,
         )
         self.specific_comparison_widget.replace_row_widget(
             old_comparison=old_comparison,

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -1823,8 +1823,10 @@ class RunStepPage(DesignerDisplay, PageWidget):
 
         self.insert_widget(run_widget, self.run_widget_placeholder)
 
-        if type(data) == PassiveStep:
+        if type(data) == PreparedPassiveStep:
             self.run_check.run_button.clicked.connect(run_widget.run_config)
+        elif type(data) == PreparedSetValueStep:
+            self.run_check.run_button.clicked.connect(run_widget.update_statuses)
 
 
 PAGE_MAP = {

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -1765,9 +1765,9 @@ class StepPage(DesignerDisplay, PageWidget):
         )
 
         # setup callback to update description if comparison page changes
-        # item.widget will be a ComparisonPage
         # gets a bit invasive here, assumes links between ComparisonPage and
         # the atef item have been made
+        # item.widget will be a ComparisonPage
         desc_update_slot = self.specific_procedure_widget.update_all_desc
         comp_page_widget = item.widget.specific_comparison_widget
         # subscribe to the relevant comparison signals

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -22,9 +22,9 @@ from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type, Union
 from weakref import WeakSet, WeakValueDictionary
 
 from qtpy.QtGui import QDropEvent
-from qtpy.QtWidgets import (QComboBox, QMessageBox, QPushButton, QSizePolicy,
-                            QStyle, QTableWidget, QToolButton, QTreeWidget,
-                            QTreeWidgetItem, QVBoxLayout, QWidget)
+from qtpy.QtWidgets import (QComboBox, QFrame, QMessageBox, QPushButton,
+                            QSizePolicy, QStyle, QTableWidget, QToolButton,
+                            QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget)
 
 from atef.check import (AnyComparison, AnyValue, Comparison, Equals, Greater,
                         GreaterOrEqual, Less, LessOrEqual, NotEquals, Range,
@@ -37,7 +37,7 @@ from atef.procedure import (ComparisonToTarget, DescriptionStep, PassiveStep,
                             PreparedProcedureStep, PreparedSetValueStep,
                             ProcedureGroup, ProcedureStep, SetValueStep)
 from atef.tools import Ping, PingResult, Tool, ToolResult
-from atef.widgets.config.data_active import (CheckRowWidget,
+from atef.widgets.config.data_active import (CheckRowWidget, ExpandableFrame,
                                              GeneralProcedureWidget,
                                              PassiveEditWidget,
                                              SetValueEditWidget)
@@ -1540,7 +1540,7 @@ class StepPage(DesignerDisplay, PageWidget):
 
     specific_procedure_placeholder: QWidget
     specific_procedure_widget: DataWidget
-    general_procedure_placeholder: QWidget
+    general_procedure_placeholder: QFrame
     general_procedure_widget: QWidget
     bottom_spacer: QWidget
 
@@ -1588,9 +1588,11 @@ class StepPage(DesignerDisplay, PageWidget):
         This is accomplished by discarding the old widgets in favor
         of new widgets.
         """
+        general_frame = ExpandableFrame(text='General Settings')
         general_widget = GeneralProcedureWidget(data=step)
+        general_frame.add_widget(general_widget)
         self.insert_widget(
-            general_widget,
+            general_frame,
             self.general_procedure_placeholder,
         )
         SpecificWidgetType = self.step_map[type(step)]

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -1789,6 +1789,10 @@ class StepPage(DesignerDisplay, PageWidget):
         )
         table.setCellWidget(found_row, 0, comp_row)
 
+    def remove_table_data(self, data: Any):
+        if isinstance(self.data, SetValueStep):
+            self.data.success_criteria.remove(data)
+
 
 class RunStepPage(DesignerDisplay, PageWidget):
     """

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -1674,8 +1674,6 @@ class StepPage(DesignerDisplay, PageWidget):
         self.name_desc_tags_widget.init_viewer(attr, config)
 
     def setup_set_value_step(self) -> None:
-        # helpful methods?...
-        # self.setup_child_button
         self.update_subpages()
         self.specific_procedure_widget.bridge.success_criteria.updated.connect(
             self.update_subpages
@@ -1834,7 +1832,11 @@ class RunStepPage(DesignerDisplay, PageWidget):
         elif isinstance(data, PreparedSetValueStep):
             self.run_check.run_button.clicked.connect(self.run_widget.update_statuses)
 
-    def link_children(self):
+    def link_children(self) -> None:
+        """
+        A helper method to link children tree items with their parent.
+        Children can get orphaned during the edit->run transition.
+        """
         if isinstance(self.data, PreparedSetValueStep):
             # set up children
             child_items = self.tree_item.takeChildren()

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -1865,7 +1865,9 @@ class RunStepPage(DesignerDisplay, PageWidget):
         if isinstance(data, PreparedPassiveStep):
             self.run_check.run_button.clicked.connect(self.run_widget.run_config)
         elif isinstance(data, PreparedSetValueStep):
-            self.run_check.run_button.clicked.connect(self.run_widget.update_statuses)
+            self.run_check.busy_thread.task_finished.connect(
+                self.run_widget.update_statuses
+            )
 
     def link_children(self) -> None:
         """

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -35,10 +35,11 @@ from atef.config import (Configuration, ConfigurationGroup,
 from atef.procedure import (DescriptionStep, PassiveStep,
                             PreparedDescriptionStep, PreparedPassiveStep,
                             PreparedProcedureStep, ProcedureGroup,
-                            ProcedureStep)
+                            ProcedureStep, SetValueStep)
 from atef.tools import Ping, PingResult, Tool, ToolResult
 from atef.widgets.config.data_active import (GeneralProcedureWidget,
-                                             PassiveEditWidget)
+                                             PassiveEditWidget,
+                                             SetValueEditWidget)
 from atef.widgets.config.run_active import (DescriptionRunWidget,
                                             PassiveRunWidget)
 from atef.widgets.config.run_base import RunCheck
@@ -1347,7 +1348,8 @@ class ProcedureGroupPage(DesignerDisplay, PageWidget):
         cls.__name__: cls for cls in (
             ProcedureGroup,
             DescriptionStep,
-            PassiveStep
+            PassiveStep,
+            SetValueStep
         )
     }
 
@@ -1464,7 +1466,7 @@ class ProcedureGroupPage(DesignerDisplay, PageWidget):
 
         Shoutouts to stackoverflow
         """
-        if event.source() is self.config_table:
+        if event.source() is self.procedure_table:
             selected_indices = self.procedure_table.selectedIndexes()
             if not selected_indices:
                 return
@@ -1541,7 +1543,8 @@ class StepPage(DesignerDisplay, PageWidget):
 
     step_map: ClassVar[Dict[ProcedureStep, DataWidget]] = {
         DescriptionStep: None,
-        PassiveStep: PassiveEditWidget
+        PassiveStep: PassiveEditWidget,
+        SetValueStep: SetValueEditWidget
     }
     step_types: Dict[str, ProcedureStep]
 
@@ -1705,7 +1708,8 @@ PAGE_MAP = {
     # Active Pages
     ProcedureGroup: ProcedureGroupPage,
     DescriptionStep: StepPage,
-    PassiveStep: StepPage
+    PassiveStep: StepPage,
+    SetValueStep: StepPage
 }
 
 

--- a/atef/widgets/config/run_active.py
+++ b/atef/widgets/config/run_active.py
@@ -11,12 +11,15 @@ import pathlib
 import qtawesome
 from qtpy import QtWidgets
 
-from atef.config import ConfigurationFile, PreparedFile, run_passive_step
-from atef.procedure import PreparedDescriptionStep, PreparedPassiveStep
+from atef.config import (ConfigurationFile, PreparedFile,
+                         PreparedSignalComparison, run_passive_step)
+from atef.procedure import (PreparedDescriptionStep, PreparedPassiveStep,
+                            PreparedSetValueStep, PreparedValueToSignal)
 from atef.widgets.config.data_base import DataWidget
-from atef.widgets.config.run_base import create_tree_items
+from atef.widgets.config.run_base import ResultStatus, create_tree_items
 from atef.widgets.config.utils import ConfigTreeModel, TreeItem
 from atef.widgets.core import DesignerDisplay
+from atef.widgets.utils import insert_widget
 
 logger = logging.getLogger(__name__)
 
@@ -98,3 +101,62 @@ class DescriptionRunWidget(DesignerDisplay, DataWidget):
     def _setup_ui(self) -> None:
         self.title_label.setText(self.bridge.origin.get().name)
         self.desc_label.setText(self.bridge.origin.get().description)
+
+
+class SetValueRunWidget(DesignerDisplay, DataWidget):
+    """ Widget for viewing set value step """
+    filename = 'set_value_run_widget.ui'
+
+    actions_table: QtWidgets.QTableWidget
+    checks_table: QtWidgets.QTableWidget
+
+    def __init__(self, *args, data: PreparedSetValueStep, **kwargs):
+        super().__init__(*args, data=data, **kwargs)
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        for table, field, cls in [
+            (self.actions_table, self.data.prepared_actions, ActionRowRunWidget),
+            (self.checks_table, self.data.prepared_criteria, CheckRowRunWidget)
+        ]:
+            for item in field:
+                ins_ind = table.rowCount()
+                action_row = cls(data=item)
+                table.insertRow(ins_ind)
+                table.setRowHeight(ins_ind, action_row.sizeHint().height())
+                table.setCellWidget(ins_ind, 0, action_row)
+
+
+class ActionRowRunWidget(DesignerDisplay, QtWidgets.QWidget):
+    filename = 'action_row_run_widget.ui'
+
+    name_label: QtWidgets.QLabel
+    target_label: QtWidgets.QLabel
+    value_label: QtWidgets.QLabel
+    status_label_placeholder: QtWidgets.QWidget
+
+    def __init__(self, *args, data: PreparedValueToSignal, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.status_label = ResultStatus(data=data)
+        insert_widget(self.status_label, self.status_label_placeholder)
+        self.name_label.setText(data.name)
+        self.target_label.setText(data.signal.name)
+        self.value_label.setText(str(data.value))
+
+
+class CheckRowRunWidget(DesignerDisplay, QtWidgets.QWidget):
+    filename = 'check_row_run_widget.ui'
+
+    child_button: QtWidgets.QPushButton
+    name_label: QtWidgets.QLabel
+    target_label: QtWidgets.QLabel
+    check_summary_label: QtWidgets.QLabel
+    status_label_placeholder: QtWidgets.QLabel
+
+    def __init__(self, *args, data: PreparedSignalComparison, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.status_label = ResultStatus(data=data)
+        insert_widget(self.status_label, self.status_label_placeholder)
+        self.name_label.setText(data.name)
+        self.target_label.setText(data.signal.name)
+        self.check_summary_label.setText(str(type(data.comparison).__name__))

--- a/atef/widgets/config/run_active.py
+++ b/atef/widgets/config/run_active.py
@@ -166,4 +166,4 @@ class CheckRowRunWidget(DesignerDisplay, QtWidgets.QWidget):
         insert_widget(self.status_label, self.status_label_placeholder)
         self.name_label.setText(data.name)
         self.target_label.setText(data.signal.name)
-        self.check_summary_label.setText(str(type(data.comparison).__name__))
+        self.check_summary_label.setText(data.comparison.describe())

--- a/atef/widgets/config/run_active.py
+++ b/atef/widgets/config/run_active.py
@@ -104,7 +104,10 @@ class DescriptionRunWidget(DesignerDisplay, DataWidget):
 
 
 class SetValueRunWidget(DesignerDisplay, DataWidget):
-    """ Widget for viewing set value step """
+    """
+    Widget for viewing set value step.  Displays Results alongside their
+    respective actions or checks
+    """
     filename = 'set_value_run_widget.ui'
 
     actions_table: QtWidgets.QTableWidget
@@ -135,6 +138,10 @@ class SetValueRunWidget(DesignerDisplay, DataWidget):
 
 
 class ActionRowRunWidget(DesignerDisplay, QtWidgets.QWidget):
+    """
+    Simple widget displaying information stored in ``PreparedValueToSignal``
+    Does not implement the SimpleRowWidget interface
+    """
     filename = 'action_row_run_widget.ui'
 
     name_label: QtWidgets.QLabel
@@ -152,6 +159,10 @@ class ActionRowRunWidget(DesignerDisplay, QtWidgets.QWidget):
 
 
 class CheckRowRunWidget(DesignerDisplay, QtWidgets.QWidget):
+    """
+    Simple widget displaying information stored in ``PreparedSignalComparison``
+    Does not implement the SimpleRowWidget interface
+    """
     filename = 'check_row_run_widget.ui'
 
     child_button: QtWidgets.QPushButton

--- a/atef/widgets/config/run_active.py
+++ b/atef/widgets/config/run_active.py
@@ -126,6 +126,13 @@ class SetValueRunWidget(DesignerDisplay, DataWidget):
                 table.setRowHeight(ins_ind, action_row.sizeHint().height())
                 table.setCellWidget(ins_ind, 0, action_row)
 
+    def update_statuses(self):
+        """ slot to be connected to RunCheck button """
+        for table in (self.actions_table, self.checks_table):
+            for i in range(table.rowCount()):
+                row_widget = table.cellWidget(i, 0)
+                row_widget.status_label.update()
+
 
 class ActionRowRunWidget(DesignerDisplay, QtWidgets.QWidget):
     filename = 'action_row_run_widget.ui'

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -243,7 +243,7 @@ class ResultStatus(QLabel):
         self.update_icon()
         self.update_tooltip()
 
-    def update_icon(self):
+    def update_icon(self) -> None:
         """ read the result and update the icon accordingly """
         chosen_icon = self.style_icons[self.data.result.severity]
         icon = self.style().standardIcon(chosen_icon)
@@ -341,7 +341,7 @@ class RunCheck(DesignerDisplay, QWidget):
     def _make_run_slot(self, configs) -> None:
 
         @busy_cursor
-        def run_slot():
+        def run_slot(*args, **kwargs):
             """ Slot that runs each step in the config list """
             for cfg in configs:
                 config_type = infer_step_type(cfg)

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -26,6 +26,7 @@ from atef.procedure import (PreparedProcedureFile, PreparedProcedureGroup,
 from atef.result import Result, combine_results
 from atef.widgets.config.utils import TreeItem
 from atef.widgets.core import DesignerDisplay
+from atef.widgets.utils import busy_cursor
 
 # avoid circular imports
 if TYPE_CHECKING:
@@ -339,6 +340,7 @@ class RunCheck(DesignerDisplay, QWidget):
 
     def _make_run_slot(self, configs) -> None:
 
+        @busy_cursor
         def run_slot():
             """ Slot that runs each step in the config list """
             for cfg in configs:

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -355,7 +355,7 @@ class RunCheck(DesignerDisplay, QWidget):
                 self.update_all_icons_tooltips()
 
         # send this to a non-gui thread
-        self.busy_thread = BusyCursorThread(func=run_slot)
+        self.busy_thread = BusyCursorThread(func=run_slot, ignore_events=True)
 
         def run_thread():
             self.busy_thread.start()

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -252,7 +252,7 @@ class ResultStatus(QLabel):
         """ Helper method to update tooltip based on ``results`` """
         result = self.data.result
         uni_icon = self.unicode_icons[result.severity]
-        tt = f'<p>{uni_icon}: {result.reason or "-"}<p>'
+        tt = f'<p>{uni_icon}: {result.reason or "-"}</p>'
         self.setToolTip(tt)
 
     def event(self, event: QtCore.QEvent) -> bool:

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -655,6 +655,11 @@ def setup_line_edit_data(
     line_edit.textEdited.connect(update_dataclass)
     value_obj.changed_value.connect(update_widget)
 
+    def disconnect_update():
+        value_obj.changed_value.disconnect(update_widget)
+
+    line_edit.destroyed.connect(disconnect_update)
+
 
 def describe_comparison_context(attr: str, config: Configuration) -> str:
     """

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -1234,9 +1234,10 @@ class TableWidgetWithAddRow(QtWidgets.QTableWidget):
     """
     A standard QTableWidget with an AddRowWidget.
     Intended to be a n x 1 table, with each row being a SimpleRowWidget.
+    allows drag-and-drop to re-order rows
     Emits table_updated when the table contents change.
 
-
+    use .add_row() to initialize a new row with an optional dataclass.
 
     The AddRowWidget is not treated as a row, and as such the following methods
     are modified.
@@ -1291,7 +1292,6 @@ class TableWidgetWithAddRow(QtWidgets.QTableWidget):
 
     def setup_delete_button(self, row: QtWidgets.QWidget) -> None:
         # row: SimpleRowWidget, but can't import due to module structure
-        # TODO: Make this work for an arbitrary list and its row
         delete_icon = self.style().standardIcon(
             QtWidgets.QStyle.SP_TitleBarCloseButton
         )
@@ -1320,7 +1320,7 @@ class TableWidgetWithAddRow(QtWidgets.QTableWidget):
         Shoutouts to stackoverflow
         """
         if event.source() is self:
-            selected_indices = self.config_table.selectedIndexes()
+            selected_indices = self.selectedIndexes()
             if not selected_indices:
                 return
             selected_row = selected_indices[0].row()
@@ -1337,26 +1337,22 @@ class TableWidgetWithAddRow(QtWidgets.QTableWidget):
         Rearanges the table, the file, and the tree.
         """
         # Skip if into the same index
-        return
-        # if source == dest:
-        #     return
+        if source == dest:
+            return
 
-        # ####
-        # config_data = self.data.steps.pop(source)
-        # ####
-
+        config_data = self.data.steps.pop(source)
         # self.data.steps.insert(dest, config_data)
         # # Rearrange the tree
         # config_item = self.tree_item.takeChild(source)
         # self.tree_item.insertChild(dest, config_item)
-        # # Rearrange the table: need a whole new widget or else segfault
-        # self.removeRow(source)
-        # self.insertRow(dest)
-        # config_row = self.row_widget_cls(data=config_data)
+        # Rearrange the table: need a whole new widget or else segfault
+        self.removeRow(source)
+        self.insertRow(dest)
+        config_row = self.row_widget_cls(data=config_data)
         # self.setup_row_buttons(
         #     row_widget=config_row,
         #     item=config_item,
         #     table=self.procedure_table,
         # )
-        # self.setRowHeight(dest, config_row.sizeHint().height())
-        # self.setCellWidget(dest, 0, config_row)
+        self.setRowHeight(dest, config_row.sizeHint().height())
+        self.setCellWidget(dest, 0, config_row)

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -1270,6 +1270,7 @@ class TableWidgetWithAddRow(QtWidgets.QTableWidget):
         self.verticalHeader().setHidden(True)
         self.row_widget_cls = row_widget_cls
         self.add_add_row_widget(text=add_row_text)
+        self.setSelectionMode(self.NoSelection)
 
     def add_add_row_widget(self, text: str):
         """ add the AddRowWidget to the end of the specified table-widget"""

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -892,7 +892,7 @@ class MultiInputDialog(QtWidgets.QDialog):
             float_edit.setValue(value)
             return float_edit
         else:
-            print('something bad happened')
+            raise RuntimeError(f"Unexpected value {value} of type {type(value).__name__}")
 
     def get_info(self) -> Dict[str, Any]:
         """

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -880,10 +880,16 @@ class MultiInputDialog(QtWidgets.QDialog):
             return text_edit
         elif isinstance(value, int):
             int_edit = QtWidgets.QSpinBox()
+            int_edit.setMinimum(-1)
+            int_edit.setSpecialValueText('None')
+            int_edit.setToolTip('Input -1 to set value to None')
             int_edit.setValue(value)
             return int_edit
         elif isinstance(value, float):
             float_edit = QtWidgets.QDoubleSpinBox()
+            float_edit.setMinimum(-1)
+            float_edit.setSpecialValueText('None')
+            float_edit.setToolTip('Input -1 to set value to None')
             float_edit.setValue(value)
             return float_edit
         else:

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -655,11 +655,6 @@ def setup_line_edit_data(
     line_edit.textEdited.connect(update_dataclass)
     value_obj.changed_value.connect(update_widget)
 
-    def disconnect_update():
-        value_obj.changed_value.disconnect(update_widget)
-
-    line_edit.destroyed.connect(disconnect_update)
-
 
 def describe_comparison_context(attr: str, config: Configuration) -> str:
     """

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -826,10 +826,17 @@ class MultiInputDialog(QtWidgets.QDialog):
 
     To retrieve the user provided data, call MultiInputDialog.get_info()
     """
-    def __init__(self, *args, init_values: Dict[str, Any], **kwargs):
+    def __init__(
+        self,
+        *args,
+        init_values: Dict[str, Any],
+        units: Optional[List[str]] = None,
+        **kwargs
+    ):
         super().__init__(*args, **kwargs)
 
         self.init_values = init_values
+        self.units = units
         vlayout = QtWidgets.QVBoxLayout(self)
         self.grid_layout = QtWidgets.QGridLayout()
         # add each name and field
@@ -837,6 +844,12 @@ class MultiInputDialog(QtWidgets.QDialog):
             spaced_key = key.replace('_', ' ')
             self.grid_layout.addWidget(self.make_label(spaced_key), i, 0)
             self.grid_layout.addWidget(self.make_field(value), i, 1)
+            if self.units:
+                try:
+                    unit_label = QtWidgets.QLabel(self.units[i])
+                except IndexError:
+                    continue
+                self.grid_layout.addWidget(unit_label, i, 2)
 
         vlayout.addLayout(self.grid_layout)
 

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -841,13 +841,13 @@ class MultiInputDialog(QtWidgets.QDialog):
         vlayout.addLayout(self.grid_layout)
 
         # add ok, cancel buttons
-        hlayout = QtWidgets.QHBoxLayout()
-        self.ok_button = QtWidgets.QPushButton('Accept')
-        self.cancel_button = QtWidgets.QPushButton('Cancel')
-        hlayout.addWidget(self.ok_button)
-        hlayout.addWidget(self.cancel_button)
-        vlayout.addLayout(hlayout)
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
+        )
+        self.ok_button = self.button_box.button(QtWidgets.QDialogButtonBox.Ok)
+        self.cancel_button = self.button_box.button(QtWidgets.QDialogButtonBox.Cancel)
 
+        vlayout.addWidget(self.button_box)
         self.ok_button.clicked.connect(self.accept)
         self.cancel_button.clicked.connect(self.reject)
 
@@ -880,9 +880,14 @@ class MultiInputDialog(QtWidgets.QDialog):
             return text_edit
         elif isinstance(value, int):
             int_edit = QtWidgets.QSpinBox()
-            int_edit.setMaximum(10)
             int_edit.setValue(value)
             return int_edit
+        elif isinstance(value, float):
+            float_edit = QtWidgets.QDoubleSpinBox()
+            float_edit.setValue(value)
+            return float_edit
+        else:
+            print('something bad happened')
 
     def get_info(self) -> Dict[str, Any]:
         """
@@ -896,7 +901,8 @@ class MultiInputDialog(QtWidgets.QDialog):
             input_widget = self.grid_layout.itemAtPosition(r, 1).widget()
             if isinstance(input_widget, QtWidgets.QLineEdit):
                 value = input_widget.text()
-            elif isinstance(input_widget, QtWidgets.QSpinBox):
+            elif isinstance(input_widget,
+                            (QtWidgets.QSpinBox, QtWidgets.QDoubleSpinBox)):
                 value = input_widget.value()
 
             unspaced_key = key.replace(' ', '_')

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -493,6 +493,7 @@ class RunTree(EditTree):
                 run_widget_cls = _edit_to_run_page[type(data)]
                 run_widget = run_widget_cls(data=prepared_data[0])
                 link_page(item, run_widget)
+                run_widget.link_children()
             else:
                 run_widget = make_run_page(item.widget, prepared_data)
                 link_page(item, run_widget)

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -23,6 +23,7 @@ from atef.procedure import (DescriptionStep, PassiveStep,
                             PreparedProcedureFile, ProcedureFile, SetValueStep)
 from atef.qt_helpers import walk_tree_widget_items
 from atef.report import PassiveAtefReport
+from atef.widgets.utils import busy_cursor
 
 from ..archive_viewer import get_archive_viewer
 from ..core import DesignerDisplay
@@ -612,6 +613,7 @@ class DualTree(QWidget):
             self.mode = 'edit'
         self.show_widgets()
 
+    @busy_cursor
     def show_widgets(self) -> None:
         """ Show active widget, hide others. (re)generate RunTree if needed """
         # If run_tree requested check if there are changes

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -507,6 +507,9 @@ class RunTree(EditTree):
             run_button: QtWidgets.QPushButton = run_widget.run_check.run_button
             run_button.clicked.connect(self.update_statuses)
 
+        # disable last 'next' button
+        run_widget.run_check.next_button.hide()
+
     def update_statuses(self) -> None:
         """ update every status icon based on stored config result """
         for item in walk_tree_widget_items(self.tree_widget):

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -20,7 +20,7 @@ from qtpy.QtWidgets import (QAction, QFileDialog, QMainWindow, QMessageBox,
 from atef.cache import DataCache
 from atef.config import ConfigurationFile, PreparedFile
 from atef.procedure import (DescriptionStep, PassiveStep,
-                            PreparedProcedureFile, ProcedureFile)
+                            PreparedProcedureFile, ProcedureFile, SetValueStep)
 from atef.qt_helpers import walk_tree_widget_items
 from atef.report import PassiveAtefReport
 
@@ -423,7 +423,8 @@ class EditTree(DesignerDisplay, QWidget):
 
 _edit_to_run_page: Dict[type, PageWidget] = {
     DescriptionStep: RunStepPage,
-    PassiveStep: RunStepPage
+    PassiveStep: RunStepPage,
+    SetValueStep: RunStepPage,
 }
 
 

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -497,7 +497,6 @@ class RunTree(EditTree):
                 run_widget.link_children()
             else:
                 run_widget = make_run_page(item.widget, prepared_data)
-                link_page(item, run_widget)
 
             if prev_widget:
                 prev_widget.run_check.setup_next_button(item)

--- a/atef/widgets/ophyd.py
+++ b/atef/widgets/ophyd.py
@@ -634,7 +634,10 @@ class OphydDeviceTableView(QtWidgets.QTableView):
                 select_action.triggered.connect(select_attr)
 
             # Insert the standard actions above the custom ones
-            self.menu.insertActions(self.menu.actions()[0], standard_actions)
+            if not self.menu.actions():
+                self.menu.insertActions(None, standard_actions)
+            else:
+                self.menu.insertActions(self.menu.actions()[0], standard_actions)
 
         self.menu.exec_(self.mapToGlobal(pos))
 

--- a/atef/widgets/utils.py
+++ b/atef/widgets/utils.py
@@ -1,7 +1,7 @@
 """
 Non-core utilities. Primarily dynamic styling tools.
 """
-from typing import Optional
+from typing import ClassVar, Optional
 
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import QEvent, QObject
@@ -120,7 +120,10 @@ def insert_widget(widget: QtWidgets.QWidget, placeholder: QtWidgets.QWidget) -> 
 
 
 def busy_cursor(func):
-    """ Decorator for making the cursor busy while a function is running """
+    """
+    Decorator for making the cursor busy while a function is running
+    Will run in the GUI thread, therefore blocking GUI interaction
+    """
     def wrapper(*args, **kwargs):
         # set busy cursor
         app = QtWidgets.QApplication.instance()
@@ -129,3 +132,50 @@ def busy_cursor(func):
         app.restoreOverrideCursor()
 
     return wrapper
+
+
+def set_cursor_busy():
+    app = QtWidgets.QApplication.instance()
+    app.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
+
+
+def reset_cursor():
+    app = QtWidgets.QApplication.instance()
+    app.restoreOverrideCursor()
+
+
+class BusyCursorThread(QtCore.QThread):
+    """
+    Thread to switch the cursor while a task is running.  Pushes the task to a
+    thread, allowing GUI interaction in the main thread.
+
+    To use, you should initialize this thread with the function/slot you want to
+    run in the thread.  Note the .start method used to kick off this thread must
+    be wrapped in a function in order to run... for some reason...
+
+    ``` python
+    busy_thread = BusyCursorThread(func=slot_to_run)
+
+    def run_thread():
+        busy_thread.start()
+
+    button.clicked.connect(run_thread)
+    ```
+    """
+    task_finished: ClassVar[QtCore.Signal] = QtCore.Signal()
+    task_starting: ClassVar[QtCore.Signal] = QtCore.Signal()
+    running: bool
+
+    def __init__(self, *args, func, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.func = func
+        self.running = False
+        self.task_starting.connect(set_cursor_busy)
+        self.task_finished.connect(reset_cursor)
+
+    def run(self) -> None:
+        # called from .start().  if called directly, will block current thread
+        self.task_starting.emit()
+        # run the attached method
+        self.func()
+        self.task_finished.emit()

--- a/atef/widgets/utils.py
+++ b/atef/widgets/utils.py
@@ -164,6 +164,7 @@ class BusyCursorThread(QtCore.QThread):
     """
     task_finished: ClassVar[QtCore.Signal] = QtCore.Signal()
     task_starting: ClassVar[QtCore.Signal] = QtCore.Signal()
+    raised_exception: ClassVar[QtCore.Signal] = QtCore.Signal()
     running: bool
 
     def __init__(self, *args, func, **kwargs):
@@ -177,5 +178,9 @@ class BusyCursorThread(QtCore.QThread):
         # called from .start().  if called directly, will block current thread
         self.task_starting.emit()
         # run the attached method
-        self.func()
-        self.task_finished.emit()
+        try:
+            self.func()
+        except Exception as ex:
+            self.raised_exception.emit(ex)
+        finally:
+            self.task_finished.emit()

--- a/atef/widgets/utils.py
+++ b/atef/widgets/utils.py
@@ -195,14 +195,12 @@ class BusyCursorThread(QtCore.QThread):
             self.task_finished.emit()
 
     def set_cursor_busy(self):
-        print('set_cursor')
         self.app = QtWidgets.QApplication.instance()
         self.app.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
         if self.ignore_events:
             self.app.installEventFilter(FILTER)
 
     def reset_cursor(self):
-        print('reset_cursor')
         self.app = QtWidgets.QApplication.instance()
         self.app.restoreOverrideCursor()
         if self.ignore_events:

--- a/atef/widgets/utils.py
+++ b/atef/widgets/utils.py
@@ -3,6 +3,7 @@ Non-core utilities. Primarily dynamic styling tools.
 """
 from typing import Optional
 
+from qtpy import QtWidgets
 from qtpy.QtCore import QEvent, QObject
 from qtpy.QtGui import QPalette
 from qtpy.QtWidgets import QLineEdit
@@ -100,3 +101,19 @@ def match_line_edit_text_width(
         text = line_edit.text()
     width = font_metrics.boundingRect(text).width()
     line_edit.setFixedWidth(max(width + buffer, minimum))
+
+
+def insert_widget(widget: QtWidgets.QWidget, placeholder: QtWidgets.QWidget) -> None:
+    """
+    Helper function for slotting e.g. data widgets into placeholders.
+    """
+    if placeholder.layout() is None:
+        layout = QtWidgets.QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        placeholder.setLayout(layout)
+    else:
+        old_widget = placeholder.layout().takeAt(0).widget()
+        if old_widget is not None:
+            # old_widget.setParent(None)
+            old_widget.deleteLater()
+    placeholder.layout().addWidget(widget)

--- a/atef/widgets/utils.py
+++ b/atef/widgets/utils.py
@@ -128,8 +128,10 @@ def busy_cursor(func):
         # set busy cursor
         app = QtWidgets.QApplication.instance()
         app.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
-        func(*args, **kwargs)
-        app.restoreOverrideCursor()
+        try:
+            func(*args, **kwargs)
+        finally:
+            app.restoreOverrideCursor()
 
     return wrapper
 
@@ -193,12 +195,14 @@ class BusyCursorThread(QtCore.QThread):
             self.task_finished.emit()
 
     def set_cursor_busy(self):
+        print('set_cursor')
         self.app = QtWidgets.QApplication.instance()
         self.app.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
         if self.ignore_events:
             self.app.installEventFilter(FILTER)
 
     def reset_cursor(self):
+        print('reset_cursor')
         self.app = QtWidgets.QApplication.instance()
         self.app.restoreOverrideCursor()
         if self.ignore_events:

--- a/atef/widgets/utils.py
+++ b/atef/widgets/utils.py
@@ -3,7 +3,7 @@ Non-core utilities. Primarily dynamic styling tools.
 """
 from typing import Optional
 
-from qtpy import QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import QEvent, QObject
 from qtpy.QtGui import QPalette
 from qtpy.QtWidgets import QLineEdit
@@ -117,3 +117,15 @@ def insert_widget(widget: QtWidgets.QWidget, placeholder: QtWidgets.QWidget) -> 
             # old_widget.setParent(None)
             old_widget.deleteLater()
     placeholder.layout().addWidget(widget)
+
+
+def busy_cursor(func):
+    """ Decorator for making the cursor busy while a function is running """
+    def wrapper():
+        # set busy cursor
+        app = QtWidgets.QApplication.instance()
+        app.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
+        func()
+        app.restoreOverrideCursor()
+
+    return wrapper

--- a/atef/widgets/utils.py
+++ b/atef/widgets/utils.py
@@ -121,11 +121,11 @@ def insert_widget(widget: QtWidgets.QWidget, placeholder: QtWidgets.QWidget) -> 
 
 def busy_cursor(func):
     """ Decorator for making the cursor busy while a function is running """
-    def wrapper():
+    def wrapper(*args, **kwargs):
         # set busy cursor
         app = QtWidgets.QApplication.instance()
         app.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
-        func()
+        func(*args, **kwargs)
         app.restoreOverrideCursor()
 
     return wrapper

--- a/docs/source/upcoming_release_notes/159-enh_set_value.rst
+++ b/docs/source/upcoming_release_notes/159-enh_set_value.rst
@@ -1,0 +1,26 @@
+159 enh_set_value
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Adds SetValueStep tothe active checkout suite, allowing for a list of actions to be taken (setting values to targets), followed by a list of checks (Comparisons) for verifying the actions succeeded.
+- Adds a ``TableWidgetWithAddRow``, a subclass of ``QTableWidget`` that includes a AddRowWidget. This add row contains a button for adding rows of a specified widget. (for better space efficiency)
+- Adds GUI support for placing a ``Comparison`` within a ``ProcedureStep``
+- Adds a busy cursor Thread worker (disables click interaction and changes to a wait cursor while a function runs) and a busy cursor decorator (not recommended, but necessary when wrapping slots that create widgets)
+
+Bugfixes
+--------
+- fixes type hint parsing in ``QDataclassBridge`` for Optional type hints.
+- carefully unsubscribes callbacks that might persist after toggling between run and edit mode, avoiding slots from referencing deleted RunTree widgets
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=45", "setuptools_scm[toml]>=6.2",]
 [project]
 classifiers = [ "Development Status :: 2 - Pre-Alpha", "Natural Language :: English", "Programming Language :: Python :: 3",]
 description = "Python Automated Test Execution Framework"
-dynamic = [ "version", "readme", "dependencies", "optional-dependencies", "optional-dependencies",]
+dynamic = [ "version", "readme", "dependencies", "optional-dependencies",]
 keywords = []
 name = "atef"
 requires-python = ">=3.9"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds a step called `SetValueStep`, for setting values to signals/components, then running a set of comparisons.  Actions are stored as a list of target-value dataclasses, and checks are stored as a list of target-comparison dataclasses.  Targets can be specified as either a device - attr combination or raw PV string.   

Along the way:
- adds `TableWIdgetWithAddRow`, a subclass of QTableWidget that includes a `AddRowWidget`. This add row contains a button for adding rows of a specified widget.  (for better space efficiency)
<img width="496" alt="image" src="https://user-images.githubusercontent.com/35379409/231898449-e0fe6d15-2f13-4f32-9d2a-a3f8f9abb206.png">

- gets overly fancy with signal/component selectors
<img width="362" alt="image" src="https://user-images.githubusercontent.com/35379409/230684945-5be09cf1-6d5e-4a2a-9312-a9f8d6930189.png">  <img width="363" alt="image" src="https://user-images.githubusercontent.com/35379409/230685122-ae52c2c0-4627-4318-af1f-bb23c233b66e.png">

- adds support for ProcedureSteps that also contains checks, I imagine this will become more common in the future
- Fixes type hint parsing in QDataClassBridge acfe193
- adds a busy cursor decorator and puts it in a few places.  Closes #143 

- Attempts to disconnect some slots on widget destruction (addressing a crash identical to #39 but from a different source)  Perhaps closes #39 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I wanted a basic action that can actually set PVs, at a very fine grained level.  I imagine this could serve as a fallback if other steps don't fit.

Notably missing (perhaps for followups, this is getting long)
- Option to use tools as checks (currently only ping?)
- look at drag and drop functionality for reordering TableWidgetWithAddRow
- keep tool menu open after component selection window, a QOL thing that I haven't figured out

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
interactively, and making sure the test suite passes.  Tested locally against the classic caproto random-walk IOC.
Existing test suite loads up the test config and toggles between edit and run, which makes sure the widgets all initialize

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings, partially so far

## Screenshots (if appropriate):
<img width="527" alt="image" src="https://user-images.githubusercontent.com/35379409/231898591-6d68e137-5196-49c7-b167-317f60a8e88d.png">
<img width="521" alt="image" src="https://user-images.githubusercontent.com/35379409/231898879-98460714-e37e-4e2e-977e-6a5755c982d8.png">
