### PR TITLE
MNT: Better mode switch handling, icon refresh

### DIFF
--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -231,6 +231,7 @@ def test_edit_run_toggle(qtbot: QtBot, config: os.PathLike):
     toggle = window.tab_widget.widget(0).toggle
     toggle.setChecked(True)
     qtbot.waitSignal(window.tab_widget.currentWidget().mode_switch_finished)
+    assert window.tab_widget.widget(0).mode == 'run'
 
 
 def test_open_happi_viewer(qtbot: QtBot, happi_client: happi.Client):

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -259,8 +259,8 @@ class ResultStatus(QLabel):
 
     def event(self, event: QtCore.QEvent) -> bool:
         """ Overload event method to update tooltips on tooltip-request """
-        # Catch tooltip events to update status tooltip
-        if event.type() == QtCore.QEvent.ToolTip:
+        # Catch relevant events to update status tooltip
+        if event.type() in (QtCore.QEvent.ToolTip, QtCore.QEvent.Paint):
             self.update()
         return super().event(event)
 

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import os.path
+import traceback
 import webbrowser
 from copy import deepcopy
 from functools import partial
@@ -701,6 +702,13 @@ class DualTree(QWidget):
                 self.toggle.setChecked(prev_toggle_state)
                 self.show_widgets()
 
+            warning_msg = QMessageBox(QMessageBox.Critical, 'Warning',
+                                      'Mode Switch Failed')
+            warning_msg.setInformativeText('Your checkout may be misconfigured.')
+            warning_msg.setDetailedText(
+                ''.join(traceback.format_exception(None, ex, ex.__traceback__))
+            )
+            warning_msg.exec()
             QTimer.singleShot(0, reset_to_edit)
         finally:
             self.mode_switch_finished.emit()

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -679,19 +679,29 @@ class DualTree(QWidget):
 
         return self.trees[mode]
 
-    def switch_mode(self) -> None:
+    def switch_mode(self, value) -> None:
         """ Switch tree modes between 'edit' and 'run' """
-        # TODO: can this switching be made more elegant?
+        if (not value and self.mode == 'edit') or (value and self.mode == 'run'):
+            return
+
         set_wait_cursor()
         try:
             self.mode_switch_finished.connect(reset_cursor)
-            if self.mode == 'edit':
+            prev_toggle_state = not self.toggle.isChecked()
+            if value:
                 self.mode = 'run'
             else:
                 self.mode = 'edit'
             self.show_widgets()
         except Exception as ex:
             logger.exception(ex)
+            # reset toggle and mode
+
+            def reset_to_edit():
+                self.toggle.setChecked(prev_toggle_state)
+                self.show_widgets()
+
+            QTimer.singleShot(0, reset_to_edit)
         finally:
             self.mode_switch_finished.emit()
             self.mode_switch_finished.disconnect(reset_cursor)

--- a/docs/source/upcoming_release_notes/186-bug_pre_tag.rst
+++ b/docs/source/upcoming_release_notes/186-bug_pre_tag.rst
@@ -1,0 +1,23 @@
+186 bug_pre_tag
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Improves ResultStatus refresh handling, now also updates on paint events
+- In the case of errors during a mode switch, the error will be revealed to the user and the switch will be reverted.
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Fixes up a couple things before tagging
- Refreshes the Result icons on paint events, so they should update every time they are brought into focus
- Improves handling when a mode switch (edit <-> run) fails.  Previously this would fail but the toggle would switch, requiring a program restart

## Motivation and Context
I was hoping to fix more bugs but I gave myself a deadline and I can't reproduce the bugs I saw when Tong was running.  🤷 

## How Has This Been Tested?
Tossing Exceptions in the middle of the switch_mode block, but otherwise just running the test suite

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
