### PR TITLE
FIX: use integers for rect bounds with QIcon.paint

### DIFF
--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -8,7 +8,8 @@ from typing import (Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type,
 
 import qtawesome as qta
 from qtpy import QtCore, QtWidgets
-from qtpy.QtCore import QPoint, QPointF, QRectF, QRegularExpression, Qt
+from qtpy.QtCore import (QPoint, QPointF, QRect, QRectF, QRegularExpression,
+                         QSize, Qt)
 from qtpy.QtCore import Signal as QSignal
 from qtpy.QtGui import (QBrush, QClipboard, QColor, QGuiApplication, QPainter,
                         QPaintEvent, QPen, QRegularExpressionValidator)
@@ -535,9 +536,13 @@ class Toggle(QCheckBox):
         # the handle will move along this line
         trailLength = contRect.width() - 2 * handleRadius
         xPos = contRect.x() + handleRadius + trailLength * self._handle_position
-        iconRad = 0.7 * handleRadius
+        iconRad = int(0.7 * handleRadius)
         # center of handle
-        icon_x = xPos - (1.3 * handleRadius) + iconRad
+        icon_x = int(xPos - (1.3 * handleRadius) + iconRad)
+        iconRect = QRect(
+            QPoint(icon_x, round(barRect.center().y()) - iconRad),
+            QSize(2 * iconRad, 2 * iconRad)
+        )
 
         if self.isChecked():
             p.setBrush(self._bar_checked_brush)
@@ -549,8 +554,7 @@ class Toggle(QCheckBox):
             )
             icon = qta.icon(self.checked_icon,
                             color=QColor(self.checked_color).darker())
-            icon.paint(p, icon_x, round(barRect.center().y()) - iconRad,
-                       2 * iconRad, 2 * iconRad)
+            icon.paint(p, iconRect)
 
         else:
             p.setBrush(self._bar_brush)
@@ -562,8 +566,7 @@ class Toggle(QCheckBox):
                 handleRadius, handleRadius
             )
             icon = qta.icon(self.unchecked_icon)
-            icon.paint(p, icon_x, round(barRect.center().y()) - iconRad,
-                       2 * iconRad, 2 * iconRad)
+            icon.paint(p, iconRect)
 
         p.end()
 

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -538,7 +538,7 @@ class Toggle(QCheckBox):
         xPos = contRect.x() + handleRadius + trailLength * self._handle_position
         iconRad = int(0.7 * handleRadius)
         # center of handle
-        icon_x = int(xPos - (1.3 * handleRadius) + iconRad)
+        icon_x = int(xPos - (1.3 * handleRadius) + (1.3 * iconRad))
         iconRect = QRect(
             QPoint(icon_x, round(barRect.center().y()) - iconRad),
             QSize(2 * iconRad, 2 * iconRad)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Typing fix for bounds of `QIcon.paint`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This was raising a type error in my conda environment which I setup per the README. I'm not using the pcds conda environment though. I'm thinking this might be related to having Qt6 installed on my system. It seems to absolutely require `int` instead of `float` or another numeric type for `QRect` and `QSize`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally in a conda environment with python 3.10.11.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

Not documented anywhere

<!--
## Screenshots (if appropriate):
-->
