### PR TITLE
MNT: Generally improve things related to signals, touch up reports default behavior

### DIFF
--- a/atef/report.py
+++ b/atef/report.py
@@ -786,8 +786,7 @@ class AtefReport(BaseDocTemplate):
             name of field in ``config`` that holds the name to be used in this header
             can be a dotted attribute (e.g. "origin.name" etc)
         default_header : Optional[str]
-            default header text.  If provided, this method will not try to
-            autogenerate a header from the config
+            default header text, will be used if ``field`` cannot be found on ``config``
         style : PS
             style to apply to the header Paragraph flowable
         """

--- a/atef/report.py
+++ b/atef/report.py
@@ -4,6 +4,7 @@ Report rendering framework
 
 import hashlib
 import logging
+from collections import defaultdict
 from dataclasses import fields
 from datetime import datetime
 from operator import attrgetter
@@ -563,6 +564,8 @@ class AtefReport(BaseDocTemplate):
         self.header_center_text = ''
         self.footer_center_text = ''
         self.approval_slots = 1
+        # for tracking untitled steps
+        self._text_called_count = defaultdict(lambda: 0)
 
     def afterFlowable(self, flowable: Flowable) -> None:
         """
@@ -751,15 +754,9 @@ class AtefReport(BaseDocTemplate):
         int
             number of times ``text`` has been called in this method
         """
-        if not hasattr(self, 'text_called_count'):
-            self.text_called_count = {}
+        self._text_called_count[text] += 1
 
-        if text in self.text_called_count:
-            self.text_called_count[text] += 1
-        else:
-            self.text_called_count[text] = 1
-
-        return self.text_called_count[text]
+        return self._text_called_count[text]
 
     def build_header_with_default(
         self,

--- a/atef/report.py
+++ b/atef/report.py
@@ -773,7 +773,7 @@ class AtefReport(BaseDocTemplate):
         Currently the top-level header-building helper method.
 
         Build a linked header with the attribute from the config if possible
-        create a placehodler title otherwise. Link it at the end
+        create a placeholder title otherwise. Link it at the end
 
         Parameters
         ----------

--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -222,5 +222,4 @@ def test_edit_run_toggle(qtbot: QtBot, config: os.PathLike):
     window.open_file(filename=str(config))
     toggle = window.tab_widget.widget(0).toggle
     toggle.setChecked(True)
-    toggle.setChecked(False)
     qtbot.addWidget(window)

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -980,6 +980,7 @@ class ActionRowWidget(TargetRowWidget):
     value_input_placeholder: QtWidgets.QWidget
     value_button_box: QtWidgets.QDialogButtonBox
     setting_button: QtWidgets.QToolButton
+    curr_val_thread: Optional[BusyCursorThread]
 
     def __init__(self, data: Optional[ValueToTarget] = None, **kwargs):
         self.curr_val_thread = None

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -982,6 +982,7 @@ class ActionRowWidget(TargetRowWidget):
     setting_button: QtWidgets.QToolButton
 
     def __init__(self, data: Optional[ValueToTarget] = None, **kwargs):
+        self.curr_val_thread = None
         if data is None:
             data = ValueToTarget()
         super().__init__(data=data, **kwargs)
@@ -1046,7 +1047,7 @@ class ActionRowWidget(TargetRowWidget):
             self.setup_input_widget(self._curr_value, self._dtype,
                                     enum_strs=self._enum_strs)
 
-        if hasattr(self, 'curr_val_thread') and self.curr_val_thread.isRunning():
+        if self.curr_val_thread and self.curr_val_thread.isRunning():
             logger.debug('thread is still running.  Ignore..')
             return
 

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -16,7 +16,7 @@ import datetime
 import logging
 import pathlib
 import pprint
-from typing import (Callable, ClassVar, Dict, Generator, List, Optional,
+from typing import (Any, Callable, ClassVar, Dict, Generator, List, Optional,
                     Sequence, Type, TypeVar, Union)
 
 import pydm
@@ -995,7 +995,6 @@ class ActionRowWidget(TargetRowWidget):
         apply_button.setToolTip('Click here to confirm value')
 
         self.setting_button.setToolTip('Configure action settings')
-        self.update_input_placeholder()
 
         self.setup_setting_button()
 
@@ -1022,23 +1021,63 @@ class ActionRowWidget(TargetRowWidget):
             self.value_button_box.hide()
             return
 
-        try:
-            curr_value = sig.get()
-            dtype = type(curr_value)
-        except TimeoutError:
-            curr_value = 'no data'
+        self._curr_value = None
+        self._dtype = None
+        self._enum_strs = None
+
+        def get_curr_value():
+            self._curr_value = sig.get()
+            self._dtype = type(self._curr_value)
+            self._enum_strs = getattr(sig, 'enum_strs', None)
+
+        def fail_get_value(ex: Exception):
+            logger.debug(f'failed to get signal data for input widget: {ex}')
+            self._curr_value = 'no data'
             # fall back to type in dataclass if available
             stored_value = self.bridge.value.get()
             if stored_value is not None:
-                dtype = type(stored_value)
+                self._dtype = type(stored_value)
             else:
-                dtype = float
+                self._dtype = float
 
+            run_setup_input_widget()
+
+        def run_setup_input_widget():
+            self.setup_input_widget(self._curr_value, self._dtype,
+                                    enum_strs=self._enum_strs)
+
+        if hasattr(self, 'curr_val_thread') and self.curr_val_thread.isRunning():
+            logger.debug('thread is still running.  Ignore..')
+            return
+
+        self.curr_val_thread = BusyCursorThread(func=get_curr_value)
+        self.curr_val_thread.raised_exception.connect(fail_get_value)
+        self.curr_val_thread.task_finished.connect(run_setup_input_widget)
+        self.curr_val_thread.start()
+
+    def setup_input_widget(
+        self,
+        curr_value: Any,
+        dtype: Any,
+        enum_strs: Optional[List[str]] = None
+    ) -> None:
+        """
+        Update the input widget given information from a signal
+
+        Parameters
+        ----------
+        curr_value : Any
+            the current value to set to the widget
+        dtype : Any
+            type of input expected
+        enum_strs : Optional[List[str]], optional
+            enum strings, by default None
+        """
         # Enum Case
-        if getattr(sig, 'enum_strs', None) is not None:
+        if enum_strs is not None:
             self.edit_widget = QtWidgets.QComboBox()
             self.edit_widget.setEditable(False)
-            for enum_str in sig.enum_strs:
+            for enum_str in enum_strs:
                 self.edit_widget.addItem(enum_str)
 
             def update_value():
@@ -1073,8 +1112,9 @@ class ActionRowWidget(TargetRowWidget):
             self.edit_widget.setValidator(validator)
             self.edit_widget.setPlaceholderText(f'({curr_value})')
             if self.bridge.value.get() is not None:
-                self.edit_widget.setText(str(self.bridge.value.get()))
-                self.edit_widget.setToolTip(str(self.bridge.value.get()))
+                if isinstance(self.bridge.value.get(), dtype):
+                    self.edit_widget.setText(str(self.bridge.value.get()))
+                    self.edit_widget.setToolTip(str(self.bridge.value.get()))
 
             # slot for value update on apply button press
             def update_value():

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -549,7 +549,7 @@ class RunTree(EditTree):
 
     def show_report_cust_prompt(self, info):
         """ generate a window allowing user to customize information """
-        msg = MultiInputDialog(init_values=info)
+        msg = MultiInputDialog(parent=self, init_values=info)
         msg.exec()
         return msg
 

--- a/atef/widgets/ophyd.py
+++ b/atef/widgets/ophyd.py
@@ -411,7 +411,7 @@ class PolledDeviceModel(QtCore.QAbstractTableModel):
         else:
             self.dataChanged.emit(
                 self.createIndex(row, DeviceColumn.readback),
-                self.createIndex(row, DeviceColumn.read_pvname),
+                self.createIndex(row, DeviceColumn.setpoint_pvname),
             )
 
     def get_data_for_row(self, row: int) -> Optional[OphydAttributeData]:

--- a/atef/widgets/ophyd.py
+++ b/atef/widgets/ophyd.py
@@ -122,9 +122,10 @@ class DeviceColumn(enum.IntEnum):
     attribute = 0
     readback = 1
     setpoint = 2
-    pvname = 3
+    read_pvname = 3
+    set_pvname = 4
 
-    total_columns = 4
+    total_columns = 5
 
 
 class _DevicePollThread(QtCore.QThread):
@@ -343,7 +344,8 @@ class PolledDeviceModel(QtCore.QAbstractTableModel):
             "Attribute",
             "Readback",
             "Setpoint",
-            "PV Name",
+            "Read PV Name",
+            "Setpoint PV Name"
         ]
         self.start()
 
@@ -409,7 +411,7 @@ class PolledDeviceModel(QtCore.QAbstractTableModel):
         else:
             self.dataChanged.emit(
                 self.createIndex(row, DeviceColumn.readback),
-                self.createIndex(row, DeviceColumn.pvname),
+                self.createIndex(row, DeviceColumn.read_pvname),
             )
 
     def get_data_for_row(self, row: int) -> Optional[OphydAttributeData]:
@@ -501,8 +503,10 @@ class PolledDeviceModel(QtCore.QAbstractTableModel):
                 return f"{info.readback} {units}"
             if column == DeviceColumn.setpoint:
                 return f"{info.setpoint}"
-            if column == DeviceColumn.pvname:
+            if column == DeviceColumn.read_pvname:
                 return info.pvname
+            if column == DeviceColumn.set_pvname:
+                return getattr(info.signal, 'setpoint_pvname', 'None')
             return ""
 
         if role == Qt.ToolTipRole:

--- a/docs/source/upcoming_release_notes/175-mnt_sig_imp.rst
+++ b/docs/source/upcoming_release_notes/175-mnt_sig_imp.rst
@@ -12,6 +12,7 @@ Features
 Bugfixes
 --------
 - Fixes optional type hint handling in ``QDataclassBridge`` (again)
+- Improve missing field handling in report generation
 
 Maintenance
 -----------

--- a/docs/source/upcoming_release_notes/175-mnt_sig_imp.rst
+++ b/docs/source/upcoming_release_notes/175-mnt_sig_imp.rst
@@ -1,0 +1,23 @@
+175 mnt_sig_imp
+###############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Adds Enum support to the ``SetValueStep``'s actions
+
+Bugfixes
+--------
+- Fixes optional type hint handling in ``QDataclassBridge`` (again)
+
+Maintenance
+-----------
+- Differentiates between read and write (set) PV's in ``OphydDeviceTableView``
+- Wraps signal.get call used for setting input type validators in ``BusyCursorThread``
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Honestly a grab-bag of various issues.
* Adds Enum support to the `SetValueStep`'s actions, closes #174 
* (attempts to) Fix optional type hint handling in `QDataclassBridge`
* Differentiates between read and write (set) PV's in `OphydDeviceTableView` -thing.  closes #173 
* Wraps signal.get call used for setting input type validators in BusyCursorThread

## Motivation and Context
Currently, `QDataclassBridge` handled optional field type hints by simply making a `QDataclassValue` with `object` as the expected type.  This worked as long as only the `changed_value` signal was used, but failed for hints such as `Optional[List[str]]`, since those often started looking for `QDataclassList` signals (`added_value`, `changed_value`, etc)

Report used to fail if users didn't add a name to their steps/checks.  Now we handle this a bit better
![image](https://github.com/pcdshub/atef/assets/35379409/f997b7a5-1f09-47ce-9760-18b4d0700fa5)

 
## How Has This Been Tested?
interactively, test suite runs. 

I need to start adding more tests.  Should I just make tests that click every button or something

## Where Has This Been Documented?
This PR


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
