### PR TITLE
TST: Attempted test suite fixups

### DIFF
--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -157,7 +157,7 @@ class Target:
     def to_signal(
         self,
         signal_cache: Optional[_SignalCache] = None
-    ) -> Optional[ophyd.EpicsSignal]:
+    ) -> Optional[ophyd.Signal]:
         """
         Return the signal described by this Target.  First attempts to use the
         device + attr information to look up the signal in happi, falling back
@@ -165,7 +165,7 @@ class Target:
 
         Returns
         -------
-        ophyd.EpicsSignal
+        ophyd.Signal
             the signal described by this Target
         """
         try:

--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -9,7 +9,6 @@ import yaml
 from pytestqt.qtbot import QtBot
 from qtpy import QtCore
 
-from atef.cache import get_signal_cache
 from atef.widgets.happi import HappiDeviceComponentWidget
 from atef.widgets.ophyd import OphydDeviceTableWidget
 
@@ -219,9 +218,6 @@ def test_config_window_save_load(qtbot: QtBot, tmp_path: pathlib.Path,
     with open(dest, 'r') as fd:
         dest_lines = fd.readlines()
     assert source_lines == dest_lines
-    # Clear the signal cache to stop signal-based callbacks from triggering
-    cache = get_signal_cache()
-    cache.clear()
     qtbot.addWidget(window)
 
 
@@ -276,3 +272,4 @@ def test_device_table(qtbot: QtBot, happi_client: happi.Client):
     otable.device = new_dev
     assert otable.windowTitle() == new_dev.name
     qtbot.addWidget(otable)
+    assert False

--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -9,6 +9,7 @@ import yaml
 from pytestqt.qtbot import QtBot
 from qtpy import QtCore
 
+from atef.cache import get_signal_cache
 from atef.widgets.happi import HappiDeviceComponentWidget
 from atef.widgets.ophyd import OphydDeviceTableWidget
 
@@ -200,14 +201,13 @@ def test_config_window_basic(qtbot: QtBot):
     qtbot.addWidget(window)
 
 
-# @pytest.mark.parametrize('config', [0, 1, 2], indirect=True)
+# @pytest.mark.skip()
 def test_config_window_save_load(qtbot: QtBot, tmp_path: pathlib.Path,
                                  all_config_path: os.PathLike):
     """
     Pass if the config gui can open a file and save the same file back
     """
     window = Window(show_welcome=False)
-    qtbot.addWidget(window)
     config = pathlib.Path(all_config_path)
     filename = config.name
     source = str(config)
@@ -219,6 +219,10 @@ def test_config_window_save_load(qtbot: QtBot, tmp_path: pathlib.Path,
     with open(dest, 'r') as fd:
         dest_lines = fd.readlines()
     assert source_lines == dest_lines
+    # Clear the signal cache to stop signal-based callbacks from triggering
+    cache = get_signal_cache()
+    cache.clear()
+    qtbot.addWidget(window)
 
 
 # # Test encountered frequent failures due to C++ objects being deleted before

--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -272,4 +272,3 @@ def test_device_table(qtbot: QtBot, happi_client: happi.Client):
     otable.device = new_dev
     assert otable.windowTitle() == new_dev.name
     qtbot.addWidget(otable)
-    assert False

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -25,7 +25,7 @@ import qtawesome
 import typhos
 import typhos.cli
 import typhos.display
-from ophyd.signal import EpicsSignalBase
+from ophyd.signal import Signal
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QDialogButtonBox
@@ -901,7 +901,7 @@ class ActionRowWidget(TargetRowWidget):
         self.edit_widget = None
         if data is None:
             data = ValueToTarget()
-        self._sig = None
+        self._sig: Optional[Signal] = None
         self._curr_value = None
         self._dtype = None
         self._enum_strs = None
@@ -960,7 +960,7 @@ class ActionRowWidget(TargetRowWidget):
         Updates value input widget with a QLineEdit with the approriate validator
         given the target's datatype
         """
-        self._sig: EpicsSignalBase = self.data.to_signal()
+        self._sig = self.data.to_signal()
         if self._sig is None:
             self.edit_widget = QtWidgets.QLabel('(no target set)')
             insert_widget(self.edit_widget, self.value_input_placeholder)

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -901,6 +901,10 @@ class ActionRowWidget(TargetRowWidget):
         self.edit_widget = None
         if data is None:
             data = ValueToTarget()
+        self._sig = None
+        self._curr_value = None
+        self._dtype = None
+        self._enum_strs = None
         super().__init__(data=data, **kwargs)
 
     def setup_ui(self) -> None:
@@ -927,13 +931,35 @@ class ActionRowWidget(TargetRowWidget):
 
         self.update_input_placeholder()
 
+    def get_curr_value(self):
+        self._sig.wait_for_connection()
+        self._curr_value = self.bridge.value.get() or self._sig.get()
+        self._dtype = type(self._curr_value)
+        self._enum_strs = getattr(self._sig, 'enum_strs', None)
+
+    def fail_get_value(self, ex: Exception):
+        logger.debug(f'failed to get signal data for input widget: {ex}')
+        self._curr_value = 'no data'
+        # fall back to type in dataclass if available
+        stored_value = self.bridge.value.get()
+        if stored_value is not None:
+            self._dtype = type(stored_value)
+        else:
+            self._dtype = float
+
+        self.run_setup_input_widget()
+
+    def run_setup_input_widget(self):
+        self.setup_input_widget(self._curr_value, self._dtype,
+                                enum_strs=self._enum_strs)
+
     def update_input_placeholder(self) -> None:
         """
         Updates value input widget with a QLineEdit with the approriate validator
         given the target's datatype
         """
-        sig: EpicsSignalBase = self.data.to_signal()
-        if sig is None:
+        self._sig: EpicsSignalBase = self.data.to_signal()
+        if self._sig is None:
             self.edit_widget = QtWidgets.QLabel('(no target set)')
             insert_widget(self.edit_widget, self.value_input_placeholder)
             self.value_button_box.hide()
@@ -943,35 +969,14 @@ class ActionRowWidget(TargetRowWidget):
         self._dtype = None
         self._enum_strs = None
 
-        def get_curr_value():
-            sig.wait_for_connection()
-            self._curr_value = self.bridge.value.get() or sig.get()
-            self._dtype = type(self._curr_value)
-            self._enum_strs = getattr(sig, 'enum_strs', None)
-
-        def fail_get_value(ex: Exception):
-            logger.debug(f'failed to get signal data for input widget: {ex}')
-            self._curr_value = 'no data'
-            # fall back to type in dataclass if available
-            stored_value = self.bridge.value.get()
-            if stored_value is not None:
-                self._dtype = type(stored_value)
-            else:
-                self._dtype = float
-
-            run_setup_input_widget()
-
-        def run_setup_input_widget():
-            self.setup_input_widget(self._curr_value, self._dtype,
-                                    enum_strs=self._enum_strs)
-
         if self.curr_val_thread and self.curr_val_thread.isRunning():
             logger.debug('thread is still running.  Ignore..')
             return
 
-        self.curr_val_thread = BusyCursorThread(func=get_curr_value)
-        self.curr_val_thread.raised_exception.connect(fail_get_value)
-        self.curr_val_thread.task_finished.connect(run_setup_input_widget)
+        self.curr_val_thread = BusyCursorThread(parent=self, func=self.get_curr_value)
+        # fail_slot = WeakPartialMethodSlot(self.curr_val_thread, self.curr_val_thread.raised_exception, self.get_curr_value, sig)
+        self.curr_val_thread.raised_exception.connect(self.fail_get_value)
+        self.curr_val_thread.task_finished.connect(self.run_setup_input_widget)
         self.curr_val_thread.start()
 
     def setup_input_widget(

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -976,7 +976,6 @@ class ActionRowWidget(TargetRowWidget):
             return
 
         self.curr_val_thread = BusyCursorThread(parent=self, func=self.get_curr_value)
-        # fail_slot = WeakPartialMethodSlot(self.curr_val_thread, self.curr_val_thread.raised_exception, self.get_curr_value, sig)
         self.curr_val_thread.raised_exception.connect(self.fail_get_value)
         self.curr_val_thread.task_finished.connect(self.run_setup_input_widget)
         self.curr_val_thread.start()

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -932,6 +932,8 @@ class ActionRowWidget(TargetRowWidget):
         self.update_input_placeholder()
 
     def get_curr_value(self):
+        if self._sig is None:
+            return
         self._sig.wait_for_connection()
         self._curr_value = self.bridge.value.get() or self._sig.get()
         self._dtype = type(self._curr_value)

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -17,7 +17,6 @@ from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Generator,
 import happi
 import qtawesome as qta
 from apischema import ValidationError, serialize
-from pcdsutils.qt.callbacks import WeakPartialMethodSlot
 from qtpy import QtCore, QtWidgets
 
 from atef.cache import DataCache, get_signal_cache
@@ -27,7 +26,8 @@ from atef.type_hints import PrimitiveType
 from atef.util import get_happi_client
 from atef.widgets.config.utils import TableWidgetWithAddRow
 from atef.widgets.core import DesignerDisplay
-from atef.widgets.utils import BusyCursorThread, insert_widget
+from atef.widgets.utils import (BusyCursorThread, WeakPartialMethodSlot,
+                                insert_widget)
 
 if TYPE_CHECKING:
     from .window import Window

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -17,6 +17,7 @@ from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Generator,
 import happi
 import qtawesome as qta
 from apischema import ValidationError, serialize
+from pcdsutils.qt.callbacks import WeakPartialMethodSlot
 from qtpy import QtCore, QtWidgets
 
 from atef.cache import DataCache, get_signal_cache
@@ -26,8 +27,7 @@ from atef.type_hints import PrimitiveType
 from atef.util import get_happi_client
 from atef.widgets.config.utils import TableWidgetWithAddRow
 from atef.widgets.core import DesignerDisplay
-from atef.widgets.utils import (BusyCursorThread, WeakPartialMethodSlot,
-                                insert_widget)
+from atef.widgets.utils import BusyCursorThread, insert_widget
 
 if TYPE_CHECKING:
     from .window import Window

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -989,7 +989,7 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
             self.details_list.setItemWidget(l_item, row_widget)
 
             remove_slot = WeakPartialMethodSlot(
-                row_widget.remove_item, row_widget.remove_item.connect,
+                row_widget, row_widget.remove_item,
                 self.remove_item_from_details, l_item
             )
             self._partial_slots.append(remove_slot)

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -560,10 +560,10 @@ class FindReplaceWidget(DesignerDisplay, QtWidgets.QWidget):
         match_fn = get_default_match_fn(self._search_regex)
         self._match_fn = match_fn
 
-    def _remove_item_from_change_list(self, list_item):
+    def _remove_item_from_change_list(self, list_item, *args, **kwargs):
         self.change_list.takeItem(self.change_list.row(list_item))
 
-    def accept_change(self, list_item):
+    def accept_change(self, list_item, *args, **kwargs):
         # make sure this only runs if action was successful
         self._remove_item_from_change_list(list_item)
 

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -591,16 +591,14 @@ class FindReplaceWidget(DesignerDisplay, QtWidgets.QWidget):
             self.change_list.addItem(l_item)
             self.change_list.setItemWidget(l_item, row_widget)
 
-            accept_slot = WeakPartialMethodSlot(
+            WeakPartialMethodSlot(
                 row_widget.button_box, row_widget.button_box.accepted,
                 self.accept_change, l_item
             )
-            row_widget.button_box.accepted.connect(accept_slot._call)
-            reject_slot = WeakPartialMethodSlot(
+            WeakPartialMethodSlot(
                 row_widget.button_box, row_widget.button_box.rejected,
                 self._remove_item_from_change_list, l_item
             )
-            row_widget.button_box.rejected.connect(reject_slot._call)
 
     def open_converted(self, *args, **kwargs) -> None:
         """ open new file in new tab """
@@ -987,11 +985,10 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
             self.details_list.addItem(l_item)
             self.details_list.setItemWidget(l_item, row_widget)
 
-            remove_slot = WeakPartialMethodSlot(
+            WeakPartialMethodSlot(
                 row_widget.remove_item, row_widget.remove_item.connect,
                 self.remove_item_from_details, l_item
             )
-            row_widget.remove_item.connect(remove_slot._call)
 
     def remove_item_from_details(self, item: QtWidgets.QListWidgetItem) -> None:
         """ remove an item from the details list """
@@ -1151,11 +1148,10 @@ class TemplateEditRowWidget(DesignerDisplay, QtWidgets.QWidget):
         details_row_widgets = []
         for action in self.actions:
             row_widget = FindReplaceRow(data=action)
-            remove_slot = WeakPartialMethodSlot(
+            WeakPartialMethodSlot(
                 row_widget, row_widget.remove_item,
                 self.remove_from_action_list, action=action
             )
-            row_widget.remove_item.connect(remove_slot._call)
             details_row_widgets.append(row_widget)
 
         return details_row_widgets

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -6,7 +6,6 @@ import logging
 import time
 from dataclasses import fields
 from enum import IntEnum
-from functools import partial
 from itertools import zip_longest
 from typing import (Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type,
                     Union)
@@ -46,6 +45,7 @@ from atef.widgets.core import DesignerDisplay
 from atef.widgets.happi import HappiDeviceComponentWidget
 from atef.widgets.ophyd import OphydAttributeData, OphydAttributeDataSummary
 from atef.widgets.utils import (BusyCursorThread, PV_validator,
+                                WeakPartialMethodSlot,
                                 match_line_edit_text_width)
 
 logger = logging.getLogger(__name__)
@@ -1609,20 +1609,34 @@ class MultiModeValueEdit(DesignerDisplay, QWidget):
         menu = QMenu()
         if not self._is_number:
             use_bool = menu.addAction("&Bool")
-            use_bool.triggered.connect(partial(self.set_mode, EditMode.BOOL)),
+            bool_slot = WeakPartialMethodSlot(use_bool, use_bool.triggered,
+                                              self.set_mode, EditMode.BOOL)
+            use_bool.triggered.connect(bool_slot._call)
             use_enum = menu.addAction("&Enum")
-            use_enum.triggered.connect(partial(self.set_mode, EditMode.ENUM))
+            enum_slot = WeakPartialMethodSlot(use_enum, use_enum.triggered,
+                                              self.set_mode, EditMode.ENUM)
+            use_enum.triggered.connect(enum_slot._call)
         use_float = menu.addAction("&Float")
-        use_float.triggered.connect(partial(self.set_mode, EditMode.FLOAT))
+        float_slot = WeakPartialMethodSlot(use_float, use_float.triggered,
+                                           self.set_mode, EditMode.FLOAT)
+        use_float.triggered.connect(float_slot._call)
         use_int = menu.addAction("&Int")
-        use_int.triggered.connect(partial(self.set_mode, EditMode.INT))
+        int_slot = WeakPartialMethodSlot(use_int, use_int.triggered,
+                                         self.set_mode, EditMode.INT)
+        use_int.triggered.connect(int_slot._call)
         if not self._is_number:
             use_str = menu.addAction("&String")
-            use_str.triggered.connect(partial(self.set_mode, EditMode.STR))
+            str_slot = WeakPartialMethodSlot(use_str, use_str.triggered,
+                                             self.set_mode, EditMode.STR)
+            use_str.triggered.connect(str_slot._call)
         use_epics = menu.addAction("EPI&CS")
-        use_epics.triggered.connect(partial(self.set_mode, EditMode.EPICS))
+        epics_slot = WeakPartialMethodSlot(use_epics, use_epics.triggered,
+                                           self.set_mode, EditMode.EPICS)
+        use_epics.triggered.connect(epics_slot._call)
         use_happi = menu.addAction("&Happi")
-        use_happi.triggered.connect(partial(self.set_mode, EditMode.HAPPI))
+        happi_slot = WeakPartialMethodSlot(use_happi, use_happi.triggered,
+                                           self.set_mode, EditMode.HAPPI)
+        use_happi.triggered.connect(happi_slot._call)
         self.select_mode_button.setMenu(menu)
         self.select_mode_button.setPopupMode(
             self.select_mode_button.InstantPopup

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -1560,6 +1560,7 @@ class MultiModeValueEdit(DesignerDisplay, QWidget):
         self._is_number = False
         self._show_tol = False
         self._prep_dynamic_thread = None
+        self._partial_slots: list[WeakPartialMethodSlot] = []
         self.setup_widgets()
         self.set_mode_from_data()
         self.setSizePolicy(
@@ -1609,27 +1610,34 @@ class MultiModeValueEdit(DesignerDisplay, QWidget):
         menu = QMenu()
         if not self._is_number:
             use_bool = menu.addAction("&Bool")
-            WeakPartialMethodSlot(use_bool, use_bool.triggered,
-                                  self.set_mode, EditMode.BOOL)
+            bool_slot = WeakPartialMethodSlot(use_bool, use_bool.triggered,
+                                              self.set_mode, EditMode.BOOL)
+            self._partial_slots.append(bool_slot)
             use_enum = menu.addAction("&Enum")
-            WeakPartialMethodSlot(use_enum, use_enum.triggered,
-                                  self.set_mode, EditMode.ENUM)
+            enum_slot = WeakPartialMethodSlot(use_enum, use_enum.triggered,
+                                              self.set_mode, EditMode.ENUM)
+            self._partial_slots.append(enum_slot)
         use_float = menu.addAction("&Float")
-        WeakPartialMethodSlot(use_float, use_float.triggered,
-                              self.set_mode, EditMode.FLOAT)
+        float_slot = WeakPartialMethodSlot(use_float, use_float.triggered,
+                                           self.set_mode, EditMode.FLOAT)
+        self._partial_slots.append(float_slot)
         use_int = menu.addAction("&Int")
-        WeakPartialMethodSlot(use_int, use_int.triggered,
-                              self.set_mode, EditMode.INT)
+        int_slot = WeakPartialMethodSlot(use_int, use_int.triggered,
+                                         self.set_mode, EditMode.INT)
+        self._partial_slots.append(int_slot)
         if not self._is_number:
             use_str = menu.addAction("&String")
-            WeakPartialMethodSlot(use_str, use_str.triggered,
-                                  self.set_mode, EditMode.STR)
+            str_slot = WeakPartialMethodSlot(use_str, use_str.triggered,
+                                             self.set_mode, EditMode.STR)
+            self._partial_slots.append(str_slot)
         use_epics = menu.addAction("EPI&CS")
-        WeakPartialMethodSlot(use_epics, use_epics.triggered,
-                              self.set_mode, EditMode.EPICS)
+        epics_slot = WeakPartialMethodSlot(use_epics, use_epics.triggered,
+                                           self.set_mode, EditMode.EPICS)
+        self._partial_slots.append(epics_slot)
         use_happi = menu.addAction("&Happi")
-        WeakPartialMethodSlot(use_happi, use_happi.triggered,
-                              self.set_mode, EditMode.HAPPI)
+        happi_slot = WeakPartialMethodSlot(use_happi, use_happi.triggered,
+                                           self.set_mode, EditMode.HAPPI)
+        self._partial_slots.append(happi_slot)
         self.select_mode_button.setMenu(menu)
         self.select_mode_button.setPopupMode(
             self.select_mode_button.InstantPopup

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -1954,7 +1954,7 @@ class MultiModeValueEdit(DesignerDisplay, QWidget):
         self.thread_worker.task_finished.connect(fill_enums)
         self.thread_worker.start()
 
-    def set_mode(self, mode: EditMode) -> None:
+    def set_mode(self, mode: EditMode, *args, **kwargs) -> None:
         """
         Change the mode of the edit widget.
         This adjusts the dynamic data classes as needed and

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -13,6 +13,7 @@ from typing import (Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type,
 import numpy as np
 import qtawesome as qta
 from ophyd import EpicsSignal, EpicsSignalRO
+from pcdsutils.qt.callbacks import WeakPartialMethodSlot
 from qtpy import QtCore, QtWidgets
 from qtpy.QtCore import (QPoint, QPointF, QRect, QRectF, QRegularExpression,
                          QSize, Qt, QTimer)
@@ -45,7 +46,6 @@ from atef.widgets.core import DesignerDisplay
 from atef.widgets.happi import HappiDeviceComponentWidget
 from atef.widgets.ophyd import OphydAttributeData, OphydAttributeDataSummary
 from atef.widgets.utils import (BusyCursorThread, PV_validator,
-                                WeakPartialMethodSlot,
                                 match_line_edit_text_width)
 
 logger = logging.getLogger(__name__)

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -13,7 +13,6 @@ from typing import (Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type,
 import numpy as np
 import qtawesome as qta
 from ophyd import EpicsSignal, EpicsSignalRO
-from pcdsutils.qt.callbacks import WeakPartialMethodSlot
 from qtpy import QtCore, QtWidgets
 from qtpy.QtCore import (QPoint, QPointF, QRect, QRectF, QRegularExpression,
                          QSize, Qt, QTimer)
@@ -46,6 +45,7 @@ from atef.widgets.core import DesignerDisplay
 from atef.widgets.happi import HappiDeviceComponentWidget
 from atef.widgets.ophyd import OphydAttributeData, OphydAttributeDataSummary
 from atef.widgets.utils import (BusyCursorThread, PV_validator,
+                                WeakPartialMethodSlot,
                                 match_line_edit_text_width)
 
 logger = logging.getLogger(__name__)

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -1609,34 +1609,27 @@ class MultiModeValueEdit(DesignerDisplay, QWidget):
         menu = QMenu()
         if not self._is_number:
             use_bool = menu.addAction("&Bool")
-            bool_slot = WeakPartialMethodSlot(use_bool, use_bool.triggered,
-                                              self.set_mode, EditMode.BOOL)
-            use_bool.triggered.connect(bool_slot._call)
+            WeakPartialMethodSlot(use_bool, use_bool.triggered,
+                                  self.set_mode, EditMode.BOOL)
             use_enum = menu.addAction("&Enum")
-            enum_slot = WeakPartialMethodSlot(use_enum, use_enum.triggered,
-                                              self.set_mode, EditMode.ENUM)
-            use_enum.triggered.connect(enum_slot._call)
+            WeakPartialMethodSlot(use_enum, use_enum.triggered,
+                                  self.set_mode, EditMode.ENUM)
         use_float = menu.addAction("&Float")
-        float_slot = WeakPartialMethodSlot(use_float, use_float.triggered,
-                                           self.set_mode, EditMode.FLOAT)
-        use_float.triggered.connect(float_slot._call)
+        WeakPartialMethodSlot(use_float, use_float.triggered,
+                              self.set_mode, EditMode.FLOAT)
         use_int = menu.addAction("&Int")
-        int_slot = WeakPartialMethodSlot(use_int, use_int.triggered,
-                                         self.set_mode, EditMode.INT)
-        use_int.triggered.connect(int_slot._call)
+        WeakPartialMethodSlot(use_int, use_int.triggered,
+                              self.set_mode, EditMode.INT)
         if not self._is_number:
             use_str = menu.addAction("&String")
-            str_slot = WeakPartialMethodSlot(use_str, use_str.triggered,
-                                             self.set_mode, EditMode.STR)
-            use_str.triggered.connect(str_slot._call)
+            WeakPartialMethodSlot(use_str, use_str.triggered,
+                                  self.set_mode, EditMode.STR)
         use_epics = menu.addAction("EPI&CS")
-        epics_slot = WeakPartialMethodSlot(use_epics, use_epics.triggered,
-                                           self.set_mode, EditMode.EPICS)
-        use_epics.triggered.connect(epics_slot._call)
+        WeakPartialMethodSlot(use_epics, use_epics.triggered,
+                              self.set_mode, EditMode.EPICS)
         use_happi = menu.addAction("&Happi")
-        happi_slot = WeakPartialMethodSlot(use_happi, use_happi.triggered,
-                                           self.set_mode, EditMode.HAPPI)
-        use_happi.triggered.connect(happi_slot._call)
+        WeakPartialMethodSlot(use_happi, use_happi.triggered,
+                              self.set_mode, EditMode.HAPPI)
         self.select_mode_button.setMenu(menu)
         self.select_mode_button.setPopupMode(
             self.select_mode_button.InstantPopup

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -114,32 +114,28 @@ class Window(DesignerDisplay, QMainWindow):
         curr_idx = self.tab_widget.count() - 1
         self.tab_widget.setCurrentIndex(curr_idx)
 
-        new_passive_slot = WeakPartialMethodSlot(
+        WeakPartialMethodSlot(
             widget.new_passive_button, widget.new_passive_button.clicked,
             self.new_file, checkout_type="passive"
         )
-        widget.new_passive_button.clicked.connect(new_passive_slot._call)
-        new_active_slot = WeakPartialMethodSlot(
+        WeakPartialMethodSlot(
             widget.new_active_button, widget.new_active_button.clicked,
             self.new_file, checkout_type="active"
         )
-        widget.new_active_button.clicked.connect(new_active_slot._call)
 
         widget.fill_template_button.clicked.connect(
             self.open_fill_template
         )
 
-        sample_active_slot = WeakPartialMethodSlot(
+        WeakPartialMethodSlot(
             widget.sample_active_button, widget.sample_active_button.clicked,
             self.open_file, filename=str(TEST_CONFIG_PATH / 'active_test.json')
         )
-        widget.sample_active_button.clicked.connect(sample_active_slot._call)
 
-        sample_passive_slot = WeakPartialMethodSlot(
+        WeakPartialMethodSlot(
             widget.sample_passive_button, widget.sample_passive_button.clicked,
             self.open_file, filename=str(TEST_CONFIG_PATH / 'all_fields.json')
         )
-        widget.sample_passive_button.clicked.connect(sample_passive_slot._call)
 
         widget.open_button.clicked.connect(self.open_file)
         widget.exit_button.clicked.connect(self.close_all)

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -16,6 +16,7 @@ from typing import ClassVar, Dict, Optional, Union
 
 import qtawesome
 from apischema import ValidationError, deserialize, serialize
+from pcdsutils.qt.callbacks import WeakPartialMethodSlot
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtCore import Signal as QSignal
@@ -30,8 +31,7 @@ from atef.qt_helpers import walk_tree_widget_items
 from atef.report import ActiveAtefReport, PassiveAtefReport
 from atef.widgets.config.find_replace import (FillTemplatePage,
                                               FindReplaceWidget)
-from atef.widgets.utils import (WeakPartialMethodSlot, reset_cursor,
-                                set_wait_cursor)
+from atef.widgets.utils import reset_cursor, set_wait_cursor
 
 from ..archive_viewer import get_archive_viewer
 from ..core import DesignerDisplay

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -72,6 +72,7 @@ class Window(DesignerDisplay, QMainWindow):
 
     def __init__(self, *args, show_welcome: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
+        self._partial_slots: list[WeakPartialMethodSlot] = []
         self.setWindowTitle('atef config')
         self.action_welcome_tab.triggered.connect(self.welcome_user)
         self.action_new_file.triggered.connect(self.new_file)
@@ -114,28 +115,32 @@ class Window(DesignerDisplay, QMainWindow):
         curr_idx = self.tab_widget.count() - 1
         self.tab_widget.setCurrentIndex(curr_idx)
 
-        WeakPartialMethodSlot(
+        new_passive_slot = WeakPartialMethodSlot(
             widget.new_passive_button, widget.new_passive_button.clicked,
             self.new_file, checkout_type="passive"
         )
-        WeakPartialMethodSlot(
+        self._partial_slots.append(new_passive_slot)
+        new_active_slot = WeakPartialMethodSlot(
             widget.new_active_button, widget.new_active_button.clicked,
             self.new_file, checkout_type="active"
         )
+        self._partial_slots.append(new_active_slot)
 
         widget.fill_template_button.clicked.connect(
             self.open_fill_template
         )
 
-        WeakPartialMethodSlot(
+        sample_active_slot = WeakPartialMethodSlot(
             widget.sample_active_button, widget.sample_active_button.clicked,
             self.open_file, filename=str(TEST_CONFIG_PATH / 'active_test.json')
         )
+        self._partial_slots.append(sample_active_slot)
 
-        WeakPartialMethodSlot(
+        sample_passive_slot = WeakPartialMethodSlot(
             widget.sample_passive_button, widget.sample_passive_button.clicked,
             self.open_file, filename=str(TEST_CONFIG_PATH / 'all_fields.json')
         )
+        self._partial_slots.append(sample_passive_slot)
 
         widget.open_button.clicked.connect(self.open_file)
         widget.exit_button.clicked.connect(self.close_all)

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -16,7 +16,6 @@ from typing import ClassVar, Dict, Optional, Union
 
 import qtawesome
 from apischema import ValidationError, deserialize, serialize
-from pcdsutils.qt.callbacks import WeakPartialMethodSlot
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtCore import Signal as QSignal
@@ -31,7 +30,8 @@ from atef.qt_helpers import walk_tree_widget_items
 from atef.report import ActiveAtefReport, PassiveAtefReport
 from atef.widgets.config.find_replace import (FillTemplatePage,
                                               FindReplaceWidget)
-from atef.widgets.utils import reset_cursor, set_wait_cursor
+from atef.widgets.utils import (WeakPartialMethodSlot, reset_cursor,
+                                set_wait_cursor)
 
 from ..archive_viewer import get_archive_viewer
 from ..core import DesignerDisplay

--- a/atef/widgets/utils.py
+++ b/atef/widgets/utils.py
@@ -1,8 +1,6 @@
 """
 Non-core utilities. Primarily dynamic styling tools.
 """
-import weakref
-from types import MethodType
 from typing import ClassVar, Generator, Optional
 
 from qtpy import QtCore, QtGui, QtWidgets
@@ -308,88 +306,3 @@ class ExpandableFrame(QtWidgets.QFrame):
 
         # self.setMinimumHeight(min_height)
         self.updateGeometry()
-
-
-class WeakPartialMethodSlot:
-    """
-    A PyQt-compatible slot for a partial method.
-
-    This utility handles deleting the connection when the method class instance
-    gets garbage collected. This avoids cycles in the garbage collector
-    that would prevent the instance from being garbage collected prior to the
-    program exiting.
-
-    Parameters
-    ----------
-    signal_owner : QtCore.QObject
-        The owner of the signal.
-    signal : QtCore.Signal
-        The signal instance itself.
-    method : instance method
-        The method slot to call when the signal fires.
-    *args :
-        Arguments to pass to the method.
-    **kwargs :
-        Keyword arguments to pass to the method.
-    """
-    def __init__(
-        self,
-        signal_owner: QtCore.QObject,
-        signal: QtCore.Signal,
-        method: MethodType,
-        *args,
-        **kwargs
-    ):
-        self.signal = signal
-        self.signal.connect(self._call, QtCore.Qt.QueuedConnection)
-        self.method = weakref.WeakMethod(method)
-        self._method_finalizer = weakref.finalize(
-            method.__self__, self._method_destroyed
-        )
-        self._signal_finalizer = weakref.finalize(
-            signal_owner, self._signal_destroyed
-        )
-        self.partial_args = args
-        self.partial_kwargs = kwargs
-
-    def _signal_destroyed(self):
-        """Callback: the owner of the signal was destroyed; clean up."""
-        if self.signal is None:
-            return
-
-        self.method = None
-        self.partial_args = []
-        self.partial_kwargs = {}
-        self.signal = None
-
-    def _method_destroyed(self):
-        """Callback: the owner of the method was destroyed; clean up."""
-        if self.signal is None:
-            return
-
-        self.method = None
-        self.partial_args = []
-        self.partial_kwargs = {}
-        try:
-            self.signal.disconnect(self._call)
-        except Exception:
-            ...
-        self.signal = None
-
-    def _call(self, *new_args, **new_kwargs):
-        """
-        PyQt callback slot which handles the internal WeakMethod.
-
-        This method currently throws away arguments passed in from the signal.
-        This is for backward-compatibility to how the previous
-        `partial()`-using implementation worked.
-
-        If reused beyond the TyphosSuite, this class may need revisiting in the
-        future.
-        """
-        method = self.method()
-        if method is None:
-            self._method_destroyed()
-            return
-        return method(*self.partial_args, *new_args,
-                      **{**self.partial_kwargs, **new_kwargs})

--- a/atef/widgets/utils.py
+++ b/atef/widgets/utils.py
@@ -1,6 +1,8 @@
 """
 Non-core utilities. Primarily dynamic styling tools.
 """
+import weakref
+from types import MethodType
 from typing import ClassVar, Generator, Optional
 
 from qtpy import QtCore, QtGui, QtWidgets
@@ -306,3 +308,88 @@ class ExpandableFrame(QtWidgets.QFrame):
 
         # self.setMinimumHeight(min_height)
         self.updateGeometry()
+
+
+class WeakPartialMethodSlot:
+    """
+    A PyQt-compatible slot for a partial method.
+
+    This utility handles deleting the connection when the method class instance
+    gets garbage collected. This avoids cycles in the garbage collector
+    that would prevent the instance from being garbage collected prior to the
+    program exiting.
+
+    Parameters
+    ----------
+    signal_owner : QtCore.QObject
+        The owner of the signal.
+    signal : QtCore.Signal
+        The signal instance itself.
+    method : instance method
+        The method slot to call when the signal fires.
+    *args :
+        Arguments to pass to the method.
+    **kwargs :
+        Keyword arguments to pass to the method.
+    """
+    def __init__(
+        self,
+        signal_owner: QtCore.QObject,
+        signal: QtCore.Signal,
+        method: MethodType,
+        *args,
+        **kwargs
+    ):
+        self.signal = signal
+        self.signal.connect(self._call, QtCore.Qt.QueuedConnection)
+        self.method = weakref.WeakMethod(method)
+        self._method_finalizer = weakref.finalize(
+            method.__self__, self._method_destroyed
+        )
+        self._signal_finalizer = weakref.finalize(
+            signal_owner, self._signal_destroyed
+        )
+        self.partial_args = args
+        self.partial_kwargs = kwargs
+
+    def _signal_destroyed(self):
+        """Callback: the owner of the signal was destroyed; clean up."""
+        if self.signal is None:
+            return
+
+        self.method = None
+        self.partial_args = []
+        self.partial_kwargs = {}
+        self.signal = None
+
+    def _method_destroyed(self):
+        """Callback: the owner of the method was destroyed; clean up."""
+        if self.signal is None:
+            return
+
+        self.method = None
+        self.partial_args = []
+        self.partial_kwargs = {}
+        try:
+            self.signal.disconnect(self._call)
+        except Exception:
+            ...
+        self.signal = None
+
+    def _call(self, *new_args):
+        """
+        PyQt callback slot which handles the internal WeakMethod.
+
+        This method currently throws away arguments passed in from the signal.
+        This is for backward-compatibility to how the previous
+        `partial()`-using implementation worked.
+
+        If reused beyond the TyphosSuite, this class may need revisiting in the
+        future.
+        """
+        method = self.method()
+        if method is None:
+            self._method_destroyed()
+            return
+
+        return method(*self.partial_args, **self.partial_kwargs)

--- a/atef/widgets/utils.py
+++ b/atef/widgets/utils.py
@@ -1,6 +1,8 @@
 """
 Non-core utilities. Primarily dynamic styling tools.
 """
+import weakref
+from types import MethodType
 from typing import ClassVar, Generator, Optional
 
 from qtpy import QtCore, QtGui, QtWidgets
@@ -306,3 +308,88 @@ class ExpandableFrame(QtWidgets.QFrame):
 
         # self.setMinimumHeight(min_height)
         self.updateGeometry()
+
+
+class WeakPartialMethodSlot:
+    """
+    A PyQt-compatible slot for a partial method.
+
+    This utility handles deleting the connection when the method class instance
+    gets garbage collected. This avoids cycles in the garbage collector
+    that would prevent the instance from being garbage collected prior to the
+    program exiting.
+
+    Parameters
+    ----------
+    signal_owner : QtCore.QObject
+        The owner of the signal.
+    signal : QtCore.Signal
+        The signal instance itself.
+    method : instance method
+        The method slot to call when the signal fires.
+    *args :
+        Arguments to pass to the method.
+    **kwargs :
+        Keyword arguments to pass to the method.
+    """
+    def __init__(
+        self,
+        signal_owner: QtCore.QObject,
+        signal: QtCore.Signal,
+        method: MethodType,
+        *args,
+        **kwargs
+    ):
+        self.signal = signal
+        self.signal.connect(self._call, QtCore.Qt.QueuedConnection)
+        self.method = weakref.WeakMethod(method)
+        self._method_finalizer = weakref.finalize(
+            method.__self__, self._method_destroyed
+        )
+        self._signal_finalizer = weakref.finalize(
+            signal_owner, self._signal_destroyed
+        )
+        self.partial_args = args
+        self.partial_kwargs = kwargs
+
+    def _signal_destroyed(self):
+        """Callback: the owner of the signal was destroyed; clean up."""
+        if self.signal is None:
+            return
+
+        self.method = None
+        self.partial_args = []
+        self.partial_kwargs = {}
+        self.signal = None
+
+    def _method_destroyed(self):
+        """Callback: the owner of the method was destroyed; clean up."""
+        if self.signal is None:
+            return
+
+        self.method = None
+        self.partial_args = []
+        self.partial_kwargs = {}
+        try:
+            self.signal.disconnect(self._call)
+        except Exception:
+            ...
+        self.signal = None
+
+    def _call(self, *new_args, **new_kwargs):
+        """
+        PyQt callback slot which handles the internal WeakMethod.
+
+        This method currently throws away arguments passed in from the signal.
+        This is for backward-compatibility to how the previous
+        `partial()`-using implementation worked.
+
+        If reused beyond the TyphosSuite, this class may need revisiting in the
+        future.
+        """
+        method = self.method()
+        if method is None:
+            self._method_destroyed()
+            return
+        return method(*self.partial_args, *new_args,
+                      **{**self.partial_kwargs, **new_kwargs})

--- a/atef/widgets/utils.py
+++ b/atef/widgets/utils.py
@@ -376,7 +376,7 @@ class WeakPartialMethodSlot:
             ...
         self.signal = None
 
-    def _call(self, *new_args):
+    def _call(self, *new_args, **new_kwargs):
         """
         PyQt callback slot which handles the internal WeakMethod.
 
@@ -391,5 +391,5 @@ class WeakPartialMethodSlot:
         if method is None:
             self._method_destroyed()
             return
-
-        return method(*self.partial_args, **self.partial_kwargs)
+        return method(*self.partial_args, *new_args,
+                      **{**self.partial_kwargs, **new_kwargs})

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,7 +34,6 @@ requirements:
   - ipython
   - numpy
   - ophyd
-  - pcdsutils >0.13.0
   - pydm
   - pyyaml
   - qtpy

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
   - ipython
   - numpy
   - ophyd
+  - pcdsutils >0.13.0
   - pydm
   - pyyaml
   - qtpy

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
   - ipython
   - numpy
   - ophyd
+  - pcdsutils >=0.14.0
   - pydm
   - pyyaml
   - qtpy

--- a/docs/source/upcoming_release_notes/214-tst_qt_teardown.rst
+++ b/docs/source/upcoming_release_notes/214-tst_qt_teardown.rst
@@ -1,0 +1,22 @@
+214 tst_qt_teardown
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Replaces use of functools.partial with `WeakPartialMethodSlot` in qt slots, cleaning up intermittent test suite failures (and hopefully production crashes)
+
+Contributors
+------------
+- tangkong

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ happi
 ipython
 numpy
 ophyd
-pcdsutils>0.13.0
 pydm
 PyQt5
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ happi
 ipython
 numpy
 ophyd
+pcdsutils>=0.14.0
 pydm
 PyQt5
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ happi
 ipython
 numpy
 ophyd
+pcdsutils>0.13.0
 pydm
 PyQt5
 pyyaml


### PR DESCRIPTION
## Description
Attempting to fix some intermittent test suite failures.  The crux of the difficulty here is that the suite consistently passes locally, failing only intermittently on GHA CI

## Motivation and Context
- Uses / vendors Typhos' `WeakPartialMethodSlot` for applying callbacks within `ActionRowWidget`
- In one case opted to try making the slots submitted to `BusyCursorThread` actual methods, rather than dynamically created functions
- When pcdsutils is updated, we can remove the vendoring here and rely on pcdsutils' versino

- There is still a very rare test suite failure, but I cannot reproduce it enough to address it.  For the curious, it seems to fail at [`get_curr_value`](https://github.com/pcdshub/atef/actions/runs/6407993392/job/17396405838#step:17:737), the epics-get portion of `ActionRowWidget`
  - While this is the one place we chose to make the callbacks methods rather than partial slots, I think the issue is more likely due to late timeouts than widgets being garbage collected early

## How Has This Been Tested?
GHA, things pass pretty consistently locally 

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
