### PR TITLE
BUG: fix type handling, etc

### DIFF
--- a/atef/qt_helpers.py
+++ b/atef/qt_helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import functools
 import logging
 import platform
+from collections.abc import Sequence
 from typing import (Any, Callable, ClassVar, Dict, Generator, List, Optional,
                     Tuple, Type, get_args, get_origin, get_type_hints)
 
@@ -87,14 +88,16 @@ class QDataclassBridge(QObject):
             # Use dataclass value and override to object type
             NestedClass = QDataclassValue
             dtype = object
-        elif origin is list:
+        elif origin in (list, Sequence):
             # Make sure we have list manipulation methods
+            # Sequence resolved as from collections.abc (even if defined from typing)
             NestedClass = QDataclassList
             dtype = args[0]
         else:
             # some complex Union? e.g. Union[str, int, bool, float]
             # Optional hints also need to have a general signal to emit NoneType
             # (technically QSignal(str) works, but is it worth the special case?)
+            logger.debug(f'Unable to parse type hint: {type_hint} - ({origin}, {args})')
             NestedClass = QDataclassValue
             dtype = object
 

--- a/atef/widgets/config/data_passive.py
+++ b/atef/widgets/config/data_passive.py
@@ -699,11 +699,11 @@ class EqualsMixin:
             to_str=str,
         )
         starting_value = self.bridge.value.get()
+        self.data_type_combo.currentTextChanged.connect(self.new_gui_type)
         self.data_type_combo.setCurrentText(
             self.type_to_label[type(starting_value)]
         )
         self.update_range_label(starting_value)
-        self.data_type_combo.currentTextChanged.connect(self.new_gui_type)
         self.bridge.value.changed_value.connect(self.update_range_label)
         self.bridge.atol.changed_value.connect(self.update_range_label)
         self.bridge.rtol.changed_value.connect(self.update_range_label)

--- a/atef/widgets/config/data_passive.py
+++ b/atef/widgets/config/data_passive.py
@@ -1305,7 +1305,7 @@ class AnyValueWidget(DesignerDisplay, DataWidget):
         self.values_table.insertRow(new_row)
         value = value if value is not None else ''
         value_item = QTableWidgetItem()
-        value_item.setText(value)
+        value_item.setText(str(value))
         type_readback_widget = QLabel()
         type_readback_widget.setMargin(3)
         self.values_table.setItem(new_row, 0, value_item)

--- a/atef/widgets/happi.py
+++ b/atef/widgets/happi.py
@@ -153,6 +153,14 @@ class HappiSearchWidget(DesignerDisplay, QWidget):
             tree_selection_changed
         )
 
+        def item_double_clicked(index: QtCore.QModelIndex):
+            if index.parent().data() is None:
+                return  # skip top-level items
+
+            self.happi_items_chosen.emit([index.data()])
+
+        view.doubleClicked.connect(item_double_clicked)
+
         view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         view.customContextMenuRequested.connect(self._tree_view_context_menu)
 

--- a/docs/source/upcoming_release_notes/168-bug_types_etc.rst
+++ b/docs/source/upcoming_release_notes/168-bug_types_etc.rst
@@ -1,0 +1,25 @@
+168 bug_types_etc
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Cast values read from the config to a string in AnyValue widget
+- Properly identify up Sequences in QDataclassBridge
+- Sets the comparison widget type based on the loaded datatype
+- Allows device selection via double-click in the HappiSearchWidget tree-view
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Fixes a smattering of bugs I found while messing around with the GUI
* cast values read from the config to a string in AnyValue widget, closes #165 
* Pick up sequences in QDataclassBridge, closes #163 
  * As a consequence transitioning from hard-coded hint recognition, this bug was created.
* Sets the comparison widget type based on the loaded datatype.  closes #78 
* Allows device selection via double-click in the HappiSearchWidget tree-view 
  * Previously there was no way to select a device from this view (no right-click context menu, etc)

## Motivation and Context
Bug free please

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
This PR, and the issues they reference