### PR TITLE
MNT: make enum checks more robust

### DIFF
--- a/atef/check.py
+++ b/atef/check.py
@@ -87,12 +87,14 @@ class Value:
 
     def compare(self, value: PrimitiveType) -> bool:
         """Compare the provided value with this one, using tolerance settings."""
-        if self.rtol is not None or self.atol is not None:
+        if ((self.rtol is not None or self.atol is not None)
+                and isinstance(value, (int, float))):
             return np.isclose(
                 value, self.value,
                 rtol=(self.rtol or 0.0),
                 atol=(self.atol or 0.0)
             )
+
         return value == self.value
 
 

--- a/atef/check.py
+++ b/atef/check.py
@@ -88,7 +88,7 @@ class Value:
     def compare(self, value: PrimitiveType) -> bool:
         """Compare the provided value with this one, using tolerance settings."""
         if ((self.rtol is not None or self.atol is not None)
-                and isinstance(value, (int, float))):
+                and not isinstance(value, (str, bool))):
             return np.isclose(
                 value, self.value,
                 rtol=(self.rtol or 0.0),

--- a/atef/config.py
+++ b/atef/config.py
@@ -1207,6 +1207,17 @@ class PreparedSignalComparison(PreparedComparison):
             identifier=self.identifier
         )
 
+    async def compare(self) -> Result:
+        # if signal is an enum, also flip the string field and retry
+        result = await super().compare()
+
+        if result.severity != Severity.success and self.signal.enum_strs:
+            self.comparison.string = not self.comparison.string
+            await self.get_data_async()
+            result = await super().compare()
+
+        return result
+
     @classmethod
     def from_device(
         cls,

--- a/atef/config.py
+++ b/atef/config.py
@@ -1214,7 +1214,8 @@ class PreparedSignalComparison(PreparedComparison):
         """
         result = await super().compare()
 
-        if result.severity != Severity.success and self.signal.enum_strs:
+        if (result.severity != Severity.success
+                and getattr(self.signal, 'enum_strs', None)):
             self.comparison.string = not self.comparison.string
             await self.get_data_async()
             result = await super().compare()

--- a/atef/config.py
+++ b/atef/config.py
@@ -1208,7 +1208,10 @@ class PreparedSignalComparison(PreparedComparison):
         )
 
     async def compare(self) -> Result:
-        # if signal is an enum, also flip the string field and retry
+        """
+        Run the inherited compare routine, but if signal is an enum,
+        also flip the string field and retry
+        """
         result = await super().compare()
 
         if result.severity != Severity.success and self.signal.enum_strs:

--- a/atef/config.py
+++ b/atef/config.py
@@ -1207,21 +1207,6 @@ class PreparedSignalComparison(PreparedComparison):
             identifier=self.identifier
         )
 
-    async def compare(self) -> Result:
-        """
-        Run the inherited compare routine, but if signal is an enum,
-        also flip the string field and retry
-        """
-        result = await super().compare()
-
-        if (result.severity != Severity.success
-                and getattr(self.signal, 'enum_strs', None)):
-            self.comparison.string = not self.comparison.string
-            await self.get_data_async()
-            result = await super().compare()
-
-        return result
-
     @classmethod
     def from_device(
         cls,

--- a/atef/reduce.py
+++ b/atef/reduce.py
@@ -23,10 +23,13 @@ class EnumValue:
     str_value: str
 
     def __eq__(self, __value: object) -> bool:
-        if isinstance(__value, int):
-            return self.int_value == __value
-        elif isinstance(__value, str):
-            return self.str_value == __value
+        if isinstance(__value, (int, str)):
+            try:
+                int_val = int(__value)
+            except ValueError:
+                int_val = __value
+
+            return self.int_value == int_val or self.str_value == str(__value)
         else:
             return False
 

--- a/atef/reduce.py
+++ b/atef/reduce.py
@@ -13,6 +13,27 @@ from .type_hints import Number, PrimitiveType
 from .util import run_in_executor
 
 
+@dataclass
+class EnumValue:
+    """
+    Wrapper for enum value that can be compared to either the string or int
+    value of the enum.  Only accepts string enums.
+    """
+    int_value: int
+    str_value: str
+
+    def __eq__(self, __value: object) -> bool:
+        if isinstance(__value, int):
+            return self.int_value == __value
+        elif isinstance(__value, str):
+            return self.str_value == __value
+        else:
+            return False
+
+    def __str__(self) -> str:
+        return f'Enum({self.int_value}|"{self.str_value}")'
+
+
 class _ReduceMethodType(Protocol):
     def __call__(self, data: Sequence[PrimitiveType], *args, **kwargs) -> PrimitiveType:
         ...
@@ -177,6 +198,12 @@ def get_data_for_signal(
             signal, reduce_period
         )
 
+    # if enum, return a special EnumValue
+    if getattr(signal, 'enum_strs', None):
+        int_value = signal.get(as_string=False)
+        str_value = signal.get(as_string=True)
+        return EnumValue(int_value, str_value)
+
     if string:
         return signal.get(as_string=True)
 
@@ -228,6 +255,12 @@ async def get_data_for_signal_async(
         )
 
     def inner_sync_get():
+        # if enum, return a special EnumValue
+        if getattr(signal, 'enum_strs', None):
+            int_value = signal.get(as_string=False)
+            str_value = signal.get(as_string=True)
+            return EnumValue(int_value, str_value)
+
         if string:
             return signal.get(as_string=True)
 

--- a/atef/tests/test_comparison.py
+++ b/atef/tests/test_comparison.py
@@ -298,7 +298,7 @@ async def test_epics_value(
     [1, Severity.error],
     ["YAG", Severity.error],
     ["UNKNOWN", Severity.error],
-    ["0", Severity.error],
+    ["0", Severity.success],
 ])
 async def test_enum_comparision(
     happi_client: happi.Client, value: Any, status: Severity

--- a/atef/tests/test_comparison.py
+++ b/atef/tests/test_comparison.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+import happi
 import pytest
 
 from atef.cache import DataCache
@@ -298,7 +301,7 @@ async def test_epics_value(
     ["0", Severity.error],
 ])
 async def test_enum_comparision(
-    happi_client, value, status
+    happi_client: happi.Client, value: Any, status: Severity
 ):
     dev = happi_client.search(name='enum1')[0].get()
     comp = Equals(value=value)

--- a/docs/source/upcoming_release_notes/219-mnt_enum_check.rst
+++ b/docs/source/upcoming_release_notes/219-mnt_enum_check.rst
@@ -1,0 +1,22 @@
+219 mnt_enum_check
+##################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Make comparisons against enum signals more robust by trying both the int and string versions if the check fails.
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
When checking against an enum signal, check against both the integer and string value if needed.
Also ignore tolerances unless comparing against a number

## Motivation and Context
closes #200 
closes #220 

## How Has This Been Tested?
Interactively, and a test case has been added. 

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
