### PR TITLE
ENH: find and replace functionality

### DIFF
--- a/atef/tests/conftest.py
+++ b/atef/tests/conftest.py
@@ -229,7 +229,21 @@ def sim_db() -> List[happi.OphydItem]:
         'functional_group': 'FUNC',
     }
 
-    for info in [sim1, sim2, sim3]:
+    sim4 = {
+        'name': 'enum2',
+        'z': 600,
+        '_id': 'enum2',
+        'prefix': 'MY:MOTORENUM',
+        'beamline': 'LCLS',
+        'type': 'OphydItem',
+        'device_class': 'atef.tests.conftest.EnumDevice',
+        'args': list(),
+        'kwargs': {'name': '{{name}}', 'prefix': '{{prefix}}'},
+        'location_group': 'LOC',
+        'functional_group': 'FUNC',
+    }
+
+    for info in [sim1, sim2, sim3, sim4]:
         items.append(happi.OphydItem(**info))
     return items
 

--- a/atef/tests/conftest.py
+++ b/atef/tests/conftest.py
@@ -312,6 +312,7 @@ def mock_pv(monkeypatch: Any):
 def configuration_group():
     group = ConfigurationGroup(
         name='config_group',
+        values={'integer': 1, 'string': 'a sample string'},
         configs=[
             PVConfiguration(
                 name='pv config 1',

--- a/atef/tests/test_find_replace.py
+++ b/atef/tests/test_find_replace.py
@@ -1,0 +1,61 @@
+import copy
+import re
+
+import pytest
+
+from atef.config import DeviceConfiguration, PreparedDeviceConfiguration
+from atef.widgets.config.find_replace import (get_item_from_path,
+                                              replace_item_from_path,
+                                              walk_find_match)
+
+
+@pytest.mark.parametrize(
+    "search_str, replace_str, flags, num_changes",
+    [
+        ('motor1', 'enum1', re.UNICODE, 1),  # replace in list
+        ('MOTor1', 'enum1', re.UNICODE, 0),  # case sensitivity in list
+        ('CoNfIG', 'shmonfig', re.UNICODE, 0),  # case sensitivity in field
+        ('device config', 'fart', re.UNICODE, 1),  # replace bare field
+        ('MOTor1', 'enum1', re.IGNORECASE, 1),
+        ('motor', 'enum', re.IGNORECASE, 2),  # partial match hits 2 devices
+        ('error', 'warning', re.UNICODE, 4),  # replace enums
+        ('ErROR', 'warning', re.UNICODE, 0),  # enums are case sensitive
+        ('Err.*', 'warning', re.IGNORECASE, 4),
+        ('setpoint', 'velocity', re.UNICODE, 1),  # replace keys
+        ('5', '4444.4', re.UNICODE, 1),  # replace non-strings, in bare field
+    ]
+)
+def test_replace_pipeline(
+    device_configuration: DeviceConfiguration,
+    search_str: str,
+    replace_str: str,
+    flags: int,
+    num_changes: int
+):
+    edited_config = copy.deepcopy(device_configuration)
+
+    assert edited_config is not device_configuration
+
+    regex = re.compile(search_str, flags=flags)
+
+    def match_fn(input):
+        return regex.search(str(input)) is not None
+
+    def replace_fn(input):
+        if isinstance(input, str):
+            return regex.sub(replace_str, input)
+        elif isinstance(input, int):
+            return int(float(replace_str))
+        else:  # try to cast as original type
+            return type(input)(replace_str)
+
+    match_paths = walk_find_match(device_configuration, match_fn)
+    assert len(list(match_paths)) == num_changes
+    for path in list(walk_find_match(device_configuration, match_fn)):
+        orig_item = get_item_from_path(path[:-1], item=device_configuration)
+        replace_item_from_path(edited_config, path, replace_fn=replace_fn)
+        new_item = get_item_from_path(path[:-1], item=edited_config)
+        assert orig_item != new_item
+
+    # smoke test preparation
+    PreparedDeviceConfiguration.from_config(edited_config)

--- a/atef/tests/test_find_replace.py
+++ b/atef/tests/test_find_replace.py
@@ -5,7 +5,8 @@ from typing import Any, List, Tuple
 import pytest
 
 from atef.check import Equals, GreaterOrEqual
-from atef.config import DeviceConfiguration, PreparedDeviceConfiguration
+from atef.config import (ConfigurationGroup, DeviceConfiguration,
+                         PreparedDeviceConfiguration)
 from atef.enums import Severity
 from atef.widgets.config.find_replace import (get_deepest_dataclass_in_path,
                                               get_item_from_path,
@@ -50,6 +51,36 @@ def test_walk_find_match(
         return regex.search(str(input)) is not None
 
     path = walk_find_match(device_configuration, match_fn)
+    for expected_path, found_path in zip(simple_path, path):
+        simplified_path = []
+        for seg in found_path:
+            if not isinstance(seg[0], str):
+                item = type(seg[0])
+            else:
+                item = seg[0]
+            simplified_path.append((item, seg[1]))
+        assert expected_path == simplified_path
+
+
+@pytest.mark.parametrize(
+    "search_str, simple_path",
+    [
+        ('integer', [[(ConfigurationGroup, 'values'), ("__dictkey__", "integer")]]),
+        ('^1$', [[(ConfigurationGroup, 'values'), ("__dictvalue__", "integer")]])
+    ]
+)
+def test_walk_find_match_2(
+    configuration_group: ConfigurationGroup,
+    search_str: str,
+    simple_path: List[Tuple[Any, Any]]
+):
+    regex = re.compile(search_str)
+
+    def match_fn(input):
+        # if type(input)
+        return regex.search(str(input)) is not None
+
+    path = walk_find_match(configuration_group, match_fn)
     for expected_path, found_path in zip(simple_path, path):
         simplified_path = []
         for seg in found_path:

--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -7,7 +7,7 @@ import happi
 import pytest
 import yaml
 from pytestqt.qtbot import QtBot
-from qtpy import QtCore
+from qtpy import QtCore, QtWidgets
 
 from atef.widgets.happi import HappiDeviceComponentWidget
 from atef.widgets.ophyd import OphydDeviceTableWidget
@@ -222,12 +222,16 @@ def test_config_window_save_load(qtbot: QtBot, tmp_path: pathlib.Path,
 
 
 @pytest.mark.parametrize('config', [0, 1, 2], indirect=True)
-def test_edit_run_toggle(qtbot: QtBot, config: os.PathLike):
+def test_edit_run_toggle(qtbot: QtBot, config: os.PathLike, monkeypatch):
     """
     Pass if the RunTree can be created from an EditTree
+    This can hang if a checkout cannot be prepared, so patch to ensure
+    the gui continues
     """
+    monkeypatch.setattr(QtWidgets.QMessageBox, 'exec', lambda *a, **k: True)
     window = Window(show_welcome=False)
     window.open_file(filename=str(config))
+    print(config)
     qtbot.addWidget(window)
     toggle = window.tab_widget.widget(0).toggle
     toggle.setChecked(True)

--- a/atef/ui/config_window.ui
+++ b/atef/ui/config_window.ui
@@ -58,6 +58,7 @@
     <addaction name="action_open_archive_viewer"/>
     <addaction name="action_print_report"/>
     <addaction name="action_clear_results"/>
+    <addaction name="action_find_replace"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuDebug"/>
@@ -112,6 +113,11 @@
   <action name="action_clear_results">
    <property name="text">
     <string>Clear Results</string>
+   </property>
+  </action>
+  <action name="action_find_replace">
+   <property name="text">
+    <string>Find / Replace</string>
    </property>
   </action>
  </widget>

--- a/atef/ui/fill_template_page.ui
+++ b/atef/ui/fill_template_page.ui
@@ -129,12 +129,12 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QWidget" name="edits_table_placeholder" native="true">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+         <widget class="QLabel" name="edits_table_placeholder">
+          <property name="text">
+           <string>Open a file to get started!</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
           </property>
          </widget>
         </item>

--- a/atef/ui/fill_template_page.ui
+++ b/atef/ui/fill_template_page.ui
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>fill_template</class>
+ <widget class="QWidget" name="fill_template">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>570</width>
+    <height>481</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="topMargin">
+      <number>5</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="file_name_label">
+       <property name="text">
+        <string>checkout_name</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="type_label">
+       <property name="text">
+        <string>type_name</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="devices_label">
+     <property name="text">
+      <string>Devices in template</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="device_list">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>50</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QFrame" name="edits_frame">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QWidget" name="edits_table_placeholder" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QFrame" name="details_frame">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="detail_label">
+          <property name="text">
+           <string>Edit Details</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QListWidget" name="details_list"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QPushButton" name="open_button">
+       <property name="text">
+        <string>Open File</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="apply_all_button">
+       <property name="text">
+        <string>Apply All</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="save_button">
+       <property name="text">
+        <string>Save As...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/fill_template_page.ui
+++ b/atef/ui/fill_template_page.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>570</width>
+    <width>750</width>
     <height>481</height>
    </rect>
   </property>
@@ -22,14 +22,14 @@
      <item>
       <widget class="QLabel" name="file_name_label">
        <property name="text">
-        <string>checkout_name</string>
+        <string>[file name]</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QLabel" name="type_label">
        <property name="text">
-        <string>type_name</string>
+        <string>[file type]</string>
        </property>
       </widget>
      </item>

--- a/atef/ui/fill_template_page.ui
+++ b/atef/ui/fill_template_page.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
+    <layout class="QHBoxLayout" name="label_hlayout">
      <property name="topMargin">
       <number>5</number>
      </property>
@@ -36,28 +36,54 @@
     </layout>
    </item>
    <item>
-    <widget class="QLabel" name="devices_label">
-     <property name="text">
-      <string>Devices in template</string>
+    <widget class="QSplitter" name="vert_splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QListWidget" name="device_list">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>50</height>
-      </size>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
      </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <item>
+     <widget class="QFrame" name="device_frame">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QLabel" name="device_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Devices in template</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTableWidget" name="device_table">
+         <property name="columnCount">
+          <number>2</number>
+         </property>
+         <column>
+          <property name="text">
+           <string>Devices</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Signals</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QSplitter" name="horiz_splitter">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="childrenCollapsible">
+       <bool>false</bool>
+      </property>
       <widget class="QFrame" name="edits_frame">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -102,21 +128,6 @@
         </item>
        </layout>
       </widget>
-     </item>
-     <item>
-      <widget class="Line" name="line_3">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QFrame" name="details_frame">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -164,11 +175,11 @@
         </item>
        </layout>
       </widget>
-     </item>
-    </layout>
+     </widget>
+    </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <layout class="QHBoxLayout" name="button_hlayout">
      <property name="topMargin">
       <number>0</number>
      </property>

--- a/atef/ui/fill_template_page.ui
+++ b/atef/ui/fill_template_page.ui
@@ -60,9 +60,21 @@
        </item>
        <item>
         <widget class="QTableWidget" name="device_table">
+         <property name="toolTip">
+          <string>Devices and Signals found in the original checkout</string>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::NoSelection</enum>
+         </property>
          <property name="columnCount">
           <number>2</number>
          </property>
+         <attribute name="verticalHeaderVisible">
+          <bool>false</bool>
+         </attribute>
          <column>
           <property name="text">
            <string>Devices</string>
@@ -194,6 +206,13 @@
       <widget class="QPushButton" name="apply_all_button">
        <property name="text">
         <string>Apply All</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="verify_button">
+       <property name="text">
+        <string>Verify</string>
        </property>
       </widget>
      </item>

--- a/atef/ui/find_replace_row_widget.ui
+++ b/atef/ui/find_replace_row_widget.ui
@@ -6,90 +6,118 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>672</width>
-    <height>181</height>
+    <width>587</width>
+    <height>50</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>50</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <layout class="QHBoxLayout" name="main_row_layout">
+    <widget class="QLabel" name="dclass_label">
+     <property name="text">
+      <string>DataclassName</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>3</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="pre_label">
+     <property name="text">
+      <string>Pre-data</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMDrawingLine" name="arrow">
+     <property name="minimumSize">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>500</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="arrowEndPoint" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="post_label">
+     <property name="text">
+      <string>Post-data</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="horizontal_spacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>70</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QLabel" name="dclass_label">
+      <widget class="QToolButton" name="details_button">
        <property name="text">
-        <string>DataclassName</string>
+        <string>&gt; details</string>
+       </property>
+       <property name="popupMode">
+        <enum>QToolButton::InstantPopup</enum>
        </property>
       </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="pre_label">
-       <property name="text">
-        <string>Pre-data</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMDrawingLine" name="PyDMDrawingLine">
-       <property name="minimumSize">
-        <size>
-         <width>20</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>500</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="arrowEndPoint" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="post_label">
-       <property name="text">
-        <string>Post-data</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontal_spacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
      </item>
      <item>
       <widget class="QDialogButtonBox" name="button_box">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="standardButtons">
         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QFrame" name="details_frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/atef/ui/find_replace_row_widget.ui
+++ b/atef/ui/find_replace_row_widget.ui
@@ -59,7 +59,7 @@
       <widget class="QLabel" name="pre_label">
        <property name="minimumSize">
         <size>
-         <width>75</width>
+         <width>0</width>
          <height>0</height>
         </size>
        </property>
@@ -69,7 +69,7 @@
       </widget>
      </item>
      <item>
-      <widget class="PyDMDrawingLine" name="arrow" native="true">
+      <widget class="PyDMDrawingLine" name="arrow">
        <property name="minimumSize">
         <size>
          <width>20</width>

--- a/atef/ui/find_replace_row_widget.ui
+++ b/atef/ui/find_replace_row_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>587</width>
+    <width>568</width>
     <height>50</height>
    </rect>
   </property>
@@ -20,6 +20,19 @@
    <string>Form</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
@@ -87,6 +100,16 @@
     </layout>
    </item>
    <item>
+    <widget class="QToolButton" name="details_button">
+     <property name="text">
+      <string>details...</string>
+     </property>
+     <property name="popupMode">
+      <enum>QToolButton::InstantPopup</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="horizontal_spacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -101,33 +124,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QToolButton" name="details_button">
-       <property name="text">
-        <string>details...</string>
-       </property>
-       <property name="popupMode">
-        <enum>QToolButton::InstantPopup</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="button_box">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/atef/ui/find_replace_row_widget.ui
+++ b/atef/ui/find_replace_row_widget.ui
@@ -12,7 +12,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>0</width>
+    <width>75</width>
     <height>50</height>
    </size>
   </property>
@@ -21,60 +21,70 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <widget class="QLabel" name="dclass_label">
-     <property name="text">
-      <string>DataclassName</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="Line" name="line">
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="lineWidth">
-      <number>3</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="pre_label">
-     <property name="text">
-      <string>Pre-data</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="PyDMDrawingLine" name="arrow">
-     <property name="minimumSize">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>500</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="arrowEndPoint" stdset="0">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="post_label">
-     <property name="text">
-      <string>Post-data</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="dclass_label">
+       <property name="text">
+        <string>DataclassName</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line">
+       <property name="frameShadow">
+        <enum>QFrame::Plain</enum>
+       </property>
+       <property name="lineWidth">
+        <number>3</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="pre_label">
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Pre-data</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMDrawingLine" name="arrow" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>500</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="arrowEndPoint" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="post_label">
+       <property name="text">
+        <string>Post-data</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <spacer name="horizontal_spacer">
@@ -86,7 +96,7 @@
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>70</width>
+       <width>150</width>
        <height>20</height>
       </size>
      </property>
@@ -97,7 +107,7 @@
      <item>
       <widget class="QToolButton" name="details_button">
        <property name="text">
-        <string>&gt; details</string>
+        <string>details...</string>
        </property>
        <property name="popupMode">
         <enum>QToolButton::InstantPopup</enum>

--- a/atef/ui/find_replace_row_widget.ui
+++ b/atef/ui/find_replace_row_widget.ui
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>672</width>
+    <height>181</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QHBoxLayout" name="main_row_layout">
+     <item>
+      <widget class="QLabel" name="dclass_label">
+       <property name="text">
+        <string>DataclassName</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="pre_label">
+       <property name="text">
+        <string>Pre-data</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMDrawingLine" name="PyDMDrawingLine">
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>500</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="arrowEndPoint" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="post_label">
+       <property name="text">
+        <string>Post-data</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontal_spacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="button_box">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QFrame" name="details_frame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMDrawingLine</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/find_replace_widget.ui
+++ b/atef/ui/find_replace_widget.ui
@@ -15,6 +15,27 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <property name="topMargin">
+      <number>5</number>
+     </property>
+     <item>
+      <widget class="QPushButton" name="open_input_file_button">
+       <property name="text">
+        <string>Choose Input File</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="open_output_file_button">
+       <property name="text">
+        <string>Choose Outupt File</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -124,9 +145,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="open_file_button">
+      <widget class="QPushButton" name="save_button">
        <property name="text">
-        <string>Open File</string>
+        <string>Save to Output File</string>
        </property>
       </widget>
      </item>

--- a/atef/ui/find_replace_widget.ui
+++ b/atef/ui/find_replace_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>443</width>
-    <height>300</height>
+    <width>752</width>
+    <height>334</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/atef/ui/find_replace_widget.ui
+++ b/atef/ui/find_replace_widget.ui
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FindAndReplace</class>
+ <widget class="QWidget" name="FindAndReplace">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Find and Replace</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLabel" name="search_label">
+           <property name="text">
+            <string>Search</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="search_edit"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="replace_label">
+           <property name="text">
+            <string>Replace</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="replace_edit"/>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QToolButton" name="case_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Match Case</string>
+         </property>
+         <property name="text">
+          <string>Aa</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="regex_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Use Regular Expressions</string>
+         </property>
+         <property name="text">
+          <string>.*</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QPushButton" name="preview_button">
+       <property name="text">
+        <string>Preview</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="verify_button">
+       <property name="text">
+        <string>Verify</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="open_button">
+       <property name="text">
+        <string>Open Converted</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QListWidget" name="change_list"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/find_replace_widget.ui
+++ b/atef/ui/find_replace_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>443</width>
     <height>300</height>
    </rect>
   </property>
@@ -124,7 +124,14 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="open_button">
+      <widget class="QPushButton" name="open_file_button">
+       <property name="text">
+        <string>Open File</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="open_converted_button">
        <property name="text">
         <string>Open Converted</string>
        </property>

--- a/atef/ui/find_replace_widget.ui
+++ b/atef/ui/find_replace_widget.ui
@@ -133,7 +133,14 @@
     </layout>
    </item>
    <item>
-    <widget class="QListWidget" name="change_list"/>
+    <widget class="QListWidget" name="change_list">
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="resizeMode">
+      <enum>QListView::Adjust</enum>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/atef/ui/landing_page.ui
+++ b/atef/ui/landing_page.ui
@@ -72,6 +72,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="fill_template_button">
+         <property name="text">
+          <string>Fill Template</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="open_button">
          <property name="text">
           <string>Open ...</string>

--- a/atef/ui/template_edit_row_widget.ui
+++ b/atef/ui/template_edit_row_widget.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>665</width>
-    <height>56</height>
+    <width>612</width>
+    <height>50</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Form</string>
@@ -22,12 +28,40 @@
     </widget>
    </item>
    <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>100</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Retry</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLineEdit" name="search_edit">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>75</width>
+       <height>0</height>
+      </size>
      </property>
      <property name="placeholderText">
       <string>search text</string>
@@ -50,7 +84,7 @@
    <item>
     <widget class="PyDMDrawingLine" name="arrow" native="true">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -74,24 +108,20 @@
    </item>
    <item>
     <widget class="QLineEdit" name="replace_edit">
-     <property name="placeholderText">
-      <string>replace text</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="button_box">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Retry</set>
+     <property name="minimumSize">
+      <size>
+       <width>75</width>
+       <height>0</height>
+      </size>
      </property>
-     <property name="centerButtons">
-      <bool>true</bool>
+     <property name="placeholderText">
+      <string>replace text</string>
      </property>
     </widget>
    </item>

--- a/atef/ui/template_edit_row_widget.ui
+++ b/atef/ui/template_edit_row_widget.ui
@@ -6,15 +6,9 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>612</width>
-    <height>50</height>
+    <width>482</width>
+    <height>62</height>
    </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Form</string>
@@ -52,14 +46,14 @@
    <item>
     <widget class="QLineEdit" name="search_edit">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="minimumSize">
       <size>
-       <width>75</width>
+       <width>60</width>
        <height>0</height>
       </size>
      </property>
@@ -83,15 +77,9 @@
    </item>
    <item>
     <widget class="PyDMDrawingLine" name="arrow" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
      <property name="minimumSize">
       <size>
-       <width>50</width>
+       <width>20</width>
        <height>0</height>
       </size>
      </property>
@@ -109,14 +97,14 @@
    <item>
     <widget class="QLineEdit" name="replace_edit">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="minimumSize">
       <size>
-       <width>75</width>
+       <width>60</width>
        <height>0</height>
       </size>
      </property>
@@ -139,7 +127,7 @@
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>40</width>
+       <width>6</width>
        <height>20</height>
       </size>
      </property>

--- a/atef/ui/template_edit_row_widget.ui
+++ b/atef/ui/template_edit_row_widget.ui
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>665</width>
+    <height>56</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QToolButton" name="child_button">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="search_edit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="placeholderText">
+      <string>search text</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="setting_button">
+     <property name="popupMode">
+      <enum>QToolButton::InstantPopup</enum>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonIconOnly</enum>
+     </property>
+     <property name="arrowType">
+      <enum>Qt::NoArrow</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMDrawingLine" name="arrow" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>50</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="arrowEndPoint" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="arrowStartPoint" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="replace_edit">
+     <property name="placeholderText">
+      <string>replace text</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Retry</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="delete_button">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMDrawingLine</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -476,8 +476,15 @@ class FindReplaceRow(DesignerDisplay, QtWidgets.QWidget):
         self.post_label.setText(post_text)
         self.post_label.setToolTip(post_text)
 
-        self.button_box.button(QtWidgets.QDialogButtonBox.Ok).setText('')
-        self.button_box.button(QtWidgets.QDialogButtonBox.Cancel).setText('')
+        ok_button = self.button_box.button(QtWidgets.QDialogButtonBox.Ok)
+        ok_button.setText('')
+        ok_button.setIcon(qta.icon('ei.check'))
+        delete_button = self.button_box.button(QtWidgets.QDialogButtonBox.Cancel)
+        delete_button.setText('')
+        delete_icon = self.style().standardIcon(
+            QtWidgets.QStyle.SP_TitleBarCloseButton
+        )
+        delete_button.setIcon(delete_icon)
 
         # path details
         path_list = []
@@ -553,8 +560,6 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
         self.open_button.clicked.connect(self.open_file)
         self.save_button.clicked.connect(self.save_file)
         self.apply_all_button.clicked.connect(self.apply_all)
-
-        self.setup_edits_table()
 
     def setup_edits_table(self):
         # set up add row widget for edits
@@ -723,8 +728,15 @@ class TemplateEditRowWidget(DesignerDisplay, QtWidgets.QWidget):
         # TODO: check if icons are reasonable before removing text
         refresh_button = self.button_box.button(QtWidgets.QDialogButtonBox.Retry)
         refresh_button.clicked.connect(self.refresh_paths)
+        refresh_button.setText('')
+        refresh_button.setToolTip('refresh edit details')
+        refresh_button.setIcon(qta.icon('ei.refresh'))
+
         apply_button = self.button_box.button(QtWidgets.QDialogButtonBox.Apply)
         apply_button.clicked.connect(self.apply_edits)
+        apply_button.setText('')
+        apply_button.setToolTip('apply all changes')
+        apply_button.setIcon(qta.icon('ei.check'))
 
         # settings menu (regex, case)
         self.setting_widget = QtWidgets.QWidget()

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -644,7 +644,7 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
             if isinstance(self.orig_file, ConfigurationFile):
                 prep_file = PreparedFile.from_config(self.orig_file, client=client)
                 asyncio.run(prep_file.fill_cache())
-            elif isinstance(self.open_file, ProcedureFile):
+            elif isinstance(self.orig_file, ProcedureFile):
                 prep_file = PreparedProcedureFile.from_origin(self.orig_file)
 
             cache = get_signal_cache()

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -359,18 +359,20 @@ class FindReplaceRow(DesignerDisplay, QtWidgets.QWidget):
 
         self.dclass_label.setText(f'{dclass_type}.{attr}')
         self.pre_label.setText(pre_text)
+        self.pre_label.setToolTip(pre_text)
         self.post_label.setText(post_text)
+        self.post_label.setToolTip(post_text)
 
         self.button_box.button(QtWidgets.QDialogButtonBox.Ok).setText('')
         self.button_box.button(QtWidgets.QDialogButtonBox.Cancel).setText('')
 
         path_list = []
         for segment in path:
-            if isinstance(segment[1], str):
-                name = segment[1]
+            if isinstance(segment[0], str):
+                name = segment[0]
             else:
-                name = type(segment[1]).__name__
-            path_list.append(f'({name}, {segment[0]})')
+                name = type(segment[0]).__name__
+            path_list.append(f'({name}, {segment[1]})')
 
         path_str = '>'.join(path_list)
         detail_scroll = QtWidgets.QScrollArea()

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -1,0 +1,280 @@
+import json
+import logging
+import re
+from dataclasses import fields, is_dataclass
+from typing import (Any, Callable, Generator, Iterable, List, Tuple, Union,
+                    get_args)
+
+from apischema import deserialize
+from qtpy import QtWidgets
+
+from atef.config import ConfigurationFile, PreparedFile
+from atef.procedure import PreparedProcedureFile, ProcedureFile
+from atef.type_hints import PrimitiveType
+from atef.widgets.core import DesignerDisplay
+from atef.widgets.utils import ExpandableFrame, insert_widget
+
+logger = logging.getLogger(__name__)
+
+
+def walk_find_match(
+    item: Any,
+    match: Callable,
+    parent: List[Tuple[Union[str, int], Any]] = []
+) -> Generator:
+    """
+    Walk the dataclass and find every key / field where ``match`` evaluates to True.
+
+    Yields a list of 'paths' to the matching key / field. A path is a list of
+    (field, object) tuples that lead from the top level ``item`` to the matching
+    key / field.
+    - If the object is a dataclass, `field` will be a field in that dataclass
+    - If the object is a list, `field` will be the index in that list
+    - If the object is a dict, `field` will be a key in that dictionary
+
+    ``match`` should be a Callable taking a single argument and returning a boolean,
+    specifying whether that argument matched a search term or not.  This is
+    commonly a simple lambda wrapping an equality or regex search.
+
+    Ex:
+    paths = walk_find_match(ConfigFile, 'All Fields Demo')
+
+    Parameters
+    ----------
+    item : Any
+        the item to search in.  A dataclass at the top level, but can also be a
+        list or dict
+    match : Callable
+        a function that takes a single argument and returns a boolean
+    parent : List[Tuple[Union[str, int], Any]], optional
+        the 'path' traveled to arive at ``item`` at this point, by default []
+        (used internally)
+
+    Yields
+    ------
+    Generator
+        paths leading to keys or fields where ``match`` is True
+    """
+    if is_dataclass(item):
+        # get fields, recurse through fields
+        for field in fields(item):
+            yield from walk_find_match(getattr(item, field.name), match,
+                                       parent=parent + [(field.name, item)])
+    elif isinstance(item, list):
+        for idx, l_item in enumerate(item):
+            # TODO: py3.10 allows isinstance with Unions
+            if not isinstance(l_item, get_args(PrimitiveType)) and match(l_item):
+                yield parent + [(idx, '__list__')]
+            else:
+                yield from walk_find_match(l_item,
+                                           match, parent=parent + [(idx, '__list__')])
+    elif isinstance(item, dict):
+        for d_key, d_value in item.items():
+            if match(d_key):
+                yield parent + [('__key__', '__dict__')]
+            # don't halt at first key match, values could also have matches
+            if not isinstance(d_value, get_args(PrimitiveType)) and match(d_value):
+                yield parent + [(d_key, '__dict__')]
+            else:
+                yield from walk_find_match(d_value,
+                                           match, parent=parent + [(d_key, '__dict__')])
+
+    elif match(item):
+        yield parent
+
+
+def get_deepest_dataclass_in_path(path) -> Any:
+    rev_idx = -1
+    while rev_idx > (-len(path) - 1):
+        if is_dataclass(path[rev_idx][1]):
+            break
+        else:
+            rev_idx -= 1
+    return path[rev_idx][1]
+
+
+def get_item_from_path(item, path) -> Any:
+    for seg in path:
+        # allow starting from an item that is partway down path
+        if seg[1] != item:
+            continue
+        if seg[1] == '__dict__':
+            if seg[0] == '__key__':
+                return item
+            else:
+                item = item[seg[0]]
+        elif seg[1] == '__list__':
+            item = item[seg[0]]
+        else:
+            # dataclass case
+            item = getattr(seg[1], seg[0])
+    return item
+
+
+def replace_item_from_path(item: Any, search: Any, replace: Any, path: List[Tuple[Any, Any]]) -> Any:
+    # traverse backward until we get a dataclass (necessary?)
+    # walk forward until step -2
+    # use step -1 to assign the new value
+    # TODO: consider enums.   How do we match those
+    final_step = path[-1]
+    parent_item = get_item_from_path(item, path[:-1])
+
+    if final_step[1] == "__dict__":
+        if final_step[0] == '__key__':
+            # replace the key in this dictionary
+            parent_item[replace] = parent_item.pop(search)
+        else:
+            # replace value
+            parent_item[final_step[0]] = replace
+    elif final_step[1] == "__list__":
+        # replace item in list
+        parent_item[final_step[0]] = replace
+    else:
+        # replace value.  If is an enum, try to access the enum.
+        setattr(parent_item, final_step, replace)
+
+
+class FindReplaceWidget(DesignerDisplay, QtWidgets.QWidget):
+
+    search_edit: QtWidgets.QLineEdit
+    replace_edit: QtWidgets.QLineEdit
+
+    case_button: QtWidgets.QToolButton
+    regex_button: QtWidgets.QToolButton
+
+    preview_button: QtWidgets.QPushButton
+    verify_button: QtWidgets.QPushButton
+    open_button: QtWidgets.QPushButton
+
+    change_list: QtWidgets.QListWidget
+
+    filename = 'find_replace_widget.ui'
+
+    def __init__(self, *args, filepath: str, config_type: Any, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fp = filepath
+        self.config_type = config_type
+        self.match_paths: Iterable[List[Any]] = []
+
+        self._refresh_original()
+
+        self.preview_button.clicked.connect(self.preview_changes)
+        self.verify_button.clicked.connect(self.verify_changes)
+        self.open_button.clicked.connect(self.open_converted)
+
+    def _refresh_original(self):
+        with open(self.fp, 'r') as fp:
+            self._original_json = json.load(fp)
+
+        self.orig_file = deserialize(self.config_type, self._original_json)
+
+    def run_search_replace(self):
+        search_text = self.search_edit.text()
+        replace_text = self.replace_edit.text()
+
+        match_case = self.case_button.isChecked()
+        use_regex = self.regex_button.isChecked()
+
+        logger.debug(f'Running search/replace with {replace_text, match_case}')
+
+        if use_regex:
+            regex = re.compile(search_text)
+        else:
+            regex = re.compile(search_text)
+
+        def match_fn(match):
+            return regex.search(str(match)) is not None
+
+        self.match_paths = walk_find_match(self.orig_file, match_fn)
+
+    def preview_changes(self, *args, **kwargs):
+        self.run_search_replace()
+        # generate the previews in
+        self.change_list.clear()
+        for path in self.match_paths:
+            # find deepest dataclass
+            rev_idx = -1
+            while rev_idx > (-len(path) - 1):
+                if is_dataclass(path[rev_idx][1]):
+                    break
+                else:
+                    rev_idx -= 1
+
+            last_type = path[rev_idx][1]
+            dclass_type = type(last_type).__name__
+            # # add item to list
+            # preview_text = ''.join(region).strip('\n')
+            row_widget = FindReplaceRow(pre_text='', post_text='', dclass_text=dclass_type, path=path)
+            l_item = QtWidgets.QListWidgetItem()
+            l_item.setSizeHint(row_widget.sizeHint())
+            self.change_list.addItem(l_item)
+            self.change_list.setItemWidget(l_item, row_widget)
+
+    def verify_changes(self, *args, **kwargs):
+        # check to make sure changes are valid
+        # Create a new File
+        # Create prepared version of file
+        # new_json = json.loads(''.join(self._new))
+        # try:
+        #     deser = deserialize(self.config_type, new_json)
+        # except Exception as ex:
+        #     print(f'deserialize fail: {ex}')
+        #     return
+
+        try:
+            if self.config_type is ConfigurationFile:
+                self.prepared_file = PreparedFile.from_config(self.orig_file)
+            if self.config_type is ProcedureFile:
+                # clear all results when making a new run tree
+                self.prepared_file = PreparedProcedureFile.from_origin(self.orig_file)
+        except Exception as ex:
+            print(f'prepare fail: {ex}')
+            return
+
+        print('should work')
+
+    def open_converted(self, *args, **kwargs):
+        # open new file in new tab
+        return
+
+
+class FindReplaceRow(DesignerDisplay, QtWidgets.QWidget):
+
+    details_frame: QtWidgets.QFrame
+    button_box: QtWidgets.QDialogButtonBox
+    dclass_label: QtWidgets.QLabel
+    pre_label: QtWidgets.QLabel
+    post_label: QtWidgets.QLabel
+
+    filename = 'find_replace_row_widget.ui'
+
+    def __init__(
+        self,
+        *args,
+        dclass_text: str = 'dclass',
+        pre_text: str = 'pre',
+        post_text: str = 'post',
+        path: List[Any] = [],
+        **kwargs
+    ) -> None:
+        super().__init__(*args, *kwargs)
+        self.post_label.setText(post_text)
+        self.pre_label.setText(pre_text)
+        self.dclass_label.setText(dclass_text)
+        self.button_box.button(QtWidgets.QDialogButtonBox.Ok).setText('')
+        self.button_box.button(QtWidgets.QDialogButtonBox.Cancel).setText('')
+
+        new_frame = ExpandableFrame(text='details...')
+        path_list = []
+        for segment in path:
+            if isinstance(segment[1], str):
+                name = segment[1]
+            else:
+                name = type(segment[1]).__name__
+            path_list.append(f'({name}, {segment[0]})')
+
+        path_str = '>'.join(path_list)
+        detail_widget = QtWidgets.QLabel(path_str + '\n')
+        detail_widget.setWordWrap(True)
+        new_frame.add_widget(detail_widget)
+        insert_widget(new_frame, self.details_frame)

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -546,7 +546,6 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
     type_label: QtWidgets.QLabel
 
     device_table: QtWidgets.QTableWidget
-    # scan through devices in original checkout?
     # filter by device type?  look at specific device types?
     vert_splitter: QtWidgets.QSplitter
     horiz_splitter: QtWidgets.QSplitter
@@ -582,7 +581,10 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
         self.apply_all_button.clicked.connect(self.apply_all)
 
         self.horiz_splitter.setSizes([375, 375])  # in pixels, a good first shot
-        self.vert_splitter.setSizes([175, 375])  # in pixels, a good first shot
+        self.vert_splitter.setSizes([175, 375])
+
+        horiz_header = self.device_table.horizontalHeader()
+        horiz_header.setSectionResizeMode(horiz_header.Stretch)
 
     def setup_edits_table(self):
         # set up add row widget for edits
@@ -643,14 +645,12 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
             signals = list(cache.keys())
             devices = list(happi.loader.cache.keys())
 
-        horiz_header = self.device_table.horizontalHeader()
-        horiz_header.setSectionResizeMode(horiz_header.Stretch)
         self.device_table.setRowCount(max(len(signals), len(devices)))
 
         for i, sig in enumerate(signals):
-            self.device_table.setItem(i, 0, QtWidgets.QTableWidgetItem(sig))
+            self.device_table.setItem(i, 1, QtWidgets.QTableWidgetItem(sig))
         for i, dev in enumerate(devices):
-            self.device_table.setItem(i, 1, QtWidgets.QTableWidgetItem(dev))
+            self.device_table.setItem(i, 0, QtWidgets.QTableWidgetItem(dev))
 
     def save_file(self):
         # open save message box
@@ -679,7 +679,7 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
                 action.apply()
 
             # clear all rows
-            self.edits_table.clear()
+            self.edits_table.clearContents()
             self.details_list.clear()
 
     def update_title(self):
@@ -705,9 +705,12 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
         # could separate this out and parametrize by row
         self.details_list.clear()
         # on selected callback, populate details table
-        selected_range = self.edits_table.selectedRanges()[0]
+        selected_ranges = self.edits_table.selectedRanges()
+        if not selected_ranges:
+            return
+
         edit_row_widget: TemplateEditRowWidget = self.edits_table.cellWidget(
-            selected_range.topRow(), 0
+            selected_ranges[0].topRow(), 0
         )
 
         if not isinstance(edit_row_widget, TemplateEditRowWidget):

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -806,7 +806,8 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
 
         if not isinstance(edit_row_widget, TemplateEditRowWidget):
             # placeholder text if nothing is selected
-            l_item = QtWidgets.QListWidgetItem('select an edit to show details...')
+            l_item = QtWidgets.QListWidgetItem("select an edit or click an edit's"
+                                               "refresh button to show details.")
             return
         elif not edit_row_widget.get_details_rows():
             l_item = QtWidgets.QListWidgetItem(

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -39,7 +39,7 @@ from atef.procedure import (ComparisonToTarget, DescriptionStep, PassiveStep,
                             ProcedureGroup, ProcedureStep, SetValueStep)
 from atef.tools import Ping, PingResult, Tool, ToolResult
 from atef.type_hints import AnyDataclass
-from atef.widgets.config.data_active import (CheckRowWidget, ExpandableFrame,
+from atef.widgets.config.data_active import (CheckRowWidget,
                                              GeneralProcedureWidget,
                                              PassiveEditWidget,
                                              SetValueEditWidget)
@@ -47,7 +47,7 @@ from atef.widgets.config.run_active import (DescriptionRunWidget,
                                             PassiveRunWidget,
                                             SetValueRunWidget)
 from atef.widgets.config.run_base import RunCheck
-from atef.widgets.utils import insert_widget
+from atef.widgets.utils import ExpandableFrame, insert_widget
 
 from ..core import DesignerDisplay
 from .data_base import DataWidget, NameDescTagsWidget

--- a/atef/widgets/config/plan_builder.py
+++ b/atef/widgets/config/plan_builder.py
@@ -12,11 +12,10 @@ from qtpy import QtCore, QtWidgets
 from qtpy.QtCore import Signal as QSignal
 
 from atef import util
-from atef.widgets.config.data_active import ExpandableFrame
 from atef.widgets.core import DesignerDisplay
 from atef.widgets.happi import HappiDeviceComponentWidget
 from atef.widgets.ophyd import OphydAttributeData
-from atef.widgets.utils import insert_widget
+from atef.widgets.utils import ExpandableFrame, insert_widget
 
 logger = logging.getLogger(__file__)
 

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -1306,6 +1306,7 @@ class TableWidgetWithAddRow(QtWidgets.QTableWidget):
         self.setHorizontalHeaderLabels([title_text])
         self.verticalHeader().setHidden(True)
         self.row_widget_cls = row_widget_cls
+        self.add_row_text = add_row_text
         self.add_add_row_widget(text=add_row_text)
         self.setSelectionMode(self.NoSelection)
 
@@ -1379,6 +1380,11 @@ class TableWidgetWithAddRow(QtWidgets.QTableWidget):
                 break
 
         self.table_updated.emit()
+
+    def clearContents(self):
+        super().clearContents()
+        self.setRowCount(0)
+        self.add_add_row_widget(text=self.add_row_text)
 
 
 def set_widget_font_size(widget: QWidget, size: int):

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -1296,6 +1296,7 @@ class TableWidgetWithAddRow(QtWidgets.QTableWidget):
     add_row_widget: AddRowWidget
 
     table_updated: ClassVar[QtCore.Signal] = QtCore.Signal()
+    row_interacted: ClassVar[QtCore.Signal] = QtCore.Signal(int)
 
     def __init__(self, *args, add_row_text: str, title_text: str, row_widget_cls: QtWidgets.QWidget, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1309,6 +1310,8 @@ class TableWidgetWithAddRow(QtWidgets.QTableWidget):
         self.add_row_text = add_row_text
         self.add_add_row_widget(text=add_row_text)
         self.setSelectionMode(self.NoSelection)
+        self.table_updated.connect(self.stash_row_numbers)
+        self.row_interacted.connect(lambda row_num: self.selectRow(row_num))
 
     def add_add_row_widget(self, text: str):
         """ add the AddRowWidget to the end of the specified table-widget"""
@@ -1380,6 +1383,12 @@ class TableWidgetWithAddRow(QtWidgets.QTableWidget):
                 break
 
         self.table_updated.emit()
+
+    def stash_row_numbers(self, *args, **kwargs):
+        """ Stash row numbers in row widgets """
+        for row_num in range(self.rowCount()):
+            row_widget = self.cellWidget(row_num, 0)
+            row_widget.row_num = row_num
 
     def clearContents(self):
         super().clearContents()

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -29,7 +29,8 @@ from atef.procedure import (DescriptionStep, PassiveStep,
                             PreparedProcedureFile, ProcedureFile, SetValueStep)
 from atef.qt_helpers import walk_tree_widget_items
 from atef.report import ActiveAtefReport, PassiveAtefReport
-from atef.widgets.config.find_replace import FindReplaceWidget
+from atef.widgets.config.find_replace import (FillTemplatePage,
+                                              FindReplaceWidget)
 from atef.widgets.utils import reset_cursor, set_wait_cursor
 
 from ..archive_viewer import get_archive_viewer
@@ -116,6 +117,9 @@ class Window(DesignerDisplay, QMainWindow):
         )
         widget.new_active_button.clicked.connect(
             partial(self.new_file, checkout_type='active')
+        )
+        widget.fill_template_button.clicked.connect(
+            self.open_fill_template
         )
         widget.sample_active_button.clicked.connect(partial(
             self.open_file, filename=str(TEST_CONFIG_PATH / 'active_test.json')
@@ -386,6 +390,15 @@ class Window(DesignerDisplay, QMainWindow):
             self._find_widget = FindReplaceWidget()
         self._find_widget.show()
 
+    def open_fill_template(self, *args, **kwargs):
+        """
+        Open a fill-template page.
+        """
+        widget = FillTemplatePage()
+        self.tab_widget.addTab(widget, 'fill template')
+        curr_idx = self.tab_widget.count() - 1
+        self.tab_widget.setCurrentIndex(curr_idx)
+
 
 class LandingPage(DesignerDisplay, QWidget):
     """ Landing Page for selecting a subsequent action """
@@ -393,6 +406,7 @@ class LandingPage(DesignerDisplay, QWidget):
 
     new_passive_button: QtWidgets.QPushButton
     new_active_button: QtWidgets.QPushButton
+    fill_template_button: QtWidgets.QPushButton
     open_button: QtWidgets.QPushButton
     exit_button: QtWidgets.QPushButton
 

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -29,6 +29,7 @@ from atef.procedure import (DescriptionStep, PassiveStep,
                             PreparedProcedureFile, ProcedureFile, SetValueStep)
 from atef.qt_helpers import walk_tree_widget_items
 from atef.report import ActiveAtefReport, PassiveAtefReport
+from atef.widgets.config.find_replace import FindReplaceWidget
 from atef.widgets.utils import reset_cursor, set_wait_cursor
 
 from ..archive_viewer import get_archive_viewer
@@ -65,6 +66,7 @@ class Window(DesignerDisplay, QMainWindow):
     action_open_archive_viewer: QAction
     action_print_report: QAction
     action_clear_results: QAction
+    action_find_replace: QAction
 
     def __init__(self, *args, show_welcome: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
@@ -80,6 +82,7 @@ class Window(DesignerDisplay, QMainWindow):
         )
         self.action_print_report.triggered.connect(self.print_report)
         self.action_clear_results.triggered.connect(self.clear_results)
+        self.action_find_replace.triggered.connect(self.find_replace)
 
         tab_bar = self.tab_widget.tabBar()
         # always use scroll area and never truncate file names
@@ -366,6 +369,15 @@ class Window(DesignerDisplay, QMainWindow):
                 clear_results(config_file)
 
             current_tree.update_statuses()
+
+    def find_replace(self, *args, **kwargs):
+        """ find and replace in the current tree.  Open a find-replace widget """
+        print(f'starting find-replace: {self.get_current_tree().full_path}')
+        curr_tree = self.get_current_tree()
+        self._find_widget = FindReplaceWidget(
+            filepath=curr_tree.full_path, config_type=type(curr_tree.config_file)
+        )
+        self._find_widget.show()
 
 
 class LandingPage(DesignerDisplay, QWidget):

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -394,7 +394,7 @@ class Window(DesignerDisplay, QMainWindow):
         """
         Open a fill-template page.
         """
-        widget = FillTemplatePage()
+        widget = FillTemplatePage(window=self)
         self.tab_widget.addTab(widget, 'fill template')
         curr_idx = self.tab_widget.count() - 1
         self.tab_widget.setCurrentIndex(curr_idx)

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -373,10 +373,17 @@ class Window(DesignerDisplay, QMainWindow):
     def find_replace(self, *args, **kwargs):
         """ find and replace in the current tree.  Open a find-replace widget """
         print(f'starting find-replace: {self.get_current_tree().full_path}')
-        curr_tree = self.get_current_tree()
-        self._find_widget = FindReplaceWidget(
-            filepath=curr_tree.full_path, config_type=type(curr_tree.config_file)
-        )
+        try:
+            curr_tree = self.get_current_tree()
+        except AttributeError:
+            curr_tree = None
+
+        if curr_tree:
+            self._find_widget = FindReplaceWidget(
+                filepath=curr_tree.full_path, window=self
+            )
+        else:
+            self._find_widget = FindReplaceWidget()
         self._find_widget.show()
 
 

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -376,9 +376,9 @@ class Window(DesignerDisplay, QMainWindow):
 
     def find_replace(self, *args, **kwargs):
         """ find and replace in the current tree.  Open a find-replace widget """
-        print(f'starting find-replace: {self.get_current_tree().full_path}')
         try:
             curr_tree = self.get_current_tree()
+            logger.debug(f'starting find-replace: {self.get_current_tree().full_path}')
         except AttributeError:
             curr_tree = None
 

--- a/docs/source/upcoming_release_notes/198-enh_fill_template.rst
+++ b/docs/source/upcoming_release_notes/198-enh_fill_template.rst
@@ -1,0 +1,24 @@
+198 enh_fill_template
+#####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Adds find-replace functionality and helpers.  These procedures walk
+  through the dataclass, rather than blindly modifying serialized json.
+- Adds a simple find-replace widget and more fully-featured fill-template page
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- Implements atef-specific find and replace functionality
- adds a basic find-and-replace widget
- finish up / clean up widget button functionality

## Motivation and Context
This stems from a request for templated checkouts, which boils down to having find-and-replace functionality.  A naive find-and-replace on the json could touch file/field names, and is rather difficult to inspect.  

My intention is to make the future "fill template" step / tool wrap this functionality, possibly with some extra visualization or streamlining buttons.  A sample checkout could be run through this tool and and "filled" as is with this tool, I imagine

(In reality I implemented the simple find-and-replace helpers, tried making it more robust, and a week later ended up here.)

Creating a step that fills templates mid-checkout is a possible next step, though we'd have to consider expanding each template step on preparation and inserting it into the tree.  Inspection of the substeps of that filled template would be un-inspectable unless we expand in edit-mode, and in that case we're basically creating a bunch of filled template checkouts separately.

## How Has This Been Tested?
Some unit tests have been added, more need to be...

## Where Has This Been Documented?
This PR

## Screenshots 
![image](https://github.com/pcdshub/atef/assets/35379409/b88ccb99-49c4-4297-ae9b-0972d17218d2)

![image](https://github.com/pcdshub/atef/assets/35379409/d4259d8e-fe36-4868-a81b-555dab66dc29)

![image](https://github.com/pcdshub/atef/assets/35379409/1ec61c27-81fd-4946-970a-f1462910d16d)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
