### PR TITLE
MNT: wrap signal connection check in BusyCursorThread

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,13 @@
 <!--
 ## Screenshots (if appropriate):
 -->
+
+## Pre-merge checklist
+- [ ] Code works interactively
+- [ ] Code contains descriptive docstrings, including context and API
+- [ ] New/changed functions and methods are covered in the test suite where possible
+- [ ] Code has been checked for threading issues (no blocking tasks in GUI thread)
+- [ ] Test suite passes locally
+- [ ] Test suite passes on GitHub Actions
+- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
+- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate

--- a/atef/widgets/utils.py
+++ b/atef/widgets/utils.py
@@ -173,7 +173,7 @@ class BusyCursorThread(QtCore.QThread):
     """
     task_finished: ClassVar[QtCore.Signal] = QtCore.Signal()
     task_starting: ClassVar[QtCore.Signal] = QtCore.Signal()
-    raised_exception: ClassVar[QtCore.Signal] = QtCore.Signal()
+    raised_exception: ClassVar[QtCore.Signal] = QtCore.Signal(Exception)
 
     def __init__(self, *args, func, ignore_events: bool = False, **kwargs):
         super().__init__(*args, **kwargs)

--- a/docs/source/upcoming_release_notes/170-mnt_bgd_signal.rst
+++ b/docs/source/upcoming_release_notes/170-mnt_bgd_signal.rst
@@ -1,0 +1,22 @@
+170 mnt_bgd_signal
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- ``BusyCursorThread.raised_exception`` now properly expects to emit an ``Exception``
+
+Maintenance
+-----------
+- places a stray sig.wait_for_connection call into a ``BusyCursorThread``
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- Places a `signal.wait_for_connection` call into a background thread
- Makes the `BusyCursorThread.raised_exception` actually expect to emit an Exception

## Motivation and Context
Closes #170 

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate