### PR TITLE
ENH: allow Qt args on the command line

### DIFF
--- a/atef/bin/config.py
+++ b/atef/bin/config.py
@@ -54,7 +54,9 @@ def build_arg_parser(argparser=None):
 
     argparser.description = """
     Runs the atef configuration GUI, optionally with an existing configuration.
-    Qt arguments are also supported. For a full list, see the Qt docs: https://doc.qt.io/qt-5/qguiapplication.html#supported-command-line-options
+    Qt arguments are also supported. For a full list, see the Qt docs:
+    https://doc.qt.io/qt-5/qapplication.html#QApplication
+    https://doc.qt.io/qt-5/qguiapplication.html#supported-command-line-options
     """
 
     argparser.add_argument(

--- a/atef/bin/config.py
+++ b/atef/bin/config.py
@@ -3,10 +3,11 @@
 """
 import argparse
 import logging
+import sys
 from typing import List, Optional
 
 from pydm import exception
-from qtpy.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication, QStyleFactory
 
 from ..type_hints import AnyPath
 from ..widgets.config.window import Window
@@ -17,6 +18,39 @@ logger = logging.getLogger(__name__)
 def build_arg_parser(argparser=None):
     if argparser is None:
         argparser = argparse.ArgumentParser()
+
+    # Arguments that need to be passed through to Qt
+    qt_args = {
+        '-qmljsdebugger': 1,
+        '-reverse': '?',
+        '-stylesheet': 1,
+        '-widgetcount': '?',
+        '-platform': 1,
+        '-platformpluginpath': 1,
+        '-platformtheme': 1,
+        '-plugin': 1,
+        '-qwindowgeometry': 1,
+        '-qwindowicon': 1,
+        '-qwindowtitle': 1,
+        '-session': 1,
+        '-display': 1,
+        '-geometry': 1
+    }
+
+    for name in qt_args:
+        argparser.add_argument(
+            name,
+            type=str,
+            nargs=qt_args[name]
+        )
+
+    argparser.add_argument(
+        '-style',
+        type=str,
+        choices=QStyleFactory.keys(),
+        default='fusion' if sys.platform == 'darwin' else None,
+        help='Qt style to use for the application'
+    )
 
     argparser.add_argument(
         "filenames",
@@ -29,8 +63,8 @@ def build_arg_parser(argparser=None):
     return argparser
 
 
-def main(filenames: Optional[List[AnyPath]] = None):
-    app = QApplication([])
+def main(filenames: Optional[List[AnyPath]] = None, **kwargs):
+    app = QApplication(sys.argv)
     main_window = Window(show_welcome=not filenames)
     main_window.show()
     exception.install()

--- a/atef/bin/config.py
+++ b/atef/bin/config.py
@@ -21,20 +21,20 @@ def build_arg_parser(argparser=None):
 
     # Arguments that need to be passed through to Qt
     qt_args = {
-        '-qmljsdebugger': 1,
-        '-reverse': '?',
-        '-stylesheet': 1,
-        '-widgetcount': '?',
-        '-platform': 1,
-        '-platformpluginpath': 1,
-        '-platformtheme': 1,
-        '-plugin': 1,
-        '-qwindowgeometry': 1,
-        '-qwindowicon': 1,
-        '-qwindowtitle': 1,
-        '-session': 1,
-        '-display': 1,
-        '-geometry': 1
+        '--qmljsdebugger': 1,
+        '--reverse': '?',
+        '--stylesheet': 1,
+        '--widgetcount': '?',
+        '--platform': 1,
+        '--platformpluginpath': 1,
+        '--platformtheme': 1,
+        '--plugin': 1,
+        '--qwindowgeometry': 1,
+        '--qwindowicon': 1,
+        '--qwindowtitle': 1,
+        '--session': 1,
+        '--display': 1,
+        '--geometry': 1
     }
 
     for name in qt_args:
@@ -45,7 +45,7 @@ def build_arg_parser(argparser=None):
         )
 
     argparser.add_argument(
-        '-style',
+        '--style',
         type=str,
         choices=QStyleFactory.keys(),
         default='fusion' if sys.platform == 'darwin' else None,

--- a/atef/bin/config.py
+++ b/atef/bin/config.py
@@ -52,6 +52,11 @@ def build_arg_parser(argparser=None):
         help='Qt style to use for the application'
     )
 
+    argparser.description = """
+    Runs the atef configuration GUI, optionally with an existing configuration.
+    Qt arguments are also supported. For a full list, see the Qt docs: https://doc.qt.io/qt-5/qguiapplication.html#supported-command-line-options
+    """
+
     argparser.add_argument(
         "filenames",
         metavar="filename",

--- a/atef/bin/config.py
+++ b/atef/bin/config.py
@@ -48,7 +48,7 @@ def build_arg_parser(argparser=None):
         '--style',
         type=str,
         choices=QStyleFactory.keys(),
-        default='fusion' if sys.platform == 'darwin' else None,
+        default='fusion',
         help='Qt style to use for the application'
     )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Allows Qt command line arguments to be passed through on the command line. Prior to this PR specifying `-style` (or anything else `QGuiApplication` can accept) wasn't possible without argparse complaining.

`-style` is handled specially and will validate against currently available styles, and default to `fusion` on OSX (as per #154).

Closes #154

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Qt styling is somewhat operating system specific, which can lead to issues like described in #154. Sometimes it's also desirable to use a different platform plugin or stylesheet. For the most part, these command line arguments are an alternative to envvars Qt also understands.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally, should work on all systems.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->


## Screenshots (if appropriate):

`atef config -style windows`:
![Screenshot_20230425_134046](https://user-images.githubusercontent.com/19717056/234398533-12fbe972-383b-41bc-a8d6-1126271ef470.png)


