### PR TITLE
GUI: improve Result refresh behavior

### DIFF
--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -583,6 +583,26 @@ class PreparedProcedureGroup(PreparedProcedureStep):
         self.step_result = result
         return self.result
 
+    @property
+    def result(self):
+        # gather step result before re-computing overall result, without running
+        results = []
+        for step in self.steps:
+            results.append(step.result)
+
+        if self.prepare_failures:
+            result = Result(
+                severity=Severity.error,
+                reason='At least one step failed to initialize'
+            )
+        else:
+            severity = _summarize_result_severity(GroupResultMode.all_, results)
+            result = Result(severity=severity)
+
+        self.step_result = result
+
+        return super().result
+
 
 @dataclass
 class PreparedDescriptionStep(PreparedProcedureStep):

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import asyncio
 import itertools
 import logging
-from typing import TYPE_CHECKING, Any, Generator, List, Optional, Union
+from typing import (TYPE_CHECKING, Any, ClassVar, Generator, List, Optional,
+                    Union)
 
 from qtpy import QtCore
 from qtpy.QtWidgets import (QDialogButtonBox, QLabel, QLayout, QLineEdit,
@@ -287,6 +288,8 @@ class RunCheck(DesignerDisplay, QWidget):
     run_next_spacer: QSpacerItem
     next_button: QPushButton
 
+    results_updated: ClassVar[QtCore.Signal] = QtCore.Signal()
+
     style_icons = {
         Severity.success: QStyle.SP_DialogApplyButton,
         Severity.warning : QStyle.SP_TitleBarContextHelpButton,
@@ -352,6 +355,7 @@ class RunCheck(DesignerDisplay, QWidget):
                     raise TypeError('incompatible type found: '
                                     f'{config_type}, {cfg}')
 
+                self.results_updated.emit()
                 self.update_all_icons_tooltips()
 
         # send this to a non-gui thread
@@ -452,7 +456,6 @@ class RunCheck(DesignerDisplay, QWidget):
             # Hide verify_run_spacer, not exposed by DesignerDisplay
             self.layout().itemAt(5).changeSize(0, 0)
         else:
-            # TODO: verify functionality for active checkouts
             # Set up verify button depending on settings
             widget = VerifyEntryWidget()
 
@@ -480,9 +483,11 @@ class RunCheck(DesignerDisplay, QWidget):
 
             def verify_success_slot():
                 set_verify(True)
+                self.results_updated.emit()
 
             def verify_fail_slot():
                 set_verify(False)
+                self.results_updated.emit()
 
             widget.verify_button_box.accepted.connect(verify_success_slot)
             widget.verify_button_box.rejected.connect(verify_fail_slot)

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -504,8 +504,7 @@ class RunTree(EditTree):
             prev_widget = run_widget
 
             # update all statuses every time a step is run
-            run_button: QtWidgets.QPushButton = run_widget.run_check.run_button
-            run_button.clicked.connect(self.update_statuses)
+            run_widget.run_check.results_updated.connect(self.update_statuses)
 
         # disable last 'next' button
         run_widget.run_check.next_button.hide()


### PR DESCRIPTION
## Description
* Uses signals to notify the GUI to refresh its result icons
* PreparedProcedureGroup now gathers available results from its children before returning the result
* PreparedConfiguration and PreparedGroup also now feature a `combined_result` field and `result` property that calculates the result given its children

## Motivation and Context
I wanted to have the result icons update more dynamically, and also not have to hit run on parent steps after running children steps

I was so stumped on this before and coming back to it with fresh eyes ... really helped/

## How Has This Been Tested?
Interactively so far. Tests have mostly involved opening the gui, opening up a group, running its children, then checking back in with the parent group. 

## Where Has This Been Documented?
This PR