### PR TITLE
ENH: Improve status output

### DIFF
--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -58,26 +58,6 @@ BS_STATE_MAP: Dict[int, BlueskyState] = {}
 MAX_PLAN_DEPTH = 200
 
 
-def walk_steps(
-    step: Union[ProcedureStep, PreparedProcedureStep]
-) -> Generator[Union[ProcedureStep, PreparedProcedureStep], None, None]:
-    """
-    Yield ProedureSteps in ``step``, depth-first.
-
-    Parameters
-    ----------
-    step : ProcedureStep
-        Step to yield ProcedureSteps from
-
-    Yields
-    ------
-    Generator[ProcedureStep, None, None]
-    """
-    yield step
-    for sub_step in getattr(step, 'steps', []):
-        yield from walk_steps(sub_step)
-
-
 @dataclasses.dataclass
 @serialization.as_tagged_union
 class ProcedureStep:
@@ -658,6 +638,13 @@ class PreparedProcedureGroup(PreparedProcedureStep):
         self.step_result = result
 
         return super().result
+
+    def walk_steps(self) -> Generator[AnyPreparedProcedure]:
+        for step in self.steps:
+            step = cast(AnyPreparedProcedure, step)
+            yield step
+            if hasattr(step, 'walk_steps'):
+                yield from step.walk_steps()
 
 
 @dataclass

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -58,7 +58,9 @@ BS_STATE_MAP: Dict[int, BlueskyState] = {}
 MAX_PLAN_DEPTH = 200
 
 
-def walk_steps(step: ProcedureStep) -> Generator[ProcedureStep, None, None]:
+def walk_steps(
+    step: Union[ProcedureStep, PreparedProcedureStep]
+) -> Generator[Union[ProcedureStep, PreparedProcedureStep], None, None]:
     """
     Yield ProedureSteps in ``step``, depth-first.
 

--- a/atef/qt_helpers.py
+++ b/atef/qt_helpers.py
@@ -436,7 +436,7 @@ def walk_tree_widget_items(
     tree_widget: QtWidgets.QTreeWidget
 ) -> Generator[Any, None, None]:
     """
-    Walk a ``QtWidgets.QTreeWidget``'s tree items.  Steps through items depht-first
+    Walk a ``QtWidgets.QTreeWidget``'s tree items.  Steps through items depth-first
 
     Parameters
     ----------

--- a/atef/tests/configs/active_test.json
+++ b/atef/tests/configs/active_test.json
@@ -42,15 +42,6 @@
               "value": 1.0,
               "timeout": 20.0,
               "settle_time": 5.0
-            },
-            {
-              "name": null,
-              "device": "im3k4",
-              "attr": "target.state",
-              "pv": "IM3K4:PPM:MMS:STATE:GET_RBV",
-              "value": 4,
-              "timeout": null,
-              "settle_time": null
             }
           ],
           "success_criteria": [

--- a/atef/tests/test_comparison.py
+++ b/atef/tests/test_comparison.py
@@ -292,6 +292,7 @@ async def test_epics_value(
     print(comparison(value).reason)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize('value, status', [
     [0, Severity.success],
     ['OUT', Severity.success],

--- a/atef/tests/test_walk.py
+++ b/atef/tests/test_walk.py
@@ -1,0 +1,73 @@
+""" Test walking functions """
+
+import pytest
+
+from atef.config import ConfigurationFile, PreparedFile
+from atef.procedure import PreparedProcedureFile, ProcedureFile
+from atef.tests.conftest import (active_checkout_configs,
+                                 passive_checkout_configs)
+from atef.walk import walk_config_file, walk_procedure_file
+
+
+def passive_walk_params():
+    """ Zip the checkout paths with their appropriate information """
+    # name, num_configs, num_comparisons
+    file_info = {
+        'lfe.json': (3, 42),  # 2 configs fail with happi access, 42 remaining comps
+        'all_fields.json': (6, 10),  # Entire device config fails w/o happi access
+        'blank_passive.json': (5, 0),  # no valid comparisons
+        'ping_localhost.json': (2, 4)
+    }
+    param_list = []
+    for filepath in passive_checkout_configs():
+        param_list.append((filepath, *file_info[filepath.name]))
+
+    return param_list
+
+
+@pytest.mark.parametrize(
+    'filepath,num_configs,num_comps',
+    passive_walk_params()
+)
+def test_passive_walks(filepath, num_configs, num_comps):
+    file = ConfigurationFile.from_filename(filepath)
+    prep_file = PreparedFile.from_config(file)
+    # also includes root
+    print([type(x[0]) for x in walk_config_file(prep_file)])
+    assert len(list(walk_config_file(prep_file))) == num_comps + num_configs + 1
+    assert len(list(prep_file.walk_groups())) == num_configs
+    assert len(list(prep_file.walk_comparisons())) == num_comps
+
+
+def active_walk_params():
+    """ Zip the checkout paths with their appropriate information """
+    # name, num_items (tree), num_steps
+    file_info = {
+        'active_test.json': (5, 4),  # 1 of each step type + 1 comparison
+        'blank_active.json': (6, 5),  # same as above + nested group
+    }
+    param_list = []
+    for filepath in active_checkout_configs():
+        param_list.append((filepath, *file_info[filepath.name]))
+
+    return param_list
+
+
+@pytest.mark.parametrize(
+    'filepath,num_items,num_steps',
+    active_walk_params()
+)
+def test_active_walks(filepath, num_items, num_steps):
+    file = ProcedureFile.from_filename(filepath)
+    prep_file = PreparedProcedureFile.from_origin(file)
+    # also includes root
+    print([type(x[0]) for x in walk_procedure_file(prep_file)])
+    assert len(list(walk_procedure_file(prep_file))) == num_items + 1
+    assert len(list(file.walk_steps())) == num_steps
+
+
+# Other ideas for tests:
+# - test gathered prepared comparisons match un-prepared (get_relevant_configs_comps)
+#   - requires walk_comparisons on un-prepared classes, unification of ordering
+# - test tree creation, match original and prepared
+#   - requires more tree helpers and may change with future refactors

--- a/atef/ui/results_summary.ui
+++ b/atef/ui/results_summary.ui
@@ -75,6 +75,13 @@
           </layout>
          </item>
          <item>
+          <widget class="Line" name="line">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
           <layout class="QFormLayout" name="formLayout">
            <property name="rightMargin">
             <number>5</number>
@@ -110,6 +117,20 @@
             <widget class="QWidget" name="type_combo_placeholder" native="true"/>
            </item>
           </layout>
+         </item>
+         <item>
+          <widget class="Line" name="line_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="refresh_button">
+           <property name="text">
+            <string>...</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>

--- a/atef/ui/results_summary.ui
+++ b/atef/ui/results_summary.ui
@@ -140,7 +140,7 @@
       <attribute name="title">
        <string>plain text</string>
       </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
         <widget class="QTextEdit" name="results_text">
          <property name="readOnly">
@@ -151,7 +151,14 @@
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;results_text&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="save_text_button">
+         <property name="text">
+          <string>Save Text Output</string>
          </property>
         </widget>
        </item>

--- a/atef/ui/results_summary.ui
+++ b/atef/ui/results_summary.ui
@@ -156,11 +156,22 @@ p, li { white-space: pre-wrap; }
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="save_text_button">
-         <property name="text">
-          <string>Save Text Output</string>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QPushButton" name="save_text_button">
+           <property name="text">
+            <string>Save Text Output</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="clipboard_button">
+           <property name="text">
+            <string>Copy to Clipboard</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/atef/ui/results_summary.ui
+++ b/atef/ui/results_summary.ui
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>540</width>
+    <height>355</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="table_tab">
+      <attribute name="title">
+       <string>table</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QTableView" name="results_table">
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContents</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <property name="topMargin">
+            <number>5</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="status_label">
+             <property name="text">
+              <string>Status</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="success_check">
+             <property name="text">
+              <string>Success</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="warning_check">
+             <property name="text">
+              <string>Warning</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="error_check">
+             <property name="text">
+              <string>Error</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QFormLayout" name="formLayout">
+           <property name="rightMargin">
+            <number>5</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="name_label">
+             <property name="text">
+              <string>Filter by name</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="name_edit"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="reason_label">
+             <property name="text">
+              <string>Filter by reason</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLineEdit" name="reason_edit"/>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="type_label">
+             <property name="text">
+              <string>Filter by type</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QWidget" name="type_combo_placeholder" native="true"/>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="text_tab">
+      <attribute name="title">
+       <string>plain text</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QTextEdit" name="results_text">
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+         <property name="html">
+          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;results_text&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/run_config_tree.ui
+++ b/atef/ui/run_config_tree.ui
@@ -35,6 +35,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="results_button">
+         <property name="text">
+          <string>Results Summary</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="print_report_button">
          <property name="text">
           <string>Print Report</string>

--- a/atef/walk.py
+++ b/atef/walk.py
@@ -1,0 +1,175 @@
+"""
+Helpers for walking dataclasses.
+
+If relying on Prepared dataclass walk methods (walk_groups, walk_comparisons),
+note that if a configuration fails to prepare, they will be skipped
+"""
+from __future__ import annotations
+
+from typing import Any, Generator, List, Tuple, Union
+
+from atef.check import Comparison
+from atef.config import (Configuration, PreparedComparison,
+                         PreparedConfiguration, PreparedFile)
+from atef.procedure import (PreparedProcedureFile, PreparedProcedureStep,
+                            ProcedureStep)
+
+
+def walk_config_file(
+    config: Union[PreparedFile, PreparedConfiguration, PreparedComparison],
+    level: int = 0
+) -> Generator[Tuple[Any, int], None, None]:
+    """
+    Yields each config and comparison and its depth
+    Performs a recursive depth-first search
+
+    Parameters
+    ----------
+    config : Union[PreparedFile, PreparedConfiguration, PreparedComparison]
+        the configuration or comparison to walk
+    level : int, optional
+        the current recursion depth, by default 0
+
+    Yields
+    ------
+    Generator[Tuple[Any, int], None, None]
+    """
+    yield config, level
+    if isinstance(config, PreparedFile):
+        yield from walk_config_file(config.root, level=level+1)
+    elif isinstance(config, PreparedConfiguration):
+        if hasattr(config, 'configs'):
+            for conf in config.configs:
+                yield from walk_config_file(conf, level=level+1)
+        if hasattr(config, 'comparisons'):
+            for comp in config.comparisons:
+                yield from walk_config_file(comp, level=level+1)
+
+
+def walk_procedure_file(
+    config: Union[PreparedProcedureFile, PreparedProcedureStep, PreparedComparison],
+    level: int = 0
+) -> Generator[Tuple[Any, int], None, None]:
+    """
+    Yields each ProcedureStep / Comparison and its depth
+    Performs a recursive depth-first search
+
+    Parameters
+    ----------
+    config : Union[PreparedProcedureFile, PreparedProcedureStep,
+                    PreparedComparison]
+        the item to yield and walk through
+    level : int, optional
+        the current recursion depth, by default 0
+
+    Yields
+    ------
+    Generator[Tuple[Any, int], None, None]
+    """
+    yield config, level
+    if isinstance(config, PreparedProcedureFile):
+        yield from walk_procedure_file(config.root, level=level+1)
+    elif isinstance(config, PreparedProcedureStep):
+        for sub_step in getattr(config, 'steps', []):
+            yield from walk_procedure_file(sub_step, level=level+1)
+        if hasattr(config, 'walk_comparisons'):
+            for sub_comp in config.walk_comparisons():
+                yield from walk_procedure_file(sub_comp, level=level+1)
+
+
+def walk_steps(
+    step: Union[ProcedureStep, PreparedProcedureStep]
+) -> Generator[Union[ProcedureStep, PreparedProcedureStep], None, None]:
+    """
+    Yield ProedureSteps in ``step``, depth-first.
+
+    Parameters
+    ----------
+    step : ProcedureStep
+        Step to yield ProcedureSteps from
+
+    Yields
+    ------
+    Generator[ProcedureStep, None, None]
+    """
+    yield step
+    for sub_step in getattr(step, 'steps', []):
+        yield from walk_steps(sub_step)
+
+
+def get_prepared_step(
+    prepared_file: PreparedProcedureFile,
+    origin: Union[ProcedureStep, Comparison],
+) -> List[Union[PreparedProcedureStep, PreparedComparison]]:
+    """
+    Gather all PreparedProcedureStep dataclasses the correspond to the original
+    ProcedureStep.
+    If a PreparedProcedureStep also has comparisions, use the walk_comparisons
+    method to check if the "origin" matches any of thoes comparisons
+
+    Only relevant for active checkouts.
+
+    Parameters
+    ----------
+    prepared_file : PreparedProcedureFile
+        the PreparedProcedureFile to search through
+    origin : Union[ProcedureStep, Comparison]
+        the step / comparison to match
+
+    Returns
+    -------
+    List[Union[PreparedProcedureStep, PreparedComparison]]
+        the PreparedProcedureStep's or PreparedComparison's related to ``origin``
+    """
+    # As of the writing of this docstring, this helper is only expected to return
+    # lists of length 1.  However in order to match the passive checkout workflow,
+    # we still return a list of relevant steps or comparisons.
+    matched_steps = []
+    for pstep in walk_steps(prepared_file.root):
+        if getattr(pstep, 'origin', None) is origin:
+            matched_steps.append(pstep)
+        # check PreparedComparisons, which might be included in some steps
+        if hasattr(pstep, 'walk_comparisons'):
+            for comp in pstep.walk_comparisons():
+                if comp.comparison is origin:
+                    matched_steps.append(comp)
+
+    return matched_steps
+
+
+def get_relevant_configs_comps(
+    prepared_file: PreparedFile,
+    original_c: Union[Configuration, Comparison]
+) -> List[Union[PreparedConfiguration, PreparedComparison]]:
+    """
+    Gather all the PreparedConfiguration or PreparedComparison dataclasses
+    that correspond to the original comparison or config.
+
+    Phrased another way: maps prepared comparisons onto the comparison
+    seen in the GUI
+
+    Currently for passive checkout files only
+
+    Parameters
+    ----------
+    prepared_file : PreparedFile
+        the file containing configs or comparisons to be gathered
+    original_c : Union[Configuration, Comparison]
+        the comparison to match PreparedComparison or PreparedConfigurations to
+
+    Returns
+    -------
+    List[Union[PreparedConfiguration, PreparedComparison]]:
+        the configuration or comparison dataclasses related to ``original_c``
+    """
+    matched_c = []
+
+    for config in prepared_file.walk_groups():
+        if config.config is original_c:
+            matched_c.append(config)
+
+    for comp in prepared_file.walk_comparisons():
+        if comp.comparison is original_c:
+            matched_c.append(comp)
+
+    return matched_c

--- a/atef/walk.py
+++ b/atef/walk.py
@@ -6,19 +6,20 @@ note that if a configuration fails to prepare, they will be skipped
 """
 from __future__ import annotations
 
-from typing import Any, Generator, List, Tuple, Union
+from typing import Generator, List, Tuple, Union
 
 from atef.check import Comparison
-from atef.config import (Configuration, PreparedComparison,
-                         PreparedConfiguration, PreparedFile)
-from atef.procedure import (PreparedProcedureFile, PreparedProcedureStep,
-                            ProcedureStep)
+from atef.config import (AnyPreparedConfiguration, Configuration,
+                         PreparedComparison, PreparedConfiguration,
+                         PreparedFile)
+from atef.procedure import (AnyPreparedProcedure, PreparedProcedureFile,
+                            PreparedProcedureStep, ProcedureStep)
 
 
 def walk_config_file(
     config: Union[PreparedFile, PreparedConfiguration, PreparedComparison],
     level: int = 0
-) -> Generator[Tuple[Any, int], None, None]:
+) -> Generator[Tuple[Union[AnyPreparedConfiguration, PreparedComparison], int], None, None]:
     """
     Yields each config and comparison and its depth
     Performs a recursive depth-first search
@@ -49,7 +50,7 @@ def walk_config_file(
 def walk_procedure_file(
     config: Union[PreparedProcedureFile, PreparedProcedureStep, PreparedComparison],
     level: int = 0
-) -> Generator[Tuple[Any, int], None, None]:
+) -> Generator[Tuple[Union[AnyPreparedProcedure, PreparedComparison], int], None, None]:
     """
     Yields each ProcedureStep / Comparison and its depth
     Performs a recursive depth-first search

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -37,7 +37,7 @@ from atef.config import ConfigurationFile
 from atef.qt_helpers import QDataclassElem
 from atef.result import Result, incomplete_result
 from atef.widgets.config.data_base import DataWidget, SimpleRowWidget
-from atef.widgets.config.run_base import create_tree_items
+from atef.widgets.config.run_base import create_tree_from_file
 from atef.widgets.config.utils import (ConfigTreeModel, MultiInputDialog,
                                        TableWidgetWithAddRow, TreeItem)
 from atef.widgets.core import DesignerDisplay
@@ -518,7 +518,7 @@ class PassiveEditWidget(DesignerDisplay, DataWidget):
         """
         # tree data
         root_item = TreeItem(data=config_file)
-        create_tree_items(data=config_file.root, parent=root_item)
+        create_tree_from_file(data=config_file.root, parent=root_item)
 
         model = ConfigTreeModel(data=root_item)
 

--- a/atef/widgets/config/result_summary.py
+++ b/atef/widgets/config/result_summary.py
@@ -1,0 +1,308 @@
+"""
+Widgets for summarizing the results of a run.
+"""
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, List
+
+from PyQt5.QtCore import QModelIndex
+from qtpy import QtCore, QtGui, QtWidgets
+
+from atef.config import PreparedFile
+from atef.enums import Severity
+from atef.procedure import PreparedProcedureFile
+from atef.type_hints import AnyDataclass
+from atef.walk import walk_config_file, walk_procedure_file
+from atef.widgets.core import DesignerDisplay
+from atef.widgets.utils import insert_widget
+
+
+@dataclasses.dataclass
+class ResultInfo:
+    """ Normalized, and slightly processed view of configs/steps with results """
+    status: Severity
+    name: str
+    reason: str
+    origin: AnyDataclass
+
+    @property
+    def type(self):
+        return type(self.origin).__name__
+
+
+class ResultModel(QtCore.QAbstractTableModel):
+    """
+    Item model for results.  Read-Only.
+    To be proxied for searching
+    """
+    result_info: List[ResultInfo]
+
+    def __init__(self, *args, data: List[ResultInfo] = [], **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.result_info = data
+        self.headers = ['Status', 'Type', 'Name', 'Reason']
+
+    @classmethod
+    def from_file(cls, file) -> ResultModel:
+        """ Build this model from a PreparedFile which contains results"""
+        if isinstance(file, PreparedFile):
+            datac = [cfg_tuple[0] for cfg_tuple in walk_config_file(file.root)]
+            data = []
+            for c in datac:
+                origin = getattr(c, 'config', None) or getattr(c, 'comparison', None)
+                if origin is None:
+                    raise ValueError('could not find origin of passive component')
+                info = ResultInfo(
+                    status=c.result.severity,
+                    reason=c.result.reason,
+                    name=origin.name,
+                    origin=origin
+                )
+                data.append(info)
+        elif isinstance(file, PreparedProcedureFile):
+            datac = [st_tuple[0] for st_tuple in walk_procedure_file(file.root)]
+            data = []
+            for s in datac:
+                data.append(ResultInfo(
+                    status=s.result.severity,
+                    reason=s.result.reason,
+                    name=s.origin.name,
+                    origin=s.origin
+                ))
+
+        return cls(data=data)
+
+    def rowCount(self, parent: QtCore.QModelIndex) -> int:
+        return len(self.result_info)
+
+    def columnCount(self, parent: QtCore.QModelIndex) -> int:
+        return 4
+
+    def data(self, index: QtCore.QModelIndex, role: int) -> Any:
+        if not index.isValid():
+            return None
+
+        if role == QtCore.Qt.DisplayRole:
+            if index.column() == 0:
+                return self.result_info[index.row()].status.name
+            elif index.column() == 1:
+                return self.result_info[index.row()].type
+            elif index.column() == 2:
+                return self.result_info[index.row()].name
+            elif index.column() == 3:
+                return self.result_info[index.row()].reason
+
+    def headerData(
+        self, section: int, orientation: QtCore.Qt.Orientation, role: int
+    ) -> Any:
+        if role != QtCore.Qt.DisplayRole:
+            return
+
+        if orientation == QtCore.Qt.Horizontal:
+            return self.headers[section]
+
+    def dclass_types(self) -> List[str]:
+        return set(res.type for res in self.result_info)
+
+
+class CheckableComboBox(QtWidgets.QComboBox):
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.setEditable(True)
+        self.lineEdit().setReadOnly(True)
+
+        # make the line edit look more like a button
+        palette = QtWidgets.QApplication.palette()
+        palette.setBrush(QtGui.QPalette.Base, palette.button())
+        self.lineEdit().setPalette(palette)
+
+        # manage click events on line edit
+        self.lineEdit().installEventFilter(self)
+        self.close_on_edit_click = False
+
+        self.model().itemChanged.connect(self.update_text)
+
+    def eventFilter(self, object, event):
+
+        if object == self.lineEdit():
+            if event.type() == QtCore.QEvent.MouseButtonRelease:
+                if self.close_on_edit_click:
+                    self.hidePopup()
+                else:
+                    self.showPopup()
+                return True
+            return False
+
+        return False
+
+    def showPopup(self):
+        super().showPopup()
+        # When the popup is displayed, a click on the lineedit should close it
+        self.close_on_edit_click = True
+
+    def hidePopup(self):
+        super().hidePopup()
+        # Used to prevent immediate reopening when clicking on the lineEdit
+        self.startTimer(100)
+        # Refresh the display text when closing
+        self.update_text()
+        self.close_on_edit_click = False
+
+    def addItem(self, item):
+        super(CheckableComboBox, self).addItem(item)
+        item = self.model().item(self.count() - 1, 0)
+        item.setFlags(QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsEnabled)
+        item.setCheckState(QtCore.Qt.Checked)
+
+    def itemChecked(self, index):
+        item = self.model().item(index, 0)
+        return item.checkState() == QtCore.Qt.Checked
+
+    def update_text(self) -> None:
+        """ if we have items, make text show all of them """
+        items = []
+        for i in range(self.model().rowCount()):
+            item = self.model().item(i, 0)
+            if item.checkState() == QtCore.Qt.Checked:
+                items.append(item.text())
+
+        if len(items) > 3:
+            self.lineEdit().setText(f'[{len(items)}] types shown')
+        else:
+            self.lineEdit().setText(', '.join(items))
+
+
+class ResultFilterProxyModel(QtCore.QSortFilterProxyModel):
+    """
+    Filter proxy model specifically for ResultModel.
+    Combines multiple filter conditions
+    """
+
+    name_regexp: QtCore.QRegularExpression
+    reason_regexp: QtCore.QRegularExpression
+
+    allowed_types: List[str]
+    allowed_statuses: List[str]
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.name_regexp = QtCore.QRegularExpression()
+        self.reason_regexp = QtCore.QRegularExpression()
+        self.allowed_types = []
+        self.allowed_statuses = []
+
+    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:
+        name_ok, reason_ok, type_ok, status_ok = True, True, True, True
+
+        name_index = self.sourceModel().index(source_row, 2, source_parent)
+        name = self.sourceModel().data(name_index, QtCore.Qt.DisplayRole)
+        name_ok = self.name_regexp.match(name).hasMatch()
+
+        reason_index = self.sourceModel().index(source_row, 3, source_parent)
+        reason = self.sourceModel().data(reason_index, QtCore.Qt.DisplayRole)
+        reason_ok = self.reason_regexp.match(reason).hasMatch()
+
+        if self.allowed_types:
+            type_index = self.sourceModel().index(source_row, 1, source_parent)
+            type_data = self.sourceModel().data(type_index, QtCore.Qt.DisplayRole)
+            type_ok = type_data in self.allowed_types
+
+        if self.allowed_statuses:
+            status_index = self.sourceModel().index(source_row, 0, source_parent)
+            status_data = self.sourceModel().data(status_index, QtCore.Qt.DisplayRole)
+            status_ok = status_data in self.allowed_statuses
+
+        return name_ok and reason_ok and type_ok and status_ok
+
+
+class ResultsSummaryWidget(DesignerDisplay, QtWidgets.QWidget):
+    """
+    Widget for showing results summary
+    """
+    filename = 'results_summary.ui'
+
+    results_table: QtWidgets.QTableView
+    results_text: QtWidgets.QTextEdit
+
+    reason_edit: QtWidgets.QLineEdit
+    name_edit: QtWidgets.QLineEdit
+    type_combo_placeholder: QtWidgets.QWidget
+    type_combo: CheckableComboBox
+
+    success_check: QtWidgets.QCheckBox
+    warning_check: QtWidgets.QCheckBox
+    error_check: QtWidgets.QCheckBox
+
+    def __init__(self, *args, file: Any, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.file = file
+        self.setup_ui()
+        self.status_map = {'success': self.success_check,
+                           'warning': self.warning_check,
+                           'error': self.error_check,
+                           'internal_error': self.error_check}
+
+    def setup_ui(self) -> None:
+        self.model = ResultModel.from_file(self.file)
+        self.proxy_model = ResultFilterProxyModel()
+        self.proxy_model.setSourceModel(self.model)
+        self.results_table.setModel(self.proxy_model)
+        self.results_table.setSortingEnabled(True)
+        self.results_table.horizontalHeader().setStretchLastSection(True)
+
+        self.success_check.setChecked(True)
+        self.warning_check.setChecked(True)
+        self.error_check.setChecked(True)
+
+        # setup type combo box
+        self.type_combo = CheckableComboBox()
+        insert_widget(self.type_combo, self.type_combo_placeholder)
+        # Fill combo box with types
+        for dclass_type in self.model.dclass_types():
+            self.type_combo.addItem(dclass_type)
+
+        # connect filter widgets
+        self.name_edit.textChanged.connect(self.filters_changed)
+        self.reason_edit.textChanged.connect(self.filters_changed)
+        self.type_combo.model().itemChanged.connect(self.filters_changed)
+        self.success_check.stateChanged.connect(self.filters_changed)
+        self.warning_check.stateChanged.connect(self.filters_changed)
+        self.error_check.stateChanged.connect(self.filters_changed)
+
+    def filters_changed(self, *args, **kwargs) -> None:
+        """ Update all the filters on the proxy model """
+        self.proxy_model.name_regexp.setPattern(self.name_edit.text())
+        self.proxy_model.reason_regexp.setPattern(self.reason_edit.text())
+        self.proxy_model.allowed_statuses = self.get_allowed_statuses()
+        self.proxy_model.allowed_types = self.get_allowed_types()
+        self.proxy_model.invalidateFilter()
+        self.update_plain_text()
+
+    def get_allowed_statuses(self) -> List[str]:
+        return [status_key for status_key, status_widget
+                in self.status_map.items()
+                if status_widget.isChecked()]
+
+    def get_allowed_types(self) -> List[str]:
+        allowed_types = []
+        for i in range(self.type_combo.model().rowCount()):
+            item = self.type_combo.model().item(i)
+            if item.checkState() == QtCore.Qt.Checked:
+                allowed_types.append(item.text())
+
+        return allowed_types
+
+    def update_plain_text(self) -> None:
+        text = 'status, type, name, reason\n'
+        for i in range(self.proxy_model.rowCount()):
+            row = []
+            for j in range(self.proxy_model.columnCount()):
+                index = self.proxy_model.index(i, j)
+                row.append(self.proxy_model.data(index, QtCore.Qt.DisplayRole))
+
+            text += ', '.join(row)
+            text += '\n'
+
+        self.results_text.setText(text)

--- a/atef/widgets/config/run_active.py
+++ b/atef/widgets/config/run_active.py
@@ -16,7 +16,7 @@ from atef.config import (ConfigurationFile, PreparedFile,
 from atef.procedure import (PreparedDescriptionStep, PreparedPassiveStep,
                             PreparedSetValueStep, PreparedValueToSignal)
 from atef.widgets.config.data_base import DataWidget
-from atef.widgets.config.run_base import ResultStatus, create_tree_items
+from atef.widgets.config.run_base import ResultStatus, create_tree_from_file
 from atef.widgets.config.utils import ConfigTreeModel, TreeItem
 from atef.widgets.core import DesignerDisplay
 from atef.widgets.utils import insert_widget
@@ -60,8 +60,8 @@ class PassiveRunWidget(DesignerDisplay, DataWidget):
         root_item = TreeItem(
             data=self.config_file, prepared_data=self.prepared_config
         )
-        create_tree_items(data=self.config_file.root, parent=root_item,
-                          prepared_file=self.prepared_config)
+        create_tree_from_file(data=self.config_file.root, parent=root_item,
+                              prepared_file=self.prepared_config)
 
         model = ConfigTreeModel(data=root_item)
         self.tree_view.setModel(model)

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -412,12 +412,12 @@ def create_tree_from_file(
     prepared_file: Optional[Union[PreparedFile, PreparedProcedureFile]] = None
 ):
     # Is prepared_data really optional?...
-    root_item = TreeItem(data=data, prepared_data=prepared_file)
+    root_item = TreeItem()
     if isinstance(data, ConfigurationFile):
-        create_passive_tree_items(data.root, root_item, prepared_file)
+        create_passive_tree_items(data, root_item, prepared_file)
         return root_item
     if isinstance(data, ProcedureFile):
-        create_active_tree_items(data.root, root_item, prepared_file)
+        create_active_tree_items(data, root_item, prepared_file)
         return root_item
 
     raise TypeError("Data was not a passive or active checkout file")
@@ -435,7 +435,7 @@ def create_passive_tree_items(
     # Handle root if necessary
     if hasattr(data, 'root'):
         # top level, add root item.
-        item = TreeItem(data, prepared_data=[prepared_data])
+        item = TreeItem(data.root, prepared_data=[prepared_data.root])
         create_passive_tree_items(data.root, item, prepared_data=prepared_data)
         parent.addChild(item)
 
@@ -480,8 +480,8 @@ def create_active_tree_items(
     # Handle root if necessary
     if hasattr(data, 'root'):
         # top level, add root item.
-        item = TreeItem(data, prepared_data=[prepared_data])
-        create_active_tree_items(data.root, item, prepared_file=prepared_data)
+        item = TreeItem(data.root, prepared_data=[prepared_data.root])
+        create_active_tree_items(data.root, item, prepared_data=prepared_data)
         parent.addChild(item)
 
     # ProcedureGroup

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -287,7 +287,7 @@ class RunCheck(DesignerDisplay, QWidget):
     def update_all_icons_tooltips(self) -> None:
         """ Convenience method for updating all the icons and tooltips """
         if not self.data:
-            logger.warning('No config associated with this step')
+            logger.debug('No config associated with this step')
             return
 
         self.update_icon(self.result_label, self.results)
@@ -452,6 +452,8 @@ def create_passive_tree_items(
     # look into configs, by_attr, by_pv, and shared
     # no config has both "by_attr" and "by_pv", but shared shows up last in tree
     # merges List[List[Comparison]] --> List[Comparison] with itertools
+    # This skips nested comparisons (via AnyComparison), which is the correct
+    # behavior, as those nested comparisons will not have Prepared variants or results
     config_categories = [
         itertools.chain.from_iterable(getattr(data, 'by_attr', {}).values()),
         itertools.chain.from_iterable(getattr(data, 'by_pv', {}).values()),

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -18,10 +18,9 @@ from qtpy.QtWidgets import (QDialogButtonBox, QLabel, QLineEdit, QMenu,
 from atef.config import (AnyConfiguration, AnyPreparedConfiguration,
                          ConfigurationFile, PreparedComparison, PreparedFile)
 from atef.enums import Severity
-from atef.procedure import (AnyPreparedProcedure, AnyProcedure,
-                            PreparedProcedureFile, PreparedProcedureGroup,
-                            PreparedProcedureStep, ProcedureFile,
-                            ProcedureStep)
+from atef.procedure import (AnyProcedure, PreparedProcedureFile,
+                            PreparedProcedureGroup, PreparedProcedureStep,
+                            ProcedureFile, ProcedureStep)
 from atef.result import Result, combine_results
 from atef.walk import get_prepared_step, get_relevant_configs_comps
 from atef.widgets.config.utils import TreeItem, disable_widget
@@ -409,9 +408,8 @@ class VerifyEntryWidget(DesignerDisplay, QWidget):
 
 def create_tree_from_file(
     data: Union[ConfigurationFile, ProcedureFile],
-    prepared_file: Optional[Union[PreparedFile, PreparedProcedureFile]] = None
+    prepared_file: Union[PreparedFile, PreparedProcedureFile]
 ):
-    # Is prepared_data really optional?...
     root_item = TreeItem()
     if isinstance(data, ConfigurationFile):
         create_passive_tree_items(data, root_item, prepared_file)
@@ -426,7 +424,7 @@ def create_tree_from_file(
 def create_passive_tree_items(
     data: AnyConfiguration,
     parent: TreeItem,
-    prepared_data: Optional[AnyPreparedConfiguration] = None  # Any prepared thing...
+    prepared_data: PreparedFile
 ) -> None:
     """
     Recursively create the tree starting from the given data
@@ -470,12 +468,10 @@ def create_passive_tree_items(
             parent.addChild(item)
 
 
-# TODO: Check to prepared_data may not ever get reduced, so could just be the
-# file the whole way through.
 def create_active_tree_items(
     data: AnyProcedure,
     parent: TreeItem,
-    prepared_data: Optional[AnyPreparedProcedure] = None
+    prepared_data: PreparedFile
 ) -> None:
     # Handle root if necessary
     if hasattr(data, 'root'):

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -1160,6 +1160,14 @@ class ConfigTreeModel(QtCore.QAbstractItemModel):
 
         return None
 
+    def data_updated(self) -> None:
+        """ method for calling dataChanged on the entire view """
+        top_left = self.index(0, 0, QtCore.QModelIndex())
+        bottom_right = self.index(self.rowCount(QtCore.QModelIndex()),
+                                  self.columnCount(QtCore.QModelIndex()),
+                                  QtCore.QModelIndex())
+        self.dataChanged.emit(top_left, bottom_right)
+
 
 # TODO: Rename this and related helpers to be more specific
 # (this refers to steps/configs and their statuses. )
@@ -1180,7 +1188,7 @@ class TreeItem:
         # x mark
         Severity.internal_error: ('\u2718', QColor(255, 0, 0, 255)),
         Severity.error: ('\u2718', QColor(255, 0, 0, 255)),
-        'N/A': ('', QColor())
+        'N/A': ('nothing', QColor())
     }
 
     def __init__(
@@ -1236,6 +1244,8 @@ class TreeItem:
 
     def tooltip(self) -> str:
         """ Construct the tooltip based on the stored result """
+        if not self.prepared_data:
+            return 'Failed to prepare'
         if self.combined_result:
             reason = self.combined_result.reason
             return reason.strip('[]').replace(', ', '\n')

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -1946,7 +1946,7 @@ class MultiModeValueEdit(DesignerDisplay, QWidget):
             start = time.monotonic()
             for sig in sigs:
                 try:
-                    sig.wait_for_connection(timeout=1)
+                    sig.wait_for_connection()
                 except TimeoutError:
                     pass
                 if time.monotonic() - start >= 1:

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -34,13 +34,13 @@ from atef.config import (Configuration, DeviceConfiguration,
                          PreparedFile, PVConfiguration, ToolConfiguration)
 from atef.enums import Severity
 from atef.exceptions import DynamicValueError, MissingHappiDeviceError
-from atef.procedure import (ProcedureFile, ProcedureStep, SetValueStep,
-                            walk_steps)
+from atef.procedure import ProcedureFile, ProcedureStep, SetValueStep
 from atef.qt_helpers import (QDataclassBridge, QDataclassList, QDataclassValue,
                              ThreadWorker)
 from atef.result import combine_results, incomplete_result
 from atef.tools import Ping
 from atef.type_hints import Number
+from atef.walk import walk_steps
 from atef.widgets.archive_viewer import get_archive_viewer
 from atef.widgets.core import DesignerDisplay
 from atef.widgets.happi import HappiDeviceComponentWidget

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -498,6 +498,7 @@ class EditTree(DesignerDisplay, QWidget):
             self.show_selected_display
         )
         self.tree_widget.setCurrentItem(self.root_item)
+        self.tree_widget.expandAll()
 
     def assemble_tree(self):
         """

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -598,13 +598,25 @@ class RunTree(EditTree):
         self.tree_view.header().swapSections(0, 1)
         self.tree_view.expandAll()
         # Connect to pages
-        for old_it, new_it in zip(walk_tree_widget_items(self.tree_widget),
-                                  walk_tree_items(self.root_item)):
-            # assign widget to item
-            new_it.widget = old_it.widget
+        # TODO: when we redo tree construction, this may need looking at
+        # ugly and dumb as is, but we need to make sure pages match tree items
+        for new_it in walk_tree_items(self.root_item):
+            for old_it in walk_tree_widget_items(self.tree_widget):
+                # match precisely the edit-mode dataclass
+                if old_it.widget.data is new_it._data:
+                    # assign widget to item
+                    new_it.widget = old_it.widget
+                    break
 
         # show widgets when interacting with new tree
         self.tree_view.selectionModel().selectionChanged.connect(self.show_selected_page)
+
+        # update tree statuses with every result update
+        for item in walk_tree_items(self.root_item):
+            if item.widget:
+                item.widget.run_check.results_updated.connect(
+                    self.model.data_updated
+                )
 
         insert_widget(self.tree_view, self.tree_widget)
 

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -17,7 +17,7 @@ from typing import ClassVar, Dict, Optional, Union
 import qtawesome
 from apischema import ValidationError, deserialize, serialize
 from pcdsutils.qt.callbacks import WeakPartialMethodSlot
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtCore import Signal as QSignal
 from qtpy.QtWidgets import (QAction, QFileDialog, QMainWindow, QMessageBox,
@@ -31,15 +31,15 @@ from atef.qt_helpers import walk_tree_widget_items
 from atef.report import ActiveAtefReport, PassiveAtefReport
 from atef.widgets.config.find_replace import (FillTemplatePage,
                                               FindReplaceWidget)
-from atef.widgets.utils import reset_cursor, set_wait_cursor
+from atef.widgets.utils import insert_widget, reset_cursor, set_wait_cursor
 
 from ..archive_viewer import get_archive_viewer
 from ..core import DesignerDisplay
 from .page import (AtefItem, ConfigurationGroupPage, PageWidget,
-                   ProcedureGroupPage, RunStepPage, link_page)
-from .run_base import (get_prepared_step, get_relevant_configs_comps,
-                       make_run_page)
-from .utils import MultiInputDialog, Toggle, clear_results
+                   ProcedureGroupPage, RunStepPage, link_page, walk_tree_items)
+from .run_base import (create_tree_from_file, get_prepared_step,
+                       get_relevant_configs_comps, make_run_page)
+from .utils import ConfigTreeModel, MultiInputDialog, Toggle, clear_results
 
 logger = logging.getLogger(__name__)
 
@@ -515,6 +515,7 @@ class EditTree(DesignerDisplay, QWidget):
         root_page = self.page_class(
             data=root_configuration_group,
         )
+        # Linking pages will set up and assign child pages
         link_page(item=self.root_item, widget=root_page)
         root_page.parent_button.hide()
 
@@ -570,8 +571,7 @@ class RunTree(EditTree):
         **kwargs
     ):
         super().__init__(config_file=config_file, full_path=full_path)
-        # Prepared file only exists for passive checkouts, None otherwise
-        self.prepared_file: Optional[PreparedFile] = None
+        self.prepared_file: Optional[Union[PreparedFile, PreparedProcedureFile]] = None
         if isinstance(config_file, ConfigurationFile):
             self.prepared_file = PreparedFile.from_config(config_file,
                                                           cache=DataCache())
@@ -581,6 +581,64 @@ class RunTree(EditTree):
 
         self._swap_to_run_widgets()
         self.print_report_button.clicked.connect(self.print_report)
+        # use new tree view summary
+        self.tree_view = QtWidgets.QTreeView()
+        self.root_item = create_tree_from_file(
+            data=self.config_file,
+            prepared_file=self.prepared_file
+        )
+        self.model = ConfigTreeModel(data=self.root_item)
+
+        self.tree_view.setModel(self.model)
+
+        self.tree_view.resizeColumnToContents(1)
+        self.tree_view.header().swapSections(0, 1)
+        self.tree_view.expandAll()
+        # Connect to pages
+        for old_it, new_it in zip(walk_tree_widget_items(self.tree_widget),
+                                  walk_tree_items(self.root_item)):
+            # assign widget to item
+            new_it.widget = old_it.widget
+
+        # show widgets when interacting with new tree
+        self.tree_view.selectionModel().selectionChanged.connect(self.show_selected_page)
+
+        insert_widget(self.tree_view, self.tree_widget)
+
+    def show_selected_page(
+        self,
+        selected: QtCore.QItemSelection,
+        deselected: QtCore.QItemSelection
+    ) -> None:
+        """
+        Show the proper widget on the right when a tree row is selected.
+
+        This works by hiding the previous widget and showing the new
+        selection, creating the widget object if needed.
+        """
+        selected_indexes = selected.indexes()
+
+        item = selected_indexes[0].internalPointer()
+
+        if item is None:
+            logger.error('Tree has no currentItem.  Cannot show selected')
+            return
+        if item is self.last_selection:
+            return
+
+        replace = bool(self.last_selection is not None)
+        if self.last_selection is not None:
+            self.last_selection.widget.setVisible(False)
+        widget = item.widget
+        if widget not in self.built_widgets:
+            self.built_widgets.add(widget)
+
+        if replace:
+            self.splitter.replaceWidget(1, widget)
+        else:
+            self.splitter.addWidget(widget)
+        widget.setVisible(True)
+        self.last_selection = item
 
     # TODO: set up to use Procedure widgets instead of config ones
     @classmethod

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -768,8 +768,10 @@ class RunTree(EditTree):
 
     def show_results_summary(self):
         """ show the results summary widget """
-        self._summary_widget = ResultsSummaryWidget(file=self.prepared_file)
+        self._summary_widget = ResultsSummaryWidget(parent=self,
+                                                    file=self.prepared_file)
         self._summary_widget.setWindowTitle('Results Summary')
+        self._summary_widget.setWindowFlags(QtCore.Qt.Window)
         self._summary_widget.show()
 
 

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -583,6 +583,7 @@ class RunTree(EditTree):
 
         self._swap_to_run_widgets()
         self.print_report_button.clicked.connect(self.print_report)
+        self._summary_widget: Optional[ResultsSummaryWidget] = None
         self.results_button.clicked.connect(self.show_results_summary)
         # use new tree view summary
         self.tree_view = QtWidgets.QTreeView()
@@ -632,8 +633,17 @@ class RunTree(EditTree):
         """
         Show the proper widget on the right when a tree row is selected.
 
+        For use as a slot connecting to QTreeView.selectionModel().selectionChanged
+
         This works by hiding the previous widget and showing the new
         selection, creating the widget object if needed.
+
+        Parameters
+        ----------
+        selected : QtCore.QItemSelection
+            Selected region
+        deselected : QtCore.QItemSelection
+            Deselected region (unused)
         """
         selected_indexes = selected.indexes()
 
@@ -756,6 +766,7 @@ class RunTree(EditTree):
         return msg
 
     def show_results_summary(self):
+        """ show the results summary widget """
         self._summary_widget = ResultsSummaryWidget(file=self.prepared_file)
         self._summary_widget.setWindowTitle('Results Summary')
         self._summary_widget.show()

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -29,6 +29,7 @@ from atef.procedure import (DescriptionStep, PassiveStep,
                             PreparedProcedureFile, ProcedureFile, SetValueStep)
 from atef.qt_helpers import walk_tree_widget_items
 from atef.report import ActiveAtefReport, PassiveAtefReport
+from atef.walk import get_prepared_step, get_relevant_configs_comps
 from atef.widgets.config.find_replace import (FillTemplatePage,
                                               FindReplaceWidget)
 from atef.widgets.utils import insert_widget, reset_cursor, set_wait_cursor
@@ -37,8 +38,8 @@ from ..archive_viewer import get_archive_viewer
 from ..core import DesignerDisplay
 from .page import (AtefItem, ConfigurationGroupPage, PageWidget,
                    ProcedureGroupPage, RunStepPage, link_page, walk_tree_items)
-from .run_base import (create_tree_from_file, get_prepared_step,
-                       get_relevant_configs_comps, make_run_page)
+from .result_summary import ResultsSummaryWidget
+from .run_base import create_tree_from_file, make_run_page
 from .utils import ConfigTreeModel, MultiInputDialog, Toggle, clear_results
 
 logger = logging.getLogger(__name__)
@@ -562,6 +563,7 @@ class RunTree(EditTree):
     filename = 'run_config_tree.ui'
 
     print_report_button: QtWidgets.QPushButton
+    results_button: QtWidgets.QPushButton
 
     def __init__(
         self,
@@ -581,6 +583,7 @@ class RunTree(EditTree):
 
         self._swap_to_run_widgets()
         self.print_report_button.clicked.connect(self.print_report)
+        self.results_button.clicked.connect(self.show_results_summary)
         # use new tree view summary
         self.tree_view = QtWidgets.QTreeView()
         self.root_item = create_tree_from_file(
@@ -735,6 +738,11 @@ class RunTree(EditTree):
         msg = MultiInputDialog(parent=self, init_values=info)
         msg.exec()
         return msg
+
+    def show_results_summary(self):
+        self._summary_widget = ResultsSummaryWidget(file=self.prepared_file)
+        self._summary_widget.setWindowTitle('Results Summary')
+        self._summary_widget.show()
 
 
 class DualTree(QWidget):

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -601,9 +601,13 @@ class RunTree(EditTree):
         # TODO: when we redo tree construction, this may need looking at
         # ugly and dumb as is, but we need to make sure pages match tree items
         for new_it in walk_tree_items(self.root_item):
+            if new_it._data is None:  # Skip the empty root
+                continue
+            logger.debug(f'attempting to match {type(new_it._data)}')
             for old_it in walk_tree_widget_items(self.tree_widget):
-                # match precisely the edit-mode dataclass
-                if old_it.widget.data is new_it._data:
+                # match precisely the edit-mode dataclass, wherever it is
+                if new_it._data in (old_it.widget.data,
+                                    getattr(old_it.widget.data, 'origin', None)):
                     # assign widget to item
                     new_it.widget = old_it.widget
                     break

--- a/docs/source/upcoming_release_notes/221-enh_status_out.rst
+++ b/docs/source/upcoming_release_notes/221-enh_status_out.rst
@@ -7,7 +7,7 @@ API Breaks
 
 Features
 --------
-- Adds results summary page accessible from run-mode
+- Adds results summary page accessible from run-mode in the `atef config` GUI
 - Adds icons to run-mode tree view
 
 Bugfixes

--- a/docs/source/upcoming_release_notes/221-enh_status_out.rst
+++ b/docs/source/upcoming_release_notes/221-enh_status_out.rst
@@ -1,0 +1,23 @@
+221 enh_status_out
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds results summary page accessible from run-mode
+- Adds icons to run-mode tree view
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Refactors tree-walking helpers to a separate submodle
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- Refactors "walk" helpers to a separate submodule, because I was getting confused and caught myself re-inventing the wheel
- Use ConfigTreeModel to show results in the tree view during run-mode (closes #146)
- Adds a "Results Summary" widget that shows a filterable view of checkout results, as well as a plaintext csv view for copying etc

## Motivation and Context
Also jira [ECS-1380](https://jira.slac.stanford.edu/browse/ECS-1380?jql=project%20%3D%20ECS%20AND%20component%20%3D%20ATEF)

Because the next thing I intend to do is rework how the page loading is done (for performance reasons), I expect the way trees are constructed to change significantly.  There's a couple places where I left todos to circle back on after I've settled on an approach.  

## How Has This Been Tested?
Interactively, a couple tests added

## Where Has This Been Documented?
This PR

![image](https://github.com/pcdshub/atef/assets/35379409/e5298af9-92ad-40fb-a61b-52b591fc2d1d)

<img width="793" alt="image" src="https://github.com/pcdshub/atef/assets/35379409/842c2fac-e648-420f-bccd-137a3bde0fa9">

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] (🤮)Test suite passes on GitHub Actions (😭)
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
