### PR TITLE
ENH: Add a bluesky-plan step

### DIFF
--- a/atef/annotated_plans.py
+++ b/atef/annotated_plans.py
@@ -1,0 +1,574 @@
+"""
+Plans with additional annotations to facilitate gui auto-generation
+In the future this should probably be pulled out into a separate repository
+as it will probably see considerable use
+"""
+from typing import (Any, Callable, Dict, Generator, Iterable, List, Optional,
+                    Union)
+
+import bluesky.plans as bp
+from bluesky_queueserver import parameter_annotation_decorator
+
+
+def add_docstring_from(func):
+    def wrapper(orig_func):
+        if not orig_func.__doc__:
+            orig_func.__doc__ = ""
+        orig_func.__doc__ += (func.__doc__ or "")
+        return orig_func
+
+    return wrapper
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "num": {"annotation": "int"},
+        "delay": {"annotation": "typing.Union[typing.Iterable[float], float]"},
+    }
+})
+@add_docstring_from(bp.count)
+def count(
+    detectors: List[Any],
+    num: int = 1,
+    delay: Union[Iterable[Union[float, int]], float, int] = None,
+    *,
+    per_shot: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.count(detectors, num, delay, per_shot=per_shot, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+    }
+})
+@add_docstring_from(bp.list_scan)
+def list_scan(
+    detectors: List[Any],
+    *args,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.list_scan(detectors, *args, per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+    }
+})
+@add_docstring_from(bp.rel_list_scan)
+def rel_list_scan(
+    detectors: List[Any],
+    *args,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.rel_list_scan(detectors, *args, per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+    }
+})
+@add_docstring_from(bp.list_grid_scan)
+def list_grid_scan(
+    detectors: List[Any],
+    *args,
+    snake_axes: bool = False,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.list_grid_scan(detectors, *args, snake_axes, per_step=per_step,
+                                 md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+    }
+})
+@add_docstring_from(bp.rel_list_grid_scan)
+def rel_list_grid_scan(
+    detectors: List[Any],
+    *args,
+    snake_axes: bool = False,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.rel_list_grid_scan(detectors, *args, snake_axes,
+                                     per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motor": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.log_scan)
+def log_scan(
+    detectors: List[Any],
+    motor: Any,
+    start: float,
+    stop: float,
+    num: int,
+    *,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.log_scan(detectors, motor, start, stop, num,
+                           per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motor": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.rel_log_scan)
+def rel_log_scan(
+    detectors: List[Any],
+    motor: Any,
+    start: float,
+    stop: float,
+    num: int,
+    *,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.rel_log_scan(detectors, motor, start, stop, num,
+                               per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motor": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.adaptive_scan)
+def adaptive_scan(
+    detectors: List[Any],
+    target_field: str,
+    motor: Any,
+    start: float,
+    stop: float,
+    min_step: float,
+    max_step: float,
+    target_delta: float,
+    backstep: bool,
+    threshold: float = 0.8,
+    *,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.adaptive_scan(detectors, target_field, motor, start, stop,
+                                min_step, max_step, target_delta, backstep,
+                                threshold, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motor": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.rel_adaptive_scan)
+def rel_adaptive_scan(
+    detectors: List[Any],
+    target_field: str,
+    motor: Any,
+    start: float,
+    stop: float,
+    min_step: float,
+    max_step: float,
+    target_delta: float,
+    backstep: bool,
+    threshold: float = 0.8,
+    *,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.rel_adaptive_scan(detectors, target_field, motor, start, stop,
+                                    min_step, max_step, target_delta, backstep,
+                                    threshold, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motor": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.tune_centroid)
+def tune_centroid(
+    detectors: List[Any],
+    signal: str,
+    motor: Any,
+    start: float,
+    stop: float,
+    min_step: float,
+    num: int = 10,
+    step_factor: float = 3.0,
+    snake: bool = False,
+    *,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.tune_centroid(detectors, signal, motor, start, stop,
+                                min_step, num, step_factor, snake, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+    }
+})
+@add_docstring_from(bp.scan_nd)
+def scan_nd(
+    detectors: List[Any],
+    cycler: Any,
+    *,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.scan_nd(detectors, cycler, per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+    }
+})
+@add_docstring_from(bp.scan)
+def scan(
+    detectors: List[Any],
+    *args,
+    num: Optional[int] = None,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.scan(detectors, *args, num=num, per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+    }
+})
+@add_docstring_from(bp.inner_product_scan)
+def inner_product_scan(
+    detectors: List[Any],
+    num: int,
+    *args,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.inner_product_scan(detectors, num, *args, per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+    }
+})
+@add_docstring_from(bp.grid_scan)
+def grid_scan(
+    detectors: List[Any],
+    *args,
+    snake_axes: Optional[Union[bool, Iterable[Any]]] = None,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.grid_scan(detectors, *args, snake_axes=snake_axes,
+                            per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+    }
+})
+@add_docstring_from(bp.rel_grid_scan)
+def rel_grid_scan(
+    detectors: List[Any],
+    *args,
+    snake_axes: Optional[Union[bool, Iterable[Any]]] = None,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.rel_grid_scan(detectors, *args, snake_axes=snake_axes,
+                                per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+    }
+})
+@add_docstring_from(bp.relative_inner_product_scan)
+def relative_inner_product_scan(
+    detectors: List[Any],
+    num: int,
+    *args,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.relative_inner_product_scan(detectors, num, *args,
+                                              per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+    }
+})
+@add_docstring_from(bp.rel_scan)
+def rel_scan(
+    detectors: List[Any],
+    *args,
+    num: Optional[int] = None,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.rel_scan(detectors, *args, num=num, per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detector": {"annotation": "__DEVICE__"},
+        "motor": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.tweak)
+def tweak(
+    detector: Any,
+    target_field: str,
+    motor: Any,
+    step: float,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.tweak(detector, target_field, motor, step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "x_motor": {"annotation": "__DEVICE__"},
+        "y_motor": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.spiral_fermat)
+def spiral_fermat(
+    detectors: List[Any],
+    x_motor: Any,
+    y_motor: Any,
+    x_start: float,
+    y_start: float,
+    x_range: float,
+    y_range: float,
+    dr: float,
+    factor: float,
+    *,
+    dr_y: Optional[float] = None,
+    tilt: Optional[float] = 0.0,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.spiral_fermat(detectors, x_motor, y_motor, x_start, y_start,
+                                x_range, y_range, dr, factor, dr_y=dr_y, tilt=tilt,
+                                per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "x_motor": {"annotation": "__DEVICE__"},
+        "y_motor": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.rel_spiral_fermat)
+def rel_spiral_fermat(
+    detectors: List[Any],
+    x_motor: Any,
+    y_motor: Any,
+    x_range: float,
+    y_range: float,
+    dr: float,
+    factor: float,
+    *,
+    dr_y: Optional[float] = None,
+    tilt: Optional[float] = 0.0,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.rel_spiral_fermat(detectors, x_motor, y_motor, x_range, y_range,
+                                    dr, factor, dr_y=dr_y, tilt=tilt,
+                                    per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "x_motor": {"annotation": "__DEVICE__"},
+        "y_motor": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.spiral)
+def spiral(
+    detectors: List[Any],
+    x_motor: Any,
+    y_motor: Any,
+    x_start: float,
+    y_start: float,
+    x_range: float,
+    y_range: float,
+    dr: float,
+    nth: float,
+    *,
+    dr_y: Optional[float] = None,
+    tilt: Optional[float] = 0.0,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.spiral(detectors, x_motor, y_motor, x_start, y_start,
+                         x_range, y_range, dr, nth, dr_y=dr_y, tilt=tilt,
+                         per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "x_motor": {"annotation": "__DEVICE__"},
+        "y_motor": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.rel_spiral)
+def rel_spiral(
+    detectors: List[Any],
+    x_motor: Any,
+    y_motor: Any,
+    x_range: float,
+    y_range: float,
+    dr: float,
+    nth: float,
+    *,
+    dr_y: Optional[float] = None,
+    tilt: Optional[float] = 0.0,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.rel_spiral(detectors, x_motor, y_motor, x_range, y_range,
+                             dr, nth, dr_y=dr_y, tilt=tilt, per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "x_motor": {"annotation": "__DEVICE__"},
+        "y_motor": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.spiral_square)
+def spiral_square(
+    detectors: List[Any],
+    x_motor: Any,
+    y_motor: Any,
+    x_center: float,
+    y_center: float,
+    x_range: float,
+    y_range: float,
+    x_num: float,
+    y_num: float,
+    *,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.spiral_square(detectors, x_motor, y_motor, x_center, y_center,
+                                x_range, y_range, x_num, y_num,
+                                per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "x_motor": {"annotation": "__DEVICE__"},
+        "y_motor": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.rel_spiral_square)
+def rel_spiral_square(
+    detectors: List[Any],
+    x_motor: Any,
+    y_motor: Any,
+    x_range: float,
+    y_range: float,
+    x_num: float,
+    y_num: float,
+    *,
+    per_step: Optional[Callable] = None,
+    md: Optional[Dict[str, Any]] = None
+):
+    yield from bp.rel_spiral_square(detectors, x_motor, y_motor,
+                                    x_range, y_range, x_num, y_num,
+                                    per_step=per_step, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "go_plan": {"annotation": "__PLAN__"},
+        "monitor_sig": {"annotation": "__DEVICE__"},
+        "inner_plan_func": {"annotation": "__PLAN__"},
+    }
+})
+@add_docstring_from(bp.ramp_plan)
+def ramp_plan(
+    go_plan: Generator,
+    monitor_sig: Any,
+    inner_plan_func: Callable,
+    take_pre_data: bool = True,
+    timeout: Optional[float] = None,
+    period: Optional[float] = None,
+    md: Dict[str, Any] = None
+):
+    yield from bp.ramp_plan(go_plan, monitor_sig, inner_plan_func, take_pre_data,
+                            timeout=timeout, period=period, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "flyers": {"annotation": "typing.List[__DEVICE__]"},
+    }
+})
+@add_docstring_from(bp.fly)
+def fly(
+    flyers: List[Any],
+    *,
+    md: Dict[str, Any] = None
+):
+    yield from bp.fly(flyers, md=md)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motor1": {"annotation": "__DEVICE__"},
+        "motor2": {"annotation": "__DEVICE__"},
+    }
+})
+@add_docstring_from(bp.x2x_scan)
+def x2x_scan(
+    detectors: List[Any],
+    motor1: Any,
+    motor2: Any,
+    start: float,
+    stop: float,
+    num: int,
+    *,
+    per_step: Optional[Callable] = None,
+    md: Optional[Callable] = None
+):
+    yield from bp.x2x_scan(detectors, motor1, motor2, start, stop, num,
+                           per_step=per_step, md=md)

--- a/atef/annotated_plans.py
+++ b/atef/annotated_plans.py
@@ -4,7 +4,7 @@ In the future this should probably be pulled out into a separate repository
 as it will probably see considerable use
 """
 from typing import (Any, Callable, Dict, Generator, Iterable, List, Optional,
-                    Union)
+                    Tuple, Union)
 
 import bluesky.plans as bp
 from bluesky_queueserver import parameter_annotation_decorator
@@ -42,64 +42,80 @@ def count(
 @parameter_annotation_decorator({
     "parameters": {
         "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motors": {"annotation": "typing.List[__DEVICE__]"},
+        "point_lists": {"annotation": "typing.List[typing.List[float]]"},
     }
 })
 @add_docstring_from(bp.list_scan)
 def list_scan(
     detectors: List[Any],
-    *args,
+    motors: List[Any],
+    point_lists: List[List[float]],
     per_step: Optional[Callable] = None,
     md: Optional[Dict[str, Any]] = None
 ):
-    yield from bp.list_scan(detectors, *args, per_step=per_step, md=md)
+    motor_args = [val for pair in zip(motors, point_lists) for val in pair]
+    yield from bp.list_scan(detectors, *motor_args, per_step=per_step, md=md)
 
 
 @parameter_annotation_decorator({
     "parameters": {
         "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motors": {"annotation": "typing.List[__DEVICE__]"},
+        "point_lists": {"annotation": "typing.List[typing.List[float]]"},
     }
 })
 @add_docstring_from(bp.rel_list_scan)
 def rel_list_scan(
     detectors: List[Any],
-    *args,
+    motors: List[Any],
+    point_lists: List[List[float]],
     per_step: Optional[Callable] = None,
     md: Optional[Dict[str, Any]] = None
 ):
-    yield from bp.rel_list_scan(detectors, *args, per_step=per_step, md=md)
+    motor_args = [val for pair in zip(motors, point_lists) for val in pair]
+    yield from bp.rel_list_scan(detectors, *motor_args, per_step=per_step, md=md)
 
 
 @parameter_annotation_decorator({
     "parameters": {
         "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motors": {"annotation": "typing.List[__DEVICE__]"},
+        "point_lists": {"annotation": "typing.List[typing.List[float]]"},
     }
 })
 @add_docstring_from(bp.list_grid_scan)
 def list_grid_scan(
     detectors: List[Any],
-    *args,
+    motors: List[Any],
+    point_lists: List[List[float]],
     snake_axes: bool = False,
     per_step: Optional[Callable] = None,
     md: Optional[Dict[str, Any]] = None
 ):
-    yield from bp.list_grid_scan(detectors, *args, snake_axes, per_step=per_step,
-                                 md=md)
+    motor_args = [val for pair in zip(motors, point_lists) for val in pair]
+    yield from bp.list_grid_scan(detectors, *motor_args, snake_axes,
+                                 per_step=per_step, md=md)
 
 
 @parameter_annotation_decorator({
     "parameters": {
         "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motors": {"annotation": "typing.List[__DEVICE__]"},
+        "point_lists": {"annotation": "typing.List[typing.List[float]]"},
     }
 })
 @add_docstring_from(bp.rel_list_grid_scan)
 def rel_list_grid_scan(
     detectors: List[Any],
-    *args,
+    motors: List[Any],
+    point_lists: List[List[float]],
     snake_axes: bool = False,
     per_step: Optional[Callable] = None,
     md: Optional[Dict[str, Any]] = None
 ):
-    yield from bp.rel_list_grid_scan(detectors, *args, snake_axes,
+    motor_args = [val for pair in zip(motors, point_lists) for val in pair]
+    yield from bp.rel_list_grid_scan(detectors, *motor_args, snake_axes,
                                      per_step=per_step, md=md)
 
 
@@ -240,100 +256,125 @@ def scan_nd(
 @parameter_annotation_decorator({
     "parameters": {
         "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motors": {"annotation": "typing.List[__DEVICE__]"},
+        "limits": {"annotation": "typing.List[typing.Tuple[float, float]]"},
     }
 })
 @add_docstring_from(bp.scan)
 def scan(
     detectors: List[Any],
-    *args,
+    motors: List[Any],
+    limits: List[Tuple[float, float]],
     num: Optional[int] = None,
     per_step: Optional[Callable] = None,
     md: Optional[Dict[str, Any]] = None
 ):
-    yield from bp.scan(detectors, *args, num=num, per_step=per_step, md=md)
+    motor_args = [item for tup in zip(motors, *zip(*limits)) for item in tup]
+    yield from bp.scan(detectors, *motor_args, num=num, per_step=per_step, md=md)
 
 
 @parameter_annotation_decorator({
     "parameters": {
         "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motors": {"annotation": "typing.List[__DEVICE__]"},
+        "limits": {"annotation": "typing.List[typing.Tuple[float, float]]"},
     }
 })
 @add_docstring_from(bp.inner_product_scan)
 def inner_product_scan(
     detectors: List[Any],
     num: int,
-    *args,
+    motors: List[Any],
+    limits: List[Tuple[float, float]],
     per_step: Optional[Callable] = None,
     md: Optional[Dict[str, Any]] = None
 ):
-    yield from bp.inner_product_scan(detectors, num, *args, per_step=per_step, md=md)
+    motor_args = [item for tup in zip(motors, *zip(*limits)) for item in tup]
+    yield from bp.inner_product_scan(detectors, num, *motor_args,
+                                     per_step=per_step, md=md)
 
 
 @parameter_annotation_decorator({
     "parameters": {
         "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motors": {"annotation": "typing.List[__DEVICE__]"},
+        "limits": {"annotation": "typing.List[typing.Tuple[float, float, int]]"},
     }
 })
 @add_docstring_from(bp.grid_scan)
 def grid_scan(
     detectors: List[Any],
-    *args,
+    motors: List[Any],
+    limits: List[Tuple[float, float, int]],
     snake_axes: Optional[Union[bool, Iterable[Any]]] = None,
     per_step: Optional[Callable] = None,
     md: Optional[Dict[str, Any]] = None
 ):
-    yield from bp.grid_scan(detectors, *args, snake_axes=snake_axes,
+    motor_args = [item for tup in zip(motors, *zip(*limits)) for item in tup]
+    yield from bp.grid_scan(detectors, *motor_args, snake_axes=snake_axes,
                             per_step=per_step, md=md)
 
 
 @parameter_annotation_decorator({
     "parameters": {
         "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motors": {"annotation": "typing.List[__DEVICE__]"},
+        "limits": {"annotation": "typing.List[typing.Tuple[float, float, int]]"},
     }
 })
 @add_docstring_from(bp.rel_grid_scan)
 def rel_grid_scan(
     detectors: List[Any],
-    *args,
+    motors: List[Any],
+    limits: List[Tuple[float, float, int]],
     snake_axes: Optional[Union[bool, Iterable[Any]]] = None,
     per_step: Optional[Callable] = None,
     md: Optional[Dict[str, Any]] = None
 ):
-    yield from bp.rel_grid_scan(detectors, *args, snake_axes=snake_axes,
+    motor_args = [item for tup in zip(motors, *zip(*limits)) for item in tup]
+    yield from bp.rel_grid_scan(detectors, *motor_args, snake_axes=snake_axes,
                                 per_step=per_step, md=md)
 
 
 @parameter_annotation_decorator({
     "parameters": {
         "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motors": {"annotation": "typing.List[__DEVICE__]"},
+        "limits": {"annotation": "typing.List[typing.Tuple[float, float]]"},
     }
 })
 @add_docstring_from(bp.relative_inner_product_scan)
 def relative_inner_product_scan(
     detectors: List[Any],
     num: int,
-    *args,
+    motors: List[Any],
+    limits: List[Tuple[float, float]],
     per_step: Optional[Callable] = None,
     md: Optional[Dict[str, Any]] = None
 ):
-    yield from bp.relative_inner_product_scan(detectors, num, *args,
+    motor_args = [item for tup in zip(motors, *zip(*limits)) for item in tup]
+    yield from bp.relative_inner_product_scan(detectors, num, *motor_args,
                                               per_step=per_step, md=md)
 
 
 @parameter_annotation_decorator({
     "parameters": {
         "detectors": {"annotation": "typing.List[__DEVICE__]"},
+        "motors": {"annotation": "typing.List[__DEVICE__]"},
+        "limits": {"annotation": "typing.List[typing.Tuple[float, float]]"},
     }
 })
 @add_docstring_from(bp.rel_scan)
 def rel_scan(
     detectors: List[Any],
-    *args,
+    motors: List[Any],
+    limits: List[Tuple[float, float]],
     num: Optional[int] = None,
     per_step: Optional[Callable] = None,
     md: Optional[Dict[str, Any]] = None
 ):
-    yield from bp.rel_scan(detectors, *args, num=num, per_step=per_step, md=md)
+    motor_args = [item for tup in zip(motors, *zip(*limits)) for item in tup]
+    yield from bp.rel_scan(detectors, *motor_args, num=num, per_step=per_step, md=md)
 
 
 @parameter_annotation_decorator({

--- a/atef/enums.py
+++ b/atef/enums.py
@@ -24,6 +24,6 @@ class GroupResultMode(str, enum.Enum):
 class PlanDestination(str, enum.Enum):
     """Destination for plans to be executed"""
     # local RunEngine
-    local_ = "local"
+    local = "local"
     # queueserver, requires extra information
-    qserver_ = "queueserver"
+    qserver = "queueserver"

--- a/atef/enums.py
+++ b/atef/enums.py
@@ -19,3 +19,11 @@ class GroupResultMode(str, enum.Enum):
     all_ = "all"
     #: At least one item must succeed.
     any_ = "any"
+
+
+class PlanDestination(str, enum.Enum):
+    """Destination for plans to be executed"""
+    # local RunEngine
+    local_ = "local"
+    # queueserver, requires extra information
+    qserver_ = "queueserver"

--- a/atef/plan_utils.py
+++ b/atef/plan_utils.py
@@ -172,3 +172,9 @@ def run_in_local_RE(item: Dict[str, Any], identifier: str, state: BlueskyState):
     state.get_allowed_plans_and_devices(destination=PlanDestination.local_)
     gre = GlobalRunEngine()
     gre.run_plan(state, item, identifier)
+
+
+def get_RE_data(index: Any, uuids: Tuple[UUID, ...]):
+    # gre = GlobalRunEngine()
+    # Use index to grab right uuid, data row
+    return []

--- a/atef/plan_utils.py
+++ b/atef/plan_utils.py
@@ -84,6 +84,9 @@ class BlueskyState:
         TODO: if the destination is a queueserver, we should query it for its
         permitted namespace
         """
+        if not destination == PlanDestination.local_:
+            raise NotImplementedError("only local plan execution supported")
+
         if self.allowed_devices and self.allowed_plans:
             return self.allowed_plans, self.allowed_devices
 

--- a/atef/plan_utils.py
+++ b/atef/plan_utils.py
@@ -21,7 +21,7 @@ DEFAULT_PERMISSIONS_PATH = (Path(__file__).parent / "tests" / "profiles" /
 
 PERMISSIONS_PATH = os.environ.get('ATEF_PERMISSIONS_PATH') or DEFAULT_PERMISSIONS_PATH
 
-_PLAN_MODULES = ['bluesky.plans', 'nabs.plans']
+_PLAN_MODULES = ['atef.annotated_plans', 'nabs.plans']
 
 
 def get_default_namespace() -> Dict[str, Any]:
@@ -30,7 +30,7 @@ def get_default_namespace() -> Dict[str, Any]:
     # Load plans: bluesky.plans, nabs
     for module_name in _PLAN_MODULES:
         try:
-            load_startup_module('bluesky.plans', nspace=nspace)
+            load_startup_module(module_name, nspace=nspace)
         except ScriptLoadingError as ex:
             logger.warning(f"unable to load namespace from module '{module_name}'"
                            f": {ex}")

--- a/atef/plan_utils.py
+++ b/atef/plan_utils.py
@@ -1,0 +1,126 @@
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+from uuid import UUID
+
+import databroker
+from bluesky import RunEngine
+from bluesky_queueserver.manager.profile_ops import (
+    ScriptLoadingError, existing_plans_and_devices_from_nspace,
+    load_allowed_plans_and_devices, load_startup_module, prepare_plan)
+
+from atef.enums import PlanDestination
+from atef.util import get_happi_client
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_PERMISSIONS_PATH = (Path(__file__).parent / "tests" / "profiles" /
+                            "user_group_permissions.yaml")
+
+PERMISSIONS_PATH = os.environ.get('ATEF_PERMISSIONS_PATH') or DEFAULT_PERMISSIONS_PATH
+
+_PLAN_MODULES = ['bluesky.plans', 'nabs.plans']
+
+
+def get_default_namespace() -> Dict[str, Any]:
+    """ Look in the basic places to get the default namespace"""
+    nspace = {}
+    # Load plans: bluesky.plans, nabs
+    for module_name in _PLAN_MODULES:
+        try:
+            load_startup_module('bluesky.plans', nspace=nspace)
+        except ScriptLoadingError as ex:
+            logger.warning(f"unable to load namespace from module '{module_name}'"
+                           f": {ex}")
+
+    # load devices: happi
+    client = get_happi_client()
+    results = client.search()
+    for res in results:
+        nspace[res.metadata['name']] = res.get()
+
+    return nspace
+
+
+class BlueskyState:
+    def __new__(cls):
+        if not hasattr(cls, 'instance'):
+            cls.instance = super(BlueskyState, cls).__new__(cls)
+        return cls.instance
+
+    def __init__(self):
+        self.db = databroker.Broker.named('temp')
+        self.RE = RunEngine({})
+        self.RE.subscribe(self.db.insert)
+
+        # Set up plans / devices to stay here for future access?
+        self.plans_md = {}
+        self.devices_md = {}
+        self.plans_in_ns = {}
+        self.devices_in_ns = {}
+
+        self.allowed_plans = {}
+        self.allowed_devices = {}
+
+    def get_allowed_plans_and_devices(
+        self,
+        destination: PlanDestination,
+        hutch: Optional[str] = None,
+    ) -> Tuple[Dict, Dict]:
+        """
+        Gather the allowed plans and devices for a given hutch and destination
+
+        Plans taken from a standard list
+
+        TODO: set up yaml file for each hutch? specify an env var for these?
+        - epad(path_to_yaml)
+
+        TODO: machinery around yaml
+
+        TODO: if the destination is a queueserver, we should query it for its
+        permitted namespace
+        """
+        if self.allowed_devices and self.allowed_plans:
+            return self.allowed_plans, self.allowed_devices
+
+        nspace = get_default_namespace()
+        epd = existing_plans_and_devices_from_nspace(nspace=nspace)
+        self.plans_md, self.devices_md, self.plans_in_ns, self.devices_in_ns = epd
+
+        self.allowed_plans, self.allowed_devices = load_allowed_plans_and_devices(
+            existing_plans=self.plans_md, existing_devices=self.devices_md,
+            path_user_group_permissions=PERMISSIONS_PATH
+        )
+
+        return self.allowed_plans, self.allowed_devices
+
+    def run_plan(self, item) -> UUID:
+        parsed_plan = prepare_plan(
+            item,
+            plans_in_nspace=self.plans_in_ns,
+            devices_in_nspace=self.devices_in_ns,
+            allowed_plans=self.allowed_plans,
+            allowed_devices=self.allowed_devices
+        )
+
+        # actually run plan
+        run_uuid = self.RE(parsed_plan["callable"](
+                           *parsed_plan["args"], **parsed_plan["kwargs"]))
+
+        return run_uuid
+
+
+def run_in_local_RE(item) -> UUID:
+    """
+    Run a plan item in a local RunEngine.  Should:
+    - once again verify the plan...
+    - get current RE instance
+    - Run plan
+    - return uuid for databroker access
+    """
+    # TODO: Dispatch to worker thread with stop/pause methods available
+    BSState = BlueskyState()
+    BSState.get_allowed_plans_and_devices(destination=PlanDestination.local_)
+    BSState.run_plan(item)

--- a/atef/plan_utils.py
+++ b/atef/plan_utils.py
@@ -45,6 +45,14 @@ def get_default_namespace() -> Dict[str, Any]:
 
 
 class BlueskyState:
+    # think about making this a singleton thread.
+    # Tryto include:
+    # - self.env_state, self.running_plan_exec_state
+    # - self.re_state (property)
+    # - self._execute_plan_or_task() -> self._execte_plan() -> self._generate_new_plan() [runs in RE]
+    # - self._generate_continued_plan()
+    # - self.run(), self.start()  --> Used by multiprocessing.Process, may have different API
+    # - shutdown code?
     def __new__(cls):
         if not hasattr(cls, 'instance'):
             cls.instance = super(BlueskyState, cls).__new__(cls)
@@ -121,6 +129,9 @@ def run_in_local_RE(item) -> UUID:
     - return uuid for databroker access
     """
     # TODO: Dispatch to worker thread with stop/pause methods available
+    # put in QThread or other thread?...
+
+    # Can we just use REWorker from bsqs?  is a multiprocessing.Process, to re_worker.start()
     BSState = BlueskyState()
     BSState.get_allowed_plans_and_devices(destination=PlanDestination.local_)
-    BSState.run_plan(item)
+    return BSState.run_plan(item)

--- a/atef/plan_utils.py
+++ b/atef/plan_utils.py
@@ -130,9 +130,7 @@ class GlobalRunEngine:
         run_uuids = self.RE(parsed_plan["callable"](
             *parsed_plan["args"], **parsed_plan["kwargs"]
         ))
-        print(run_uuids)
         state.run_map[identifier] = run_uuids
-        print(state.run_map)
         return run_uuids
 
 
@@ -172,9 +170,3 @@ def run_in_local_RE(item: Dict[str, Any], identifier: str, state: BlueskyState):
     state.get_allowed_plans_and_devices(destination=PlanDestination.local_)
     gre = GlobalRunEngine()
     gre.run_plan(state, item, identifier)
-
-
-def get_RE_data(index: Any, uuids: Tuple[UUID, ...]):
-    # gre = GlobalRunEngine()
-    # Use index to grab right uuid, data row
-    return []

--- a/atef/plan_utils.py
+++ b/atef/plan_utils.py
@@ -1,6 +1,7 @@
 import logging
 import operator
 import os
+from itertools import zip_longest
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 from uuid import UUID
@@ -196,7 +197,7 @@ def get_attr_from_strings(base: Any, cpt: Any) -> Any:
     if isinstance(base, dict):
         return {k: get_attr_from_strings(base[k], cpt[k]) for k in base.keys()}
     elif isinstance(base, list):
-        return [get_attr_from_strings(b, c) for b, c in zip(base, cpt)]
+        return [get_attr_from_strings(b, c) for b, c in zip_longest(base, cpt)]
     elif isinstance(base, ophyd.Device) and (base.name != cpt):
         return operator.attrgetter(cpt)(base)
     else:

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -927,7 +927,6 @@ class PreparedPlanStep(PreparedProcedureStep):
 
         # get namespace (based on destination?
         # How will we know what's in the queueserver's destination?)
-        print('start PPS._run')
         nspace = {}
         nspace = get_default_namespace()
         epd = existing_plans_and_devices_from_nspace(nspace=nspace)
@@ -937,7 +936,6 @@ class PreparedPlanStep(PreparedProcedureStep):
                        for plan in self.prep_plans]
 
         validation_status = [status[0] for status in plan_status]
-        print(validation_status)
         if not all(validation_status):
             # raise an error, place info in result
             fail_plan_names = [pl['name'] for pl, st in

--- a/atef/tests/conftest.py
+++ b/atef/tests/conftest.py
@@ -184,7 +184,7 @@ class EnumDevice(ophyd.sim.SynAxis):
         self.enum.get = partial(self.enum.get, as_string=False)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def sim_db() -> List[happi.OphydItem]:
     items = []
     sim1 = {
@@ -234,7 +234,7 @@ def sim_db() -> List[happi.OphydItem]:
     return items
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def mockjsonclient():
     # Write underlying database
     with tempfile.NamedTemporaryFile(mode='w') as handle:
@@ -246,15 +246,25 @@ def mockjsonclient():
         # tempfile will be deleted once context manager is resolved
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def happi_client(mockjsonclient: happi.Client, sim_db: List[happi.OphydItem]):
     for item in sim_db:
         mockjsonclient.add_item(item)
     return mockjsonclient
 
 
-@pytest.fixture(scope='function', autouse=True)
-def mock_happi(monkeypatch: Any, happi_client: happi.Client):
+@pytest.fixture(scope='session')
+def monkeymodule():
+    # monkeypatch requires function scope, which works fine for the first test
+    # that uses the final mock_happi fixture.  Note that all fixtures called by
+    # mock_happi must also be function-scoped as a result
+    # Subsequent tests will fail due to the
+    with pytest.MonkeyPatch.context() as mp:
+        yield mp
+
+
+@pytest.fixture(scope='session', autouse=True)
+def mock_happi(monkeymodule: Any, happi_client: happi.Client):
     # give `pvname` to all the components, since they don't exist on sim devices
     for result in happi_client.search():
         dev = result.get()
@@ -262,11 +272,15 @@ def mock_happi(monkeypatch: Any, happi_client: happi.Client):
             cpt = getattr(dev, cpt_name)
             if not hasattr(cpt, 'pvname'):
                 setattr(cpt, 'pvname', f'{dev.prefix}:{cpt_name}')
-    monkeypatch.setattr(atef.util, 'get_happi_client', lambda: happi_client)
+
+    def return_client():
+        return happi_client
+
+    monkeymodule.setattr(atef.util, 'get_happi_client', return_client)
     # Only one of these should be needed, but after adding the PlanStep
     # tests both were needed (test_plan_step failed without atef.util,
     # test_gather_pvs failed with atef.util and without from_config)
-    monkeypatch.setattr(happi.Client, 'from_config', lambda: happi_client)
+    monkeymodule.setattr(happi.Client, 'from_config', return_client)
 
 
 @pytest.fixture(scope='function')

--- a/atef/tests/conftest.py
+++ b/atef/tests/conftest.py
@@ -263,6 +263,10 @@ def mock_happi(monkeypatch: Any, happi_client: happi.Client):
             if not hasattr(cpt, 'pvname'):
                 setattr(cpt, 'pvname', f'{dev.prefix}:{cpt_name}')
     monkeypatch.setattr(atef.util, 'get_happi_client', lambda: happi_client)
+    # Only one of these should be needed, but after adding the PlanStep
+    # tests both were needed (test_plan_step failed without atef.util,
+    # test_gather_pvs failed with atef.util and without from_config)
+    monkeypatch.setattr(happi.Client, 'from_config', lambda: happi_client)
 
 
 @pytest.fixture(scope='function')

--- a/atef/tests/profiles/user_group_permissions.yaml
+++ b/atef/tests/profiles/user_group_permissions.yaml
@@ -1,0 +1,14 @@
+user_groups:
+  root:  # Defines the rules for preliminary filtering of plan/device/function names for all groups.
+    allowed_plans:
+      - null  # Allow all
+    forbidden_plans:
+      - ":^_"  # All plans with names starting with '_'
+    allowed_devices:
+      - null  # Allow all
+    forbidden_devices:
+      - ":^_:?.*"  # All devices with names starting with '_'
+    allowed_functions:
+      - null  # Allow all
+    forbidden_functions:
+      - ":^_"  # All functions with names starting with '_'

--- a/atef/tests/sample_plans.py
+++ b/atef/tests/sample_plans.py
@@ -35,7 +35,7 @@ def docstring_plan(dets: List[Any], num: int, default_arg=1):
 @parameter_annotation_decorator({
     "parameters": {
         "dets": {
-            "annotation": "typing.List[__DEVICE__]",
+            "annotation": "typing.List[typing.List[__DEVICE__]]",
             "description": "detector_desc, param_ann_plan"
         },
         "num": {
@@ -43,5 +43,5 @@ def docstring_plan(dets: List[Any], num: int, default_arg=1):
         }
     }
 })
-def param_ann_plan(dets: List[Any], num: int, default_arg=1):
+def param_ann_plan(dets: List[List[Any]], num: int, default_arg=1):
     yield from count(dets, num=num)

--- a/atef/tests/sample_plans.py
+++ b/atef/tests/sample_plans.py
@@ -1,0 +1,47 @@
+from typing import Any, List
+
+from bluesky.plans import count
+from bluesky_queueserver import parameter_annotation_decorator
+
+
+def unmarked_plan(dets, num, default_arg=1):
+    yield from count(dets, num=num)
+
+
+def native_hint_plan(dets: List[Any], num: int, default_arg=1):
+    yield from count(dets, num=num)
+
+
+def docstring_plan(dets: List[Any], num: int, default_arg=1):
+    """This is the docstring plan
+
+    Parameters
+    ----------
+    dets : List[__DEVICE__]
+        This is a list of devices to read as detectors
+    num : int
+        Number of times to acquire
+    default_arg : int, optional
+        not used I guess, by default 1
+
+    Yields
+    ------
+    Any
+        this is a plan
+    """
+    yield from count(dets, num=num)
+
+
+@parameter_annotation_decorator({
+    "parameters": {
+        "dets": {
+            "annotation": "typing.List[__DEVICE__]",
+            "description": "detector_desc, param_ann_plan"
+        },
+        "num": {
+            "annotation": "str"  # takes prescedence
+        }
+    }
+})
+def param_ann_plan(dets: List[Any], num: int, default_arg=1):
+    yield from count(dets, num=num)

--- a/atef/tests/test_plan_utils.py
+++ b/atef/tests/test_plan_utils.py
@@ -1,4 +1,8 @@
-from atef.plan_utils import BlueskyState
+import pytest
+
+from atef.enums import PlanDestination
+from atef.plan_utils import (BlueskyState, GlobalRunEngine, run_in_local_RE,
+                             separate_attrs_from_strings)
 from atef.procedure import register_run_identifier
 
 
@@ -11,3 +15,67 @@ def test_run_identifier():
     assert len(bs_state.run_map) == 2
     assert 'run_name' in bs_state.run_map
     assert 'run_name_1' in bs_state.run_map
+
+
+def test_bluesky_state():
+    state = BlueskyState()
+    state.get_allowed_plans_and_devices(PlanDestination.local_)
+
+
+def test_cpt_separation():
+    item = {'name': 'scan',
+            'args': [['enum1.readback'], 'motor2.a.b.s', [(0, 10)], 10.2],
+            'kwargs': {'num': 42, 'kwarg2': 'string.cpt'},
+            'user_group': 'root'}
+
+    base, cpt = separate_attrs_from_strings(item)
+
+    assert base['args'][0][0] == 'enum1'
+    assert cpt['args'][0][0] == 'readback'
+    assert base['args'][1] == 'motor2'
+    assert cpt['args'][1] == 'a.b.s'
+    assert base['kwargs']['kwarg2'] == 'string'
+    assert cpt['kwargs']['kwarg2'] == 'cpt'
+
+
+@pytest.mark.parametrize(
+    "plan_item, num_points", [
+        pytest.param(
+            {'name': 'scan',
+             'args': [['enum1'], ['motor2'], [(0, 10)], 10],
+             'kwargs': {},
+             'user_group': 'root'},
+            10,
+            id='scan',
+        ),
+        pytest.param(
+            {'name': 'count',
+             'args': [['motor1.readback']],
+             'kwargs': {'num': 13},
+             'user_group': 'root'},
+            13,
+            id='count',
+        ),
+        pytest.param(
+            {'name': 'count',
+             'args': [['motor1.readback'], 42],
+             'kwargs': {},
+             'user_group': 'root'},
+            42,
+            id='count_arg',
+        ),
+        pytest.param(
+            {'name': 'grid_scan',
+             'args': [['enum1'], ['motor1', 'motor2'], [(0, 1, 10), (0, 1, 10)]],
+             'kwargs': {'snake_axes': False},
+             'user_group': 'root'},
+            100,
+            id='grid',
+        ),]
+)
+def test_run_local_plan(plan_item, num_points):
+    bs_state = BlueskyState()
+    run_in_local_RE(item=plan_item, identifier=plan_item['name'], state=bs_state)
+    gre = GlobalRunEngine()
+    uuids = bs_state.run_map[plan_item['name']]
+    assert len(gre.db[uuids[0]].table()) == num_points

--- a/atef/tests/test_plan_utils.py
+++ b/atef/tests/test_plan_utils.py
@@ -1,0 +1,13 @@
+from atef.plan_utils import BlueskyState
+from atef.procedure import register_run_identifier
+
+
+def test_run_identifier():
+    bs_state = BlueskyState()
+    register_run_identifier(bs_state, 'run_name')
+    assert 'run_name' in bs_state.run_map
+
+    register_run_identifier(bs_state, 'run_name')
+    assert len(bs_state.run_map) == 2
+    assert 'run_name' in bs_state.run_map
+    assert 'run_name_1' in bs_state.run_map

--- a/atef/tests/test_procedure.py
+++ b/atef/tests/test_procedure.py
@@ -99,6 +99,9 @@ async def test_plan_step():
 
     await prepared_plan_step.run()
 
+    print(prepared_plan_step.step_result)
     assert prepared_plan_step.step_result == pass_result
+    print(prepared_plan_step.prepared_checks[0].result)
     assert prepared_plan_step.prepared_checks[0].result == pass_result
+    print(prepared_plan_step.prepared_plans[0].result)
     assert prepared_plan_step.prepared_plans[0].result == pass_result

--- a/atef/tests/test_procedure.py
+++ b/atef/tests/test_procedure.py
@@ -84,7 +84,7 @@ async def test_plan_step():
     plan_opt_1 = PlanOptions(
         name='plan_opt_1',
         plan='scan',
-        args=[['motor1'], 'motor2', 0, 10, 10]
+        args=[['motor1'], ['motor2'], [(0, 10)], 10]
     )
 
     plan_comp = ComparisonToPlanData(

--- a/atef/tests/test_procedure.py
+++ b/atef/tests/test_procedure.py
@@ -99,9 +99,10 @@ async def test_plan_step():
 
     await prepared_plan_step.run()
 
+    # plan step has an additional reason, so we compare directly to the severity
     print(prepared_plan_step.step_result)
-    assert prepared_plan_step.step_result == pass_result
+    assert prepared_plan_step.step_result.severity == pass_result.severity
     print(prepared_plan_step.prepared_checks[0].result)
-    assert prepared_plan_step.prepared_checks[0].result == pass_result
+    assert prepared_plan_step.prepared_checks[0].result.severity == pass_result.severity
     print(prepared_plan_step.prepared_plans[0].result)
-    assert prepared_plan_step.prepared_plans[0].result == pass_result
+    assert prepared_plan_step.prepared_plans[0].result.severity == pass_result.severity

--- a/atef/widgets/config/plan_builder.py
+++ b/atef/widgets/config/plan_builder.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar, Dict, List, Optional
+
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import Signal as QSignal
+
+from atef import util
+from atef.widgets.happi import HappiDeviceComponentWidget
+from atef.widgets.ophyd import OphydAttributeData
+
+logger = logging.getLogger(__file__)
+
+
+class PlanEntryWidget(QtWidgets.QWidget):
+    """ holds many ArgumentEntryWidget's and supplies a plan item """
+
+    def __init__(self, *args, plan: Dict[str, Any], **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.plan_info = plan
+        self.vlayout = QtWidgets.QVBoxLayout()
+        self.setLayout(self.vlayout)
+
+        self.arg_widgets = []
+        for param_info in plan['parameters']:
+            arg_widget = build_arg_widget(param_info)
+            self.arg_widgets.append(arg_widget)
+            self.vlayout.addWidget(arg_widget)
+
+    def plan_item(self) -> Dict[str, Any]:
+        """ Returns a plan item in the form {...}"""
+        plan_item = {'name': self.plan_info['name'], 'args': [], 'kwargs': {},
+                     'user_group': 'root'}
+        for param_info, arg_widget in zip(self.plan_info['parameters'], self.arg_widgets):
+            value = arg_widget.value()
+            if param_info['kind']['name'] == 'KEYWORD_ONLY':
+                arg_name = param_info['name']
+                plan_item['kwargs'][arg_name] = value
+            elif param_info['kind']['name'] == 'POSITIONAL_OR_KEYWORD':
+                plan_item['args'].append(value)
+
+        return plan_item
+
+
+def build_arg_widget(info: Dict[str, Any]) -> QtWidgets.QWidget:
+    """ Intended to be a factory function """
+    if not info.get('annotation'):
+        # no annotation, just use a simple text edit
+        return BasicArgEdit(name=info['name'], info=info)
+    elif info['annotation']['type'] in ('str'):
+        return BasicArgEdit(name=info['name'], info=info)
+    elif '__DEVICE__' in info['annotation']['type']:
+        return DeviceChoiceWidget(name=info['name'], info=info)
+    return QtWidgets.QLabel('Could not identify argument type')
+
+
+class ArgumentEntryWidget(QtWidgets.QWidget):
+    """ Base class for various input widgets? needed? """
+    # `info` is expected to be dictionary containing parameter info keys:
+    # - "kind": positional or keyword, etc
+    # - "description": a text description
+    # - "annotaiton": a dictionary itself, with a type annotation
+
+    # .value(): giving plan - compatible value
+    # .arg_label: arg name
+    # arg_changed: QSignal
+    arg_label: QtWidgets.QLabel
+    arg_changed: ClassVar[QtCore.Signal] = QSignal()
+
+    def __init__(self, *args, info: Dict[str, Any], name: Optional[str] = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = name
+        self.info = info
+
+        self.hlayout = QtWidgets.QHBoxLayout()
+        self.setLayout(self.hlayout)
+
+        if self.name:
+            self.arg_label = QtWidgets.QLabel()
+            self.arg_label.setText(self.name)
+            self.hlayout.addWidget(self.arg_label)
+
+        # TODO: set description as tooltip?
+
+    def value(self) -> str:
+        """ Return the entered value as string. """
+        raise NotImplementedError
+
+# Default is str, just leave as str, let qserver construct plan
+# Read enum from annotation first
+# List -> table widget?.....
+# primitives -> specific edits
+# __DEVICE__ -> happi selector
+
+
+class BasicArgEdit(ArgumentEntryWidget):
+
+    line_edit: QtWidgets.QLineEdit
+
+    def __init__(
+        self,
+        *args,
+        info: Dict[str, Any],
+        name: Optional[str] = None,
+        **kwargs
+    ) -> None:
+        super().__init__(*args, name=name, info=info, **kwargs)
+        self.line_edit = QtWidgets.QLineEdit()
+        self.hlayout.addWidget(self.line_edit)
+
+    def value(self) -> str:
+        return self.line_edit.text()
+
+
+class DeviceChoiceWidget(ArgumentEntryWidget):
+    """ For arguments that require devices """
+    _search_widget: Optional[HappiDeviceComponentWidget] = None
+    combo_box: Optional[QtWidgets.QComboBox] = None
+    signal_button: Optional[QtWidgets.QPushButton] = None
+
+    def __init__(self, *args, info: Dict[str, Any], name: Optional[str] = None, **kwargs) -> None:
+        super().__init__(*args, name=name, info=info, **kwargs)
+        self._device = None
+        self._signal_attr = None
+
+        if 'devices' in info:
+            # set up a combo box with given values
+            self.combo_box = QtWidgets.QComboBox()
+            for _, value in info['devices'].items():
+                for device_name in value:
+                    self.combo_box.addItem(device_name)
+
+            # TODO: Connect signal to arg_changed ?
+            self.hlayout.addWidget(self.combo_box)
+
+        else:
+            # No pre-determined values, pick from general devices
+            self.signal_button = QtWidgets.QPushButton()
+            self.signal_button.clicked.connect(self.pick_signal)
+            self.hlayout.addWidget(self.signal_button)
+
+    def pick_signal(self) -> None:
+        """
+        Slot for signal_button.  Opens the HappiDeviceComponentWidget and
+        configures it to send the signal selection to this widget
+        """
+        if self._search_widget is None:
+            widget = HappiDeviceComponentWidget(
+                client=util.get_happi_client()
+            )
+
+            # clear previous cache state
+            self._device = None
+            self._signal_attr = None
+            # look at connecting widget.attributes_selected -> List[OphydAttributeData]
+            widget.item_search_widget.happi_items_chosen.connect(self.set_device)
+            widget.device_widget.attributes_selected.connect(self.set_signal)
+
+            # prevent multiple selection
+            self._search_widget: QtWidgets.QWidget = widget
+
+        self._search_widget.show()
+        self._search_widget.activateWindow()
+        self._search_widget.setWindowState(QtCore.Qt.WindowActive)
+
+    def set_device(self, device_selected: List[str]) -> None:
+        """
+        Slot to be connected to
+        HappiDeviceComponentWidget.item_search_widget.happi_items_chosen.
+        Can only take the first device in the list received
+        """
+        dev = device_selected[0]
+        logger.debug(f'found device: {dev}')
+        self._device = dev
+        self.signal_button.setText(self._device)
+
+    def set_signal(self, attr_selected: List[OphydAttributeData]) -> None:
+        """
+        Slot to be connected to
+        HappiDeviceComponentWidget.device_widget.attributes_selected.
+        """
+        attr = attr_selected[0]
+        logger.debug(f'found attr: {attr}')
+        self._signal_attr = attr.attr
+        self.signal_button.setText(f'{self._device}.{self._signal_attr}')
+
+    def value(self) -> str:
+        if self.combo_box:
+            return self.combo_box.currentText()
+        elif self.signal_button:
+            return self.signal_button.text()
+        else:
+            raise RuntimeError('no entry widgets available')

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,7 +28,8 @@ requirements:
   - bluesky
   - bluesky-queueserver >=0.0.19
   - bluesky-widgets
-  - databroker
+  # databroker >2 incompatible with pydantic v2
+  - databroker <2.0.0
   - happi
   - ipython
   - numpy

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   - bluesky-queueserver >=0.0.19
   - bluesky-widgets
   # databroker >2 incompatible with pydantic v2
-  - databroker <2.0.0
+  - databroker <2.0.0a0
   - happi
   - ipython
   - numpy

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,8 +26,8 @@ requirements:
   - apischema
   - archapp >=1.1.0
   - bluesky
+  - bluesky-queueserver >=0.0.19
   - bluesky-widgets
-  - bluesky-queueserver
   - databroker
   - happi
   - ipython

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
   - archapp >=1.1.0
   - bluesky
   - bluesky-widgets
+  - bluesky-queueserver
   - databroker
   - happi
   - ipython

--- a/docs/source/upcoming_release_notes/193-enh_plan_step.rst
+++ b/docs/source/upcoming_release_notes/193-enh_plan_step.rst
@@ -7,7 +7,7 @@ API Changes
 
 Features
 --------
-- Adds backend for running Bluesky plans in active chekckouts
+- Adds backend for running Bluesky plans in active checkouts
 - Prototypes auto-generated plan argument entry widgets
 - Annotates built-in Bluesky plans with bluesky-queueserver compatible type hints
 

--- a/docs/source/upcoming_release_notes/193-enh_plan_step.rst
+++ b/docs/source/upcoming_release_notes/193-enh_plan_step.rst
@@ -1,0 +1,24 @@
+193 enh_plan_step
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Adds backend for running Bluesky plans in active chekckouts
+- Prototypes auto-generated plan argument entry widgets
+- Annotates built-in Bluesky plans with bluesky-queueserver compatible type hints
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- adds bluesky-queueserver dependency and pins databroker
+
+Contributors
+------------
+- tangkong

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ archapp>=1.1.0
 bluesky
 bluesky-queueserver>=0.0.19
 bluesky-widgets
-databroker
+# databroker >2 incompatible with pydantic v2
+databroker<2.0.0
 happi
 ipython
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bluesky
 bluesky-queueserver>=0.0.19
 bluesky-widgets
 # databroker >2 incompatible with pydantic v2
-databroker<2.0.0
+databroker<2.0.0a0
 happi
 ipython
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 apischema
 archapp>=1.1.0
 bluesky
+bluesky-queueserver>=0.0.19
 bluesky-widgets
-bluesky-queueserver
 databroker
 happi
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ apischema
 archapp>=1.1.0
 bluesky
 bluesky-widgets
+bluesky-queueserver
 databroker
 happi
 ipython


### PR DESCRIPTION
## Description
Adds a step for specifying and running a bluesky step as part of an atef checkout.  Adopts bluesky_queueserver's api for specifying and preparing plans to run, with the eventual dream of being able to support sending plans to a queueserver.  (Whether or not this actually happens, I think their way of handling plans and annotations is worth adopting)

There's a lot that will go into this.  I will enumerate and organize tasks below, and update the list as I decide whether or not to work on any given task.  "completion" is transient at best, as I end up having to re-work previously completed items during development

[Ever-evolving dataclass diagram](https://docs.google.com/drawings/d/1ch44p8pCC4M1C4FldKMPHAMLK_GEFozzgzi6mbdo3Hw/edit?usp=sharing)

I've been told to shift my focus to templated checkouts and other direct stakeholder requests, so I'll be cutting this work short and continuing the effort later (widgets, reports, etc).

### Tasks
<details><summary>Overly detailed task list </summary>
<p>

 - [x] Dataclasses / backend
    - [x] create plan step dataclass
    - [x] create prepared plan step variant
        - [x] needs run uuid, plan "item", prepared comparisons, result
        - [x] fall back to plan names if user does not provide name, needed for plan_id
    - [x] GlobalRunEngine signleton, BlueskyState class
    - [x] check / comparison integration with bluesky plan results
- [x] Programmatic Plan argument widgets, first pass
- [x] Unit Tests
- [x] Supporting work
    - [x] ~get bluesky.plans annotated~  (addressed via atef.annotated_plans)

</p>
</details> 


### thoughts, "tabled" efforts
<details><summary>Details</summary>
<p>

- bluesky-queueserver has a concept of permissions and allowed plans/devices.  For simplicity this effort will assume everyone has access to everything (using a completely permissive `user_groups_permissions.yaml`, but in the future we could filter this with lightpath or specify permissions manually.
- Getting run identifiers sorted out is a bit tricky.  I'll try to describe it below, but it probably needs a visual
    - The requirements are:
        - plans need to be linked to comparisons at EDIT time, meaning they need an identifier that is set and carried over to run/preparation time. -> cannot use RE-generated uuids
        - each checkout file needs access to its own runs, names could be expected to collide between configs/files -> A single global record of plan runs is not possible
        - plan names are not sufficient (plans could be reused), and user-provided names will probably also collide (users are lazy, uniqueness would have to be enforced on GUI side).  -> Need some machinery about generating and saving names
    - As a result, there is a single `BlueskyState` for each `ProcedureFile`, that holds all the run identifiers for that config.
        - plan identifiers are based on the user-provided plan_id, with incrementing suffixes appended
        - these plan identifiers can be accessed via `BlueskyState.run_map` when it comes to letting users choose between existing plans for comparisons
        - all of this is a bit icky, but it works.  

For a separate PR
- [ ] dispatch run engine runs to a non-GUI thread
        - [ ] make pause, stop abort commands available from main thread
        - [ ] add `.clear()` method to reset database with each run-mode preparation?
- [ ] GUI elements
    - [ ] plan building widgets (edit mode)
        - [ ] automated argument entry widgets
    - [ ] plan run widgets (run mode)
    - [ ] plan control (pause, stop, abort) (run)
    - [ ] plan preview utilities (to help reveal what happens in a plan?)
- [ ] Reports
    - [ ] determine how to display run results in report
- [ ] get nabs.plans annotated

</p>
</details> 


## Motivation and Context
Running Bluesky plans is something we want to be available in atef, and the utilities created here will hopefully be useful elsewhere as well.

## How Has This Been Tested?
interactively 

## Where Has This Been Documented?
this pr

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
