### PR TITLE
GUI: Replace welcome dialog with welcome tab, enable closable tabs

### DIFF
--- a/atef/ui/config_window.ui
+++ b/atef/ui/config_window.ui
@@ -16,7 +16,11 @@
   <widget class="QWidget" name="central_widget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <widget class="QTabWidget" name="tab_widget"/>
+     <widget class="QTabWidget" name="tab_widget">
+      <property name="tabsClosable">
+       <bool>true</bool>
+      </property>
+     </widget>
     </item>
    </layout>
   </widget>

--- a/atef/ui/landing_page.ui
+++ b/atef/ui/landing_page.ui
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>405</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="welcome_label">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>20</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Welcome to Atef!</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="openExternalLinks">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <layout class="QVBoxLayout" name="left_vlayout">
+       <item>
+        <widget class="QLabel" name="start_label">
+         <property name="font">
+          <font>
+           <pointsize>15</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>Start:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="new_passive_button">
+         <property name="text">
+          <string>New Passive Checkout</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="new_active_button">
+         <property name="text">
+          <string>New Active Checkout</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="open_button">
+         <property name="text">
+          <string>Open ...</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="left_vspacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="exit_button">
+         <property name="text">
+          <string>Exit</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="right_vlayout">
+       <item>
+        <widget class="QLabel" name="examples_label">
+         <property name="font">
+          <font>
+           <pointsize>15</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>Examples</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="sample_passive_button">
+         <property name="text">
+          <string>Sample Passive Checkout</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="sample_active_button">
+         <property name="text">
+          <string>Sample Active Checkout</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="docs_label">
+         <property name="font">
+          <font>
+           <pointsize>15</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>Documentation:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="docs_button">
+         <property name="text">
+          <string>Open Documentation</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="source_button">
+         <property name="text">
+          <string>View source</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="right_vspacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -17,7 +17,7 @@ from typing import Dict, Optional, Union
 import qtawesome
 from apischema import ValidationError, deserialize, serialize
 from qtpy import QtWidgets
-from qtpy.QtCore import QTimer
+from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import (QAction, QFileDialog, QMainWindow, QMessageBox,
                             QTabWidget, QTreeWidget, QWidget)
 
@@ -79,7 +79,14 @@ class Window(DesignerDisplay, QMainWindow):
         self.action_print_report.triggered.connect(self.print_report)
         self.action_clear_results.triggered.connect(self.clear_results)
 
-        self.tab_widget.tabBar().setUsesScrollButtons(True)
+        tab_bar = self.tab_widget.tabBar()
+        # always use scroll area and never truncate file names
+        tab_bar.setUsesScrollButtons(True)
+        tab_bar.setElideMode(Qt.ElideNone)
+        # ensure tabbar close button on right, run toggle will be on left
+        tab_bar.setStyleSheet(
+            "QTabBar::close-button { subcontrol-position: right}"
+        )
 
         if show_welcome:
             QTimer.singleShot(0, self.welcome_user)

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -103,7 +103,7 @@ class Window(DesignerDisplay, QMainWindow):
             self.open_file, filename=TEST_CONFIG_PATH / 'active_test.json'
         ))
 
-        widget.sample_active_button.clicked.connect(partial(
+        widget.sample_passive_button.clicked.connect(partial(
             self.open_file, filename=TEST_CONFIG_PATH / 'all_fields.json'
         ))
 

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -79,11 +79,6 @@ class Window(DesignerDisplay, QMainWindow):
         self.action_print_report.triggered.connect(self.print_report)
         self.action_clear_results.triggered.connect(self.clear_results)
 
-        self.tab_widget.setTabsClosable(True)
-        self.tab_widget.tabCloseRequested.connect(
-            lambda idx: self.tab_widget.removeTab(idx)
-        )
-
         if show_welcome:
             QTimer.singleShot(0, self.welcome_user)
 
@@ -244,7 +239,11 @@ class Window(DesignerDisplay, QMainWindow):
         # set up edit-run toggle
         tab_bar = self.tab_widget.tabBar()
         widget.toggle.stateChanged.connect(widget.switch_mode)
-        tab_bar.setTabButton(curr_idx, QtWidgets.QTabBar.RightSide, widget.toggle)
+        tab_bar.setTabButton(curr_idx, QtWidgets.QTabBar.LeftSide, widget.toggle)
+        # set up close button
+        self.tab_widget.tabCloseRequested.connect(
+            lambda idx: self.tab_widget.removeTab(idx)
+        )
 
     def save(self, *args, **kwargs):
         """

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -7,10 +7,14 @@ import json
 import logging
 import os
 import os.path
+import webbrowser
 from copy import deepcopy
+from functools import partial
+from pathlib import Path
 from pprint import pprint
 from typing import Dict, Optional, Union
 
+import qtawesome
 from apischema import ValidationError, deserialize, serialize
 from qtpy import QtWidgets
 from qtpy.QtCore import QTimer
@@ -34,6 +38,8 @@ from .run_base import (get_prepared_step, get_relevant_configs_comps,
 from .utils import MultiInputDialog, Toggle, clear_results
 
 logger = logging.getLogger(__name__)
+
+TEST_CONFIG_PATH = Path(__file__).parent.parent.parent / 'tests' / 'configs'
 
 
 class Window(DesignerDisplay, QMainWindow):
@@ -72,24 +78,46 @@ class Window(DesignerDisplay, QMainWindow):
         )
         self.action_print_report.triggered.connect(self.print_report)
         self.action_clear_results.triggered.connect(self.clear_results)
+
+        self.tab_widget.setTabsClosable(True)
+        self.tab_widget.tabCloseRequested.connect(
+            lambda idx: self.tab_widget.removeTab(idx)
+        )
+
         if show_welcome:
             QTimer.singleShot(0, self.welcome_user)
 
     def welcome_user(self):
         """
         On open, ask the user what they'd like to do (new config? load?)
+
+        Set up the landing page
         """
-        welcome_box = QMessageBox(self)
-        welcome_box.setIcon(QMessageBox.Question)
-        welcome_box.setWindowTitle('Welcome')
-        welcome_box.setText('Welcome to atef config!')
-        welcome_box.setInformativeText('Please select a startup action')
-        open_button = welcome_box.addButton(QMessageBox.Open)
-        new_button = welcome_box.addButton('New', QMessageBox.AcceptRole)
-        welcome_box.addButton(QMessageBox.Close)
-        open_button.clicked.connect(self.open_file)
-        new_button.clicked.connect(self.new_file)
-        welcome_box.exec()
+        widget = LandingPage()
+        self.tab_widget.addTab(widget, 'Welcome to Atef!')
+        curr_idx = self.tab_widget.count() - 1
+        self.tab_widget.setCurrentIndex(curr_idx)
+
+        widget.new_passive_button.clicked.connect(
+            partial(self.new_file, checkout_type='passive')
+        )
+        widget.new_active_button.clicked.connect(
+            partial(self.new_file, checkout_type='active')
+        )
+        widget.sample_active_button.clicked.connect(partial(
+            self.open_file, filename=TEST_CONFIG_PATH / 'active_test.json'
+        ))
+
+        widget.sample_active_button.clicked.connect(partial(
+            self.open_file, filename=TEST_CONFIG_PATH / 'all_fields.json'
+        ))
+
+        widget.open_button.clicked.connect(self.open_file)
+        widget.exit_button.clicked.connect(self.close_all)
+
+    def close_all(self):
+        qapp = QtWidgets.QApplication.instance()
+        qapp.closeAllWindows()
 
     def _passive_or_active(self) -> str:
         """
@@ -139,14 +167,15 @@ class Window(DesignerDisplay, QMainWindow):
         """
         return self.tab_widget.currentWidget().get_tree()
 
-    def new_file(self, *args, **kwargs):
+    def new_file(self, *args, checkout_type: Optional[str] = None, **kwargs):
         """
         Create and populate a new edit tab.
 
         The parameters are open as to accept inputs from any signal.
         """
         # prompt user to select checkout type
-        checkout_type = self._passive_or_active()
+        if checkout_type is None:
+            checkout_type = self._passive_or_active()
         if checkout_type == 'passive':
             data = ConfigurationFile()
         elif checkout_type == 'active':
@@ -327,6 +356,39 @@ class Window(DesignerDisplay, QMainWindow):
                 clear_results(config_file)
 
             current_tree.update_statuses()
+
+
+class LandingPage(DesignerDisplay, QWidget):
+    """ Landing Page for selecting a subsequent action """
+    filename = 'landing_page.ui'
+
+    new_passive_button: QtWidgets.QPushButton
+    new_active_button: QtWidgets.QPushButton
+    open_button: QtWidgets.QPushButton
+    exit_button: QtWidgets.QPushButton
+
+    sample_passive_button: QtWidgets.QPushButton
+    sample_active_button: QtWidgets.QPushButton
+    docs_button: QtWidgets.QPushButton
+    source_button: QtWidgets.QPushButton
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setup_ui()
+
+    def setup_ui(self):
+        # icons for buttons
+        self.open_button.setIcon(qtawesome.icon('fa.folder-open-o'))
+        self.exit_button.setIcon(qtawesome.icon('fa.close'))
+        self.new_passive_button.setIcon(qtawesome.icon('fa.file-text-o'))
+        self.new_active_button.setIcon(qtawesome.icon('fa.file-code-o'))
+        # links for buttons... maybe
+        self.docs_button.clicked.connect(
+            lambda: webbrowser.open('https://confluence.slac.stanford.edu/display/PCDS/atef')
+        )
+        self.source_button.clicked.connect(
+            lambda: webbrowser.open('https://github.com/pcdshub/atef/tree/master')
+        )
 
 
 class EditTree(DesignerDisplay, QWidget):

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -79,6 +79,8 @@ class Window(DesignerDisplay, QMainWindow):
         self.action_print_report.triggered.connect(self.print_report)
         self.action_clear_results.triggered.connect(self.clear_results)
 
+        self.tab_widget.tabBar().setUsesScrollButtons(True)
+
         if show_welcome:
             QTimer.singleShot(0, self.welcome_user)
 

--- a/docs/source/upcoming_release_notes/176-gui_landing_page.rst
+++ b/docs/source/upcoming_release_notes/176-gui_landing_page.rst
@@ -1,0 +1,23 @@
+176 gui_landing_page
+####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Replaces the welcome dialog with a welcome landing tab
+- Enable the close-tab button
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- Replace the welcome dialog with a landing tab, closes #151 
- Set up close buttons, and move run-toggle to reveal it

## Motivation and Context
I grow tired of users losing the welcome splash in their array of 6 monitors and complaining atef is frozen.

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
This PR

![image](https://github.com/pcdshub/atef/assets/35379409/2b37afe6-1a26-4f56-b971-52cbfb41fb42)

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
