### PR TITLE
BUG: fix observed value report output

### DIFF
--- a/atef/report.py
+++ b/atef/report.py
@@ -349,15 +349,18 @@ def build_data_table(
     story.append(Paragraph('Observed Data', l0))
     # use cached value.
     observed_value = getattr(comp, 'data', 'N/A')
-    if not observed_value:
+    if observed_value is None:
         # attr can be set to None
         observed_value = 'N/A'
     observed_value = Paragraph(str(observed_value), styles['BodyText'])
     try:
-        timestamp = comp.signal.timestamp.ctime()
-        source = Paragraph(getattr(comp.signal, 'name', ''), styles['BodyText'])
+        timestamp = datetime.fromtimestamp(comp.signal.timestamp).ctime()
     except AttributeError:
         timestamp = 'unknown'
+
+    try:
+        source = Paragraph(getattr(comp.signal, 'name', ''), styles['BodyText'])
+    except AttributeError:
         source = 'undefined'
     observed_data = [['Observed Value', 'Timestamp', 'Source'],
                      [observed_value, timestamp, source]]

--- a/docs/source/upcoming_release_notes/183-bug_report_val.rst
+++ b/docs/source/upcoming_release_notes/183-bug_report_val.rst
@@ -1,0 +1,22 @@
+183 bug_report_val
+##################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fixes a bug where False-y observed values would fail to be reported
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Fixes a quick bug, the observed value could be False-y (e.g. 0), and skip the whole block.  also cleans up try blocks

## Motivation and Context
Make sure reports always report actual observed values 

## How Has This Been Tested?
Interactively 

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [X] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
