### PR TITLE
ENH: Add and apply PagedTableWidget

### DIFF
--- a/atef/config.py
+++ b/atef/config.py
@@ -99,6 +99,32 @@ class Configuration:
                     else:
                         break
 
+    def move_comparison(
+        self,
+        comp: Comparison,
+        new_attr: str,
+        comp_attrs: List[str],
+    ) -> None:
+        print(f'super.move_comparison: ({comp}) -> {new_attr}')
+        if not any(hasattr(self, att) for att in comp_attrs + ["shared"]):
+            print('an attr is missing')
+            return
+
+        # remove from all attrs
+        util.remove_by_id(self.shared, comp)
+        for attr in comp_attrs:
+            for comp_list in getattr(self, attr, {}).values():
+                util.remove_by_id(comp_list, comp)
+
+        # place into new_attr
+        if new_attr == "shared":
+            self.shared.append(comp)
+        else:
+            for attr in comp_attrs:
+                attr_dict = getattr(self, attr, {})
+                if new_attr in attr_dict:
+                    attr_dict[new_attr].append(comp)
+
 
 @dataclass
 class ConfigurationGroup(Configuration):
@@ -175,6 +201,14 @@ class DeviceConfiguration(Configuration):
             comp_attrs = ['by_attr']
         super().replace_comparison(old_comp, new_comp, comp_attrs)
 
+    def move_comparison(
+        self,
+        comp: Comparison,
+        new_attr: str,
+        comp_attrs: Optional[List[str]] = None
+    ) -> None:
+        super().move_comparison(comp, new_attr, comp_attrs=['by_attr'])
+
 
 @dataclass
 class PVConfiguration(Configuration):
@@ -214,6 +248,14 @@ class PVConfiguration(Configuration):
         if comp_attrs is None:
             comp_attrs = ['by_pv']
         super().replace_comparison(old_comp, new_comp, comp_attrs)
+
+    def move_comparison(
+        self,
+        comp: Comparison,
+        new_attr: str,
+        comp_attrs: Optional[List[str]] = None
+    ) -> None:
+        super().move_comparison(comp, new_attr, comp_attrs=['by_pv'])
 
 
 @dataclass
@@ -260,6 +302,14 @@ class ToolConfiguration(Configuration):
         if comp_attrs is None:
             comp_attrs = ['by_attr']
         super().replace_comparison(old_comp, new_comp, comp_attrs)
+
+    def move_comparison(
+        self,
+        comp: Comparison,
+        new_attr: str,
+        comp_attrs: Optional[List[str]] = None
+    ) -> None:
+        super().move_comparison(comp, new_attr, comp_attrs=['by_attr'])
 
 
 AnyConfiguration = Union[

--- a/atef/config.py
+++ b/atef/config.py
@@ -105,9 +105,8 @@ class Configuration:
         new_attr: str,
         comp_attrs: List[str],
     ) -> None:
-        print(f'super.move_comparison: ({comp}) -> {new_attr}')
         if not any(hasattr(self, att) for att in comp_attrs + ["shared"]):
-            print('an attr is missing')
+            logger.debug('cannot find a requested attr in dataclass')
             return
 
         # remove from all attrs

--- a/atef/ui/device_configuration_page.ui
+++ b/atef/ui/device_configuration_page.ui
@@ -35,7 +35,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="comparisons_table_placeholder" native="true"/>
+    <widget class="PagedTableWidget" name="comparisons_table" native="true"/>
    </item>
    <item>
     <widget class="QPushButton" name="add_comparison_button">
@@ -46,6 +46,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PagedTableWidget</class>
+   <extends>QWidget</extends>
+   <header>atef.widgets.config.paged_table</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/atef/ui/device_configuration_page.ui
+++ b/atef/ui/device_configuration_page.ui
@@ -35,19 +35,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QTableWidget" name="comparisons_table">
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Comparisons</string>
-      </property>
-     </column>
-    </widget>
+    <widget class="QWidget" name="comparisons_table_placeholder" native="true"/>
    </item>
    <item>
     <widget class="QPushButton" name="add_comparison_button">

--- a/atef/ui/paged_table.ui
+++ b/atef/ui/paged_table.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>421</width>
+    <height>436</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableView" name="table_view"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="prev_button">
+       <property name="text">
+        <string>&lt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="page_label">
+       <property name="text">
+        <string>Page</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="page_spinbox">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="page_count_label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>/ 0</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="next_button">
+       <property name="text">
+        <string>&gt;</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/paged_table.ui
+++ b/atef/ui/paged_table.ui
@@ -42,14 +42,15 @@
      </item>
      <item>
       <widget class="QLabel" name="page_count_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
        <property name="text">
         <string>/ 0</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="search_edit">
+       <property name="placeholderText">
+        <string>Search by name</string>
        </property>
       </widget>
      </item>

--- a/atef/ui/pv_configuration_page.ui
+++ b/atef/ui/pv_configuration_page.ui
@@ -144,7 +144,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QWidget" name="comparisons_table_placeholder" native="true"/>
+         <widget class="PagedTableWidget" name="comparisons_table" native="true"/>
         </item>
         <item>
          <widget class="QPushButton" name="add_comparison_button">
@@ -160,6 +160,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PagedTableWidget</class>
+   <extends>QWidget</extends>
+   <header>atef.widgets.config.paged_table</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/atef/ui/pv_configuration_page.ui
+++ b/atef/ui/pv_configuration_page.ui
@@ -144,25 +144,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QTableWidget" name="comparisons_table">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <attribute name="horizontalHeaderStretchLastSection">
-           <bool>true</bool>
-          </attribute>
-          <attribute name="verticalHeaderVisible">
-           <bool>false</bool>
-          </attribute>
-          <column>
-           <property name="text">
-            <string>Comparisons</string>
-           </property>
-          </column>
-         </widget>
+         <widget class="QWidget" name="comparisons_table_placeholder" native="true"/>
         </item>
         <item>
          <widget class="QPushButton" name="add_comparison_button">

--- a/atef/ui/tool_configuration_page.ui
+++ b/atef/ui/tool_configuration_page.ui
@@ -69,19 +69,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QTableWidget" name="comparisons_table">
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Comparisons</string>
-      </property>
-     </column>
-    </widget>
+    <widget class="QWidget" name="comparisons_table_placeholder" native="true"/>
    </item>
    <item>
     <widget class="QPushButton" name="add_comparison_button">

--- a/atef/ui/tool_configuration_page.ui
+++ b/atef/ui/tool_configuration_page.ui
@@ -69,7 +69,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="comparisons_table_placeholder" native="true"/>
+    <widget class="PagedTableWidget" name="comparisons_table" native="true"/>
    </item>
    <item>
     <widget class="QPushButton" name="add_comparison_button">
@@ -80,6 +80,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PagedTableWidget</class>
+   <extends>QWidget</extends>
+   <header>atef.widgets.config.paged_table</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/atef/util.py
+++ b/atef/util.py
@@ -153,6 +153,13 @@ async def run_in_executor(
     return await loop.run_in_executor(executor, wrapped)
 
 
-def replace_in_list(old: T, new: T, item_list: List[T]):
+def replace_in_list(old: T, new: T, item_list: List[T]) -> None:
     index = item_list.index(old)
     item_list[index] = new
+
+
+def remove_by_id(series: List[T], item: T) -> None:
+    for i in range(len(series)):
+        if series[i] is item:
+            series.pop(i)
+            return

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -46,8 +46,7 @@ from atef.widgets.config.data_active import (CheckRowWidget,
                                              GeneralProcedureWidget,
                                              PassiveEditWidget,
                                              SetValueEditWidget)
-from atef.widgets.config.paged_table import (SETUP_SLOT_ROLE, USER_DATA_ROLE,
-                                             PagedTableWidget)
+from atef.widgets.config.paged_table import SETUP_SLOT_ROLE, PagedTableWidget
 from atef.widgets.config.run_active import (DescriptionRunWidget,
                                             PassiveRunWidget,
                                             SetValueRunWidget)
@@ -440,11 +439,6 @@ class PageWidget(QWidget):
 
         # Remove row from the table
         table.remove_data(row.data)
-        # for row_index in range(table.rowCount()):
-        #     widget = table.cellWidget(row_index, 0)
-        #     if widget is row:
-        #         table.removeRow(row_index)
-        #         break
         # Remove configuration from the data structure
         self.remove_table_data(data)
 
@@ -889,7 +883,7 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
                 )
 
         row_count = self.comparisons_table.row_count()
-        self.comparisons_table.insert_setup_row(
+        self.comparisons_table.insert_row(
             row_count,
             comparison,
             partial(self.configure_row_widget,
@@ -916,7 +910,7 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
 
     def update_combo_attrs(self, row_widget: ComparisonRowWidget) -> None:
         """
-        For every row combobox, set the allowed values.
+        Set the allowed values for ``attr_combo`` in ``row_widget``
         """
         combo = row_widget.attr_combo
         orig_value = combo.currentText()
@@ -940,6 +934,10 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
         return
 
     def update_comparison_dicts(self, *args, **kwargs) -> None:
+        """
+        Rebuild the comparison lists when anything changes.  Refresh the
+        comparisons table to reflect the changes.
+        """
         unsorted: List[Tuple[str, Comparison]] = []
 
         for row_index in range(self.comparisons_table.row_count()):
@@ -1062,7 +1060,7 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
                 )
 
         row_count = self.comparisons_table.row_count()
-        self.comparisons_table.insert_setup_row(
+        self.comparisons_table.insert_row(
             row_count,
             comparison,
             partial(self.configure_row_widget,
@@ -1089,7 +1087,7 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
 
     def update_combo_attrs(self, row_widget: ComparisonRowWidget) -> None:
         """
-        For set the allowed values for ``row_widget``
+        Set the allowed values for ``attr_combo`` in ``row_widget``
         """
         combo = row_widget.attr_combo
         orig_value = combo.currentText()
@@ -1106,6 +1104,9 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
             combo.setCurrentIndex(combo.count() - 1)
 
     def update_comparison_attr(self, text: str, *args, comparison: Comparison, **kwargs) -> None:
+        """
+        Update comparison location in parent config
+        """
         self.data.move_comparison(comparison, text)
 
     def update_comparison_dicts(self, *args, **kwargs) -> None:
@@ -1245,7 +1246,7 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
                 )
 
         row_count = self.comparisons_table.row_count()
-        self.comparisons_table.insert_setup_row(
+        self.comparisons_table.insert_row(
             row_count,
             comparison,
             partial(self.configure_row_widget,
@@ -1272,7 +1273,7 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
 
     def update_combo_attrs(self, row_widget: ComparisonRowWidget) -> None:
         """
-        For every row combobox, set the allowed values.
+        Set the allowed values for ``attr_combo`` in ``row_widget``
         """
         combo = row_widget.attr_combo
         orig_value = combo.currentText()
@@ -1302,7 +1303,7 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
         unsorted: List[Tuple[str, Comparison]] = []
 
         for row_index in range(self.comparisons_table.row_count()):
-            comp = self.comparisons_table.source_model.index(row_index, 0).data(USER_DATA_ROLE)
+            comp = self.comparisons_table.row_data(row_index)
             curr_attr = get_comp_field_in_parent(comp, self.data)
             unsorted.append(
                 (curr_attr, comp)

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -861,7 +861,6 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
     device_widget_placeholder: QWidget
     device_config_widget: DeviceConfigurationWidget
 
-    comparisons_table_placeholder: QWidget
     comparisons_table: PagedTableWidget
     add_comparison_button: QPushButton
 
@@ -874,11 +873,7 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
             self.device_widget_placeholder,
         )
 
-        self.comparisons_table = PagedTableWidget(title="Comparisons")
-        self.insert_widget(
-            self.comparisons_table,
-            self.comparisons_table_placeholder
-        )
+        self.comparisons_table.set_title("Comparisons")
         self.post_tree_setup()
 
     def post_tree_setup(self) -> None:
@@ -1037,7 +1032,6 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
     pv_widget_placeholder: QWidget
     pv_configuration_widget: PVConfigurationWidget
 
-    comparisons_table_placeholder: QWidget
     comparisons_table: PagedTableWidget
     add_comparison_button: QPushButton
 
@@ -1050,11 +1044,7 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
             self.pv_widget_placeholder,
         )
 
-        self.comparisons_table = PagedTableWidget(title="Comparisons")
-        self.insert_widget(
-            self.comparisons_table,
-            self.comparisons_table_placeholder
-        )
+        self.comparisons_table.set_title('Comparisons')
         self.post_tree_setup()
 
     def post_tree_setup(self) -> None:
@@ -1213,7 +1203,6 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
     tool_placeholder: QWidget
     tool_widget: DataWidget
 
-    comparisons_table_placeholder: QWidget
     comparisons_table: PagedTableWidget
     add_comparison_button: QPushButton
     tool_select_combo: QComboBox
@@ -1226,14 +1215,9 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
 
     def __init__(self, data: ToolConfiguration, **kwargs):
         super().__init__(data=data, **kwargs)
-        # Create the static sub-widgets and place them
         self.setup_name_desc_tags_init()
 
-        self.comparisons_table = PagedTableWidget(title="Comparisons")
-        self.insert_widget(
-            self.comparisons_table,
-            self.comparisons_table_placeholder
-        )
+        self.comparisons_table.set_title('Comparisons')
         self.post_tree_setup()
 
     def post_tree_setup(self) -> None:

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -583,11 +583,13 @@ class PageWidget(QWidget):
                     self.add_comparison_row(
                         attr=attr,
                         comparison=config,
+                        update=False
                     )
             for config in self.data.shared:
                 self.add_comparison_row(
                     attr='shared',
                     comparison=config,
+                    update=False
                 )
             # Allow the user to add more rows
             self.add_comparison_button.clicked.connect(self.add_comparison_row)
@@ -605,6 +607,7 @@ class PageWidget(QWidget):
         checked: bool = False,
         attr: str = '',
         comparison: Optional[Comparison] = None,
+        update: bool = True
     ) -> None:
         """
         Add a new row to the comparison table.
@@ -893,6 +896,7 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
         checked: bool = False,
         attr: str = '',
         comparison: Optional[Comparison] = None,
+        update: bool = True
     ) -> None:
         """
         Add a new row to the comparison table.
@@ -922,9 +926,11 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
             comparison,
             partial(self.configure_row_widget,
                     comparison=comparison,
-                    comp_item=comp_item)
+                    comp_item=comp_item),
+            update=update
         )
-        self.comparisons_table.show_row_for_data(comparison)
+        if update:
+            self.comparisons_table.show_row_for_data(comparison)
 
     def remove_table_data(self, data: Comparison) -> None:
         """
@@ -1064,6 +1070,7 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
         checked: bool = False,
         attr: str = '',
         comparison: Optional[Comparison] = None,
+        update: bool = True
     ):
         """
         Add a new row to the comparison table.
@@ -1094,9 +1101,11 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
             comparison,
             partial(self.configure_row_widget,
                     comparison=comparison,
-                    comp_item=comp_item)
+                    comp_item=comp_item),
+            update=update
         )
-        self.comparisons_table.show_row_for_data(comparison)
+        if update:
+            self.comparisons_table.show_row_for_data(comparison)
 
     def remove_table_data(self, data: Comparison) -> None:
         """
@@ -1245,6 +1254,7 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
         checked: bool = False,
         attr: str = '',
         comparison: Optional[Comparison] = None,
+        update: bool = True
     ) -> None:
         """
         Add a new row to the comparison table.
@@ -1274,9 +1284,11 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
             comparison,
             partial(self.configure_row_widget,
                     comparison=comparison,
-                    comp_item=comp_item)
+                    comp_item=comp_item),
+            update=update
         )
-        self.comparisons_table.show_row_for_data(comparison)
+        if update:
+            self.comparisons_table.show_row_for_data(comparison)
 
     def remove_table_data(self, data: Comparison) -> None:
         """

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -857,7 +857,7 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
             by_attr_key='by_attr',
             data_widget=self.device_config_widget,
         )
-        self.comparisons_table.show_page(1)
+        self.comparisons_table.set_page(1)
         self.setup_name_desc_tags_link()
 
     def add_comparison_row(
@@ -888,8 +888,7 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
                     tree_parent=self.tree_item,
                 )
 
-        row_count = self.comparisons_table.rowCount()
-
+        row_count = self.comparisons_table.row_count()
         self.comparisons_table.insert_setup_row(
             row_count,
             comparison,
@@ -897,6 +896,7 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
                     comparison=comparison,
                     comp_item=comp_item)
         )
+        self.comparisons_table.show_row_for_data(comparison)
 
     def remove_table_data(self, data: Comparison) -> None:
         """
@@ -942,11 +942,9 @@ class DeviceConfigurationPage(DesignerDisplay, PageWidget):
     def update_comparison_dicts(self, *args, **kwargs) -> None:
         unsorted: List[Tuple[str, Comparison]] = []
 
-        for row_index in range(self.comparisons_table.rowCount()):
-            # TODO: make thisd page table method
-            comp = self.comparisons_table.source_model.index(row_index, 0).data(USER_DATA_ROLE)
+        for row_index in range(self.comparisons_table.row_count()):
+            comp = self.comparisons_table.row_data(row_index)
             curr_attr = get_comp_field_in_parent(comp, self.data)
-            # row_widget = self.comparisons_table.cellWidget(row_index, 0)
             unsorted.append(
                 (curr_attr, comp)
             )
@@ -1031,6 +1029,7 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
             by_attr_key='by_pv',
             data_widget=self.pv_configuration_widget,
         )
+        self.comparisons_table.set_page(1)
         self.setup_name_desc_tags_link()
 
     def add_comparison_row(
@@ -1062,7 +1061,7 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
                     tree_parent=self.tree_item,
                 )
 
-        row_count = self.comparisons_table.rowCount()
+        row_count = self.comparisons_table.row_count()
         self.comparisons_table.insert_setup_row(
             row_count,
             comparison,
@@ -1070,6 +1069,7 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
                     comparison=comparison,
                     comp_item=comp_item)
         )
+        self.comparisons_table.show_row_for_data(comparison)
 
     def remove_table_data(self, data: Comparison) -> None:
         """
@@ -1114,9 +1114,8 @@ class PVConfigurationPage(DesignerDisplay, PageWidget):
         """
         unsorted: List[Tuple[str, Comparison]] = []
 
-        for row_index in range(self.comparisons_table.rowCount()):
-            # TODO: make thisd page table method
-            comp = self.comparisons_table.source_model.index(row_index, 0).data(USER_DATA_ROLE)
+        for row_index in range(self.comparisons_table.row_count()):
+            comp = self.comparisons_table.row_data(row_index)
             curr_attr = get_comp_field_in_parent(comp, self.data)
             unsorted.append(
                 (curr_attr, comp)
@@ -1213,6 +1212,8 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
                 self.tool_select_combo.addItem(tool.__name__)
                 self.tool_names[tool.__name__] = tool
             self.tool_select_combo.activated.connect(self.new_tool_selected)
+
+        self.comparisons_table.set_page(1)
         self.setup_name_desc_tags_link()
 
     def add_comparison_row(
@@ -1243,8 +1244,7 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
                     tree_parent=self.tree_item,
                 )
 
-        row_count = self.comparisons_table.rowCount()
-
+        row_count = self.comparisons_table.row_count()
         self.comparisons_table.insert_setup_row(
             row_count,
             comparison,
@@ -1252,6 +1252,7 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
                     comparison=comparison,
                     comp_item=comp_item)
         )
+        self.comparisons_table.show_row_for_data(comparison)
 
     def remove_table_data(self, data: Comparison) -> None:
         """
@@ -1300,7 +1301,7 @@ class ToolConfigurationPage(DesignerDisplay, PageWidget):
         """
         unsorted: List[Tuple[str, Comparison]] = []
 
-        for row_index in range(self.comparisons_table.rowCount()):
+        for row_index in range(self.comparisons_table.row_count()):
             comp = self.comparisons_table.source_model.index(row_index, 0).data(USER_DATA_ROLE)
             curr_attr = get_comp_field_in_parent(comp, self.data)
             unsorted.append(

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -812,6 +812,45 @@ class ConfigurationGroupPage(DesignerDisplay, PageWidget):
                 dest_row = self.config_table.rowCount() - 1
             self.move_config_row(selected_row, dest_row)
 
+    def delete_table_row(
+        self,
+        *args,
+        table: QTableWidget,
+        item: TreeItem,
+        row: DataWidget,
+        **kwargs
+    ) -> None:
+        # Use old QTableWidget handling
+        # Confirmation dialog
+        reply = QMessageBox.question(
+            self,
+            'Confirm deletion',
+            (
+                'Are you sure you want to delete the '
+                f'{item.data(2)} named "{item.data(0)}"? '
+                'Note that this will delete any child nodes in the tree.'
+            ),
+        )
+        if reply != QMessageBox.Yes:
+            return
+        # Get the identity of the data
+        data = row.bridge.data
+        # Remove item from the tree
+        with self.full_tree.modifies_tree():
+            try:
+                self.tree_item.removeChild(item)
+            except ValueError:
+                pass
+
+        # Remove row from the table
+        for row_index in range(table.rowCount()):
+            widget = table.cellWidget(row_index, 0)
+            if widget is row:
+                table.removeRow(row_index)
+                break
+        # Remove configuration from the data structure
+        self.remove_table_data(data)
+
 
 class DeviceConfigurationPage(DesignerDisplay, PageWidget):
     """

--- a/atef/widgets/config/paged_table.py
+++ b/atef/widgets/config/paged_table.py
@@ -1,3 +1,4 @@
+import logging
 import math
 from typing import Any, Callable, List, Optional
 
@@ -6,6 +7,8 @@ from qtpy.QtCore import QModelIndex, Qt
 
 from atef.widgets.config.data_passive import ComparisonRowWidget
 from atef.widgets.core import DesignerDisplay
+
+logger = logging.getLogger(__name__)
 
 USER_DATA_ROLE = Qt.UserRole + 1
 SETUP_SLOT_ROLE = Qt.UserRole + 2
@@ -218,7 +221,8 @@ class PagedTableWidget(DesignerDisplay, QtWidgets.QWidget):
         self,
         index: int,
         data: Any,
-        setup_slot: Optional[Callable[[QtWidgets.QWidget], None]] = None
+        setup_slot: Optional[Callable[[QtWidgets.QWidget], None]] = None,
+        update: bool = False
     ) -> None:
         """
         Add ``data`` to the table's model.
@@ -235,13 +239,15 @@ class PagedTableWidget(DesignerDisplay, QtWidgets.QWidget):
         setup_slot : Optional[Callable[[QtWidgets.QWidget], None]]
             a function used to setup the row widget delegate after creation
         """
+        logger.debug(f'inserting row ({data} @ {index}), update: {update}')
         item = QtGui.QStandardItem()
         item.setData(data, role=USER_DATA_ROLE)
         item.setData(data.name or '', role=Qt.ToolTipRole)
         if setup_slot is not None:
             item.setData(setup_slot, role=SETUP_SLOT_ROLE)
         self.source_model.insertRow(index, item)
-        self.update_table()
+        if update:
+            self.update_table()
 
     def find_data_index(self, data: Any, role: int = USER_DATA_ROLE) -> QModelIndex:
         """

--- a/atef/widgets/config/paged_table.py
+++ b/atef/widgets/config/paged_table.py
@@ -345,6 +345,11 @@ class PagedTableWidget(DesignerDisplay, QtWidgets.QWidget):
         self.refresh()
         return
 
+    def showEvent(self, a0: QtGui.QShowEvent) -> None:
+        """Refresh table whenever revealed"""
+        super().showEvent(a0)
+        self.refresh()
+
 
 class PagedProxyModel(QtCore.QSortFilterProxyModel):
     """

--- a/atef/widgets/config/paged_table.py
+++ b/atef/widgets/config/paged_table.py
@@ -87,11 +87,8 @@ class PagedTableWidget(DesignerDisplay, QtWidgets.QWidget):
             self.row_delegate = CustDelegate(widget_cls=self.row_cls)
             self.table_view.setItemDelegateForColumn(0, self.row_delegate)
 
+        self.set_title(title)
         self.table_view.horizontalHeader().setStretchLastSection(True)
-        if title:
-            self.source_model.setHeaderData(0, Qt.Horizontal, title, Qt.DisplayRole)
-        else:
-            self.table_view.horizontalHeader().hide()
         self.table_view.verticalHeader().hide()
         self.proxy_model.sort(-1)
 
@@ -109,6 +106,12 @@ class PagedTableWidget(DesignerDisplay, QtWidgets.QWidget):
         self.next_button.clicked.connect(self.next_page)
         self.search_edit.textChanged.connect(self.update_table)
         self.update_table()
+
+    def set_title(self, title: Optional[str] = None) -> None:
+        if title is not None:
+            self.source_model.setHeaderData(0, Qt.Horizontal, title, Qt.DisplayRole)
+        else:
+            self.table_view.horizontalHeader().hide()
 
     def next_page(self, *args, **kwargs) -> None:
         """Navigate to the next page, constrained by limits of the spinbox"""

--- a/atef/widgets/config/paged_table.py
+++ b/atef/widgets/config/paged_table.py
@@ -29,6 +29,7 @@ class PagedTableWidget(DesignerDisplay, QtWidgets.QWidget):
     def __init__(
         self,
         *args,
+        title: Optional[str] = None,
         item_list: Optional[List[Any]] = None,
         page_size: Optional[int] = None,
         widget_cls: Optional[QtWidgets.QWidget] = ComparisonRowWidget,
@@ -48,7 +49,11 @@ class PagedTableWidget(DesignerDisplay, QtWidgets.QWidget):
         self.row_delegate = CustDelegate(widget_cls=self.row_cls)
         self.table_view.setItemDelegateForColumn(0, self.row_delegate)
         self.table_view.horizontalHeader().setStretchLastSection(True)
-        self.table_view.setSortingEnabled(True)
+        if title:
+            self.source_model.setHeaderData(0, Qt.Horizontal, title, Qt.DisplayRole)
+        else:
+            self.table_view.horizontalHeader().hide()
+        self.table_view.verticalHeader().hide()
         self.proxy_model.sort(-1)
 
         if item_list:
@@ -63,7 +68,7 @@ class PagedTableWidget(DesignerDisplay, QtWidgets.QWidget):
         self.page_spinbox.valueChanged.connect(self.show_page)
         self.prev_button.clicked.connect(self.prev_page)
         self.next_button.clicked.connect(self.next_page)
-        self.search_edit.editingFinished.connect(self.update_table)
+        self.search_edit.textChanged.connect(self.update_table)
         self.update_table()
 
     def next_page(self, *args, **kwargs) -> None:

--- a/atef/widgets/config/paged_table.py
+++ b/atef/widgets/config/paged_table.py
@@ -172,7 +172,10 @@ class PagedTableWidget(DesignerDisplay, QtWidgets.QWidget):
         page_no : int
             page number to show
         """
+        orig_page = self.proxy_model.curr_page
         self.page_spinbox.setValue(page_no)
+        if page_no == orig_page:
+            self.refresh()
 
     def show_row_for_data(self, data: Any, role: int = USER_DATA_ROLE) -> None:
         """

--- a/atef/widgets/config/paged_table.py
+++ b/atef/widgets/config/paged_table.py
@@ -1,0 +1,237 @@
+import math
+from typing import Any, Callable, List, Optional
+
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import QModelIndex, Qt
+
+from atef.widgets.config.data_passive import ComparisonRowWidget
+from atef.widgets.core import DesignerDisplay
+
+USER_DATA_ROLE = Qt.UserRole + 1
+SETUP_SLOT_ROLE = Qt.UserRole + 2
+
+
+class PagedTableWidget(DesignerDisplay, QtWidgets.QWidget):
+    table_view: QtWidgets.QTableView
+    page_spinbox: QtWidgets.QSpinBox
+    next_button: QtWidgets.QToolButton
+    prev_button: QtWidgets.QToolButton
+    search_edit: QtWidgets.QLineEdit
+    page_count_label: QtWidgets.QLabel
+
+    filename = 'paged_table.ui'
+
+    # TODO mimic QTableWidget methods used
+
+    def __init__(
+        self,
+        *args,
+        item_list: Optional[List[Any]] = None,
+        page_size: Optional[int] = None,
+        widget_cls: Optional[QtWidgets.QWidget] = ComparisonRowWidget,
+        **kwargs
+    ):
+        # TODO: remove row numbers
+        # TODO: set up title for column
+        super().__init__(*args, **kwargs)
+        self.page_size = page_size
+        self.row_cls = widget_cls
+
+        self.source_model = QtGui.QStandardItemModel(1, 1, parent=self)
+        self.proxy_model = PagedProxyModel(self)
+        self.proxy_model.setSourceModel(self.source_model)
+        self.table_view.setModel(self.proxy_model)
+
+        self.row_delegate = CustDelegate(widget_cls=self.row_cls)
+        self.table_view.setItemDelegateForColumn(0, self.row_delegate)
+        self.table_view.horizontalHeader().setStretchLastSection(True)
+        self.table_view.setSortingEnabled(True)
+        self.proxy_model.sort(-1)
+
+        if item_list:
+            for item in item_list:
+                self.insertRow(item, self.rowCount())
+
+        self.show_page(1)
+
+        self.setup_ui()
+
+    def setup_ui(self) -> None:
+        # link spinbox to show_page
+        self.page_spinbox.valueChanged.connect(self.show_page)
+        self.prev_button.clicked.connect(self.prev_page)
+        self.next_button.clicked.connect(self.next_page)
+        self.search_edit.editingFinished.connect(self.update_table)
+        self.update_table()
+
+    def next_page(self, *args, **kwargs) -> None:
+        self.page_spinbox.stepUp()
+
+    def prev_page(self, *args, **kwargs) -> None:
+        self.page_spinbox.stepDown()
+
+    def update_table(self) -> None:
+        # Update search
+        self.proxy_model.search_regexp.setPattern(self.search_edit.text())
+        self.proxy_model.invalidateFilter()
+        # post-model refresh setup
+        for i in range(self.proxy_model.rowCount()):
+            index = self.proxy_model.index(i, 0)
+            # Delegates normally only open editor if requested.  Request all
+            # visible delegates by default
+            self.table_view.openPersistentEditor(index)
+
+            widget = self.table_view.indexWidget(index)
+            if widget:
+                self.table_view.setRowHeight(i, widget.sizeHint().height())
+        # reset total pages
+        self.page_count_label.setText(f'/ {self.proxy_model.total_pages}')
+        self.page_spinbox.setMaximum(self.proxy_model.total_pages)
+
+    def show_page(self, page_no: int):
+        # set page 0 to clear history effects
+        # I don't like how this is, but apparently filterAcceptsRow gets called
+        # first on the rows that were already showing.  Because the proxy model
+        # accepts the first (page_size) valid rows, this breaks the sorting
+        # So, we need to clear this history
+        self.proxy_model.curr_page = 0
+        self.proxy_model.invalidateFilter()  # This shouldn't take long, not drawing
+
+        # set proper page for filter model
+        self.proxy_model.curr_page = page_no
+        self.update_table()
+
+    def insertRow(self, data: Any, index: int) -> None:
+        # add item to model
+        # if widget: self.table_widget.{insertRow -> setRowHeight -> setCellWidget}
+        item = QtGui.QStandardItem()
+        item.setData(data)  # Qt.UserRole + 1
+        item.setData(data.name or '', role=Qt.ToolTipRole)
+        self.source_model.insertRow(index, item)
+
+    def insert_setup_row(self, index: int, data: Any, setup_slot: Callable) -> None:
+        item = QtGui.QStandardItem()
+        item.setData(data, role=USER_DATA_ROLE)  # Qt.UserRole + 1
+        item.setData(data.name or '', role=Qt.ToolTipRole)
+        item.setData(setup_slot, role=SETUP_SLOT_ROLE)
+        self.source_model.insertRow(index, item)
+        self.update_table()
+        # TODO: Figure out how to ensure
+
+    def remove_data(self, data: Any) -> None:
+        """Removes ``data`` from source model"""
+        for row_num in range(self.source_model.rowCount()):
+            row_index = self.source_model.index(row_num, 0)
+            if row_index.data(USER_DATA_ROLE) is data:
+                self.source_model.removeRow(row_num)
+                return
+
+    def get_widget_for_data(self, data: Any) -> Optional[Any]:
+        """Return widget for with supplied data"""
+        # Delegate creates and destroys widgets, no bueno
+        raise NotImplementedError
+
+    def cellWidget(self, row: int, column: int) -> None:
+        # not necessary probably
+        pass
+
+    def rowCount(self) -> int:
+        # return total number of rows
+        return self.source_model.rowCount()
+
+    def selectedIndexes(self) -> QtCore.QModelIndex:
+        pass
+
+    def indexAt(self) -> QtCore.QModelIndex:
+        pass
+
+
+class PagedProxyModel(QtCore.QSortFilterProxyModel):
+    def __init__(self, *args, page_size=3, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.page_size = page_size
+        self.curr_page = 1
+        self.search_regexp = QtCore.QRegularExpression()
+
+        self.total_pages = 0
+
+        self.total_displayed = 0
+        self.total_allowed = 0
+        self.min_count = self.curr_page * self.page_size
+        self.max_count = self.min_count + self.page_size
+
+    def invalidateFilter(self) -> None:
+        self.total_pages = 0
+
+        self.total_displayed = 0
+        self.total_allowed = 0
+
+        self.min_count = (self.curr_page - 1) * self.page_size
+        self.max_count = self.min_count + self.page_size
+
+        return super().invalidateFilter()
+
+    def process_row(
+        self,
+        accepted: bool,
+        allowed: bool,
+        reason: Optional[str] = None
+    ) -> bool:
+        """
+        Process the row, and remember how many rows passed.
+        Rows can be valid but not shown, reducing the page count.
+
+        accept: row is accepted, will be displayed
+        allowed: row passes filter, will be considered in page count
+        reason: reason for decision
+        """
+        print(f'pr: ({accepted, allowed, reason})')
+        if accepted and not allowed:
+            self.total_displayed += 1
+
+        if allowed:
+            self.total_allowed += 1
+            self.total_pages = math.ceil(
+                self.total_allowed / self.page_size
+            )
+        return accepted
+
+    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:
+        print(f'far: {source_row}')
+        source = self.sourceModel()
+        index = source.index(source_row, self.filterKeyColumn(), source_parent)
+        # TODO: Include basic search text (for name field?)
+        inside_page_range = ((self.total_allowed >= self.min_count)
+                             and (self.total_allowed < self.max_count))
+        row_text = source.data(index, Qt.ToolTipRole)
+        text_match = self.search_regexp.match(row_text).hasMatch()
+
+        if not source.data(index, Qt.UserRole+1):
+            return self.process_row(False, False, reason='No Data, ignoring row')
+        elif not text_match:
+            return self.process_row(False, False, reason="Text match failed")
+        elif (self.total_displayed >= self.page_size):
+            return self.process_row(False, True, reason='Outside page range')
+        elif inside_page_range and text_match:
+            return self.process_row(True, True, reason="Inside Page Range, text match")
+
+        return self.process_row(False, True, reason="Default")
+
+
+class CustDelegate(QtWidgets.QStyledItemDelegate):
+    # An edit-mode delegate
+    def __init__(self, *args, widget_cls=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.widget_cls = widget_cls
+
+    def createEditor(
+        self,
+        parent: QtWidgets.QWidget,
+        option,
+        index: QtCore.QModelIndex
+    ) -> QtWidgets.QWidget:
+        row_widget = self.widget_cls(index.data(USER_DATA_ROLE), parent=parent)
+        setup_slot = index.data(SETUP_SLOT_ROLE)
+        if callable(setup_slot):
+            setup_slot(row_widget)
+        return row_widget

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -655,6 +655,7 @@ class DualTree(DesignerDisplay, QWidget):
             # typically this is fast enough, but if garbage collection is quick
             # the widget may be deleted before we can delete it ourselves
             try:
+                print(f'*** deleting widget from cache: {oldest_widget} ***')
                 oldest_widget.setParent(None)
                 oldest_widget.deleteLater()
             except RuntimeError:

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -655,7 +655,7 @@ class DualTree(DesignerDisplay, QWidget):
             # typically this is fast enough, but if garbage collection is quick
             # the widget may be deleted before we can delete it ourselves
             try:
-                print(f'*** deleting widget from cache: {oldest_widget} ***')
+                logger.debug(f'deleting widget from cache: {type(oldest_widget)}')
                 oldest_widget.setParent(None)
                 oldest_widget.deleteLater()
             except RuntimeError:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
   - ipython
   - numpy
   - ophyd
-  - pcdsutils >=0.14.0
+  - pcdsutils >=0.14.1
   - pydm
   - pyyaml
   - qtpy

--- a/docs/source/upcoming_release_notes/226-enh_paged_table.rst
+++ b/docs/source/upcoming_release_notes/226-enh_paged_table.rst
@@ -1,0 +1,22 @@
+226 enh_paged_table
+###################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds PagedTableWidget, apply it to passive checkout group pages
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/docs/source/upcoming_release_notes/226-enh_paged_table.rst
+++ b/docs/source/upcoming_release_notes/226-enh_paged_table.rst
@@ -8,6 +8,7 @@ API Breaks
 Features
 --------
 - Adds PagedTableWidget, apply it to passive checkout group pages
+  to substantially improve the loading performance of group pages with many, many comparisons.
 
 Bugfixes
 --------

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ happi
 ipython
 numpy
 ophyd
-pcdsutils>=0.14.0
+pcdsutils>=0.14.1
 pydm
 PyQt5
 pyyaml


### PR DESCRIPTION
## Description
Replaces the existing `QTableWidget` + `cellWidget` combination with a `PagedTableWidget`, for splitting up rows into pages.

## Motivation and Context
Previously, all the row widgets were created on PageWidget creation.  This can lead to long loading times that aren't remedied by the previous lazy page loading effort. 

This may seem a bit complicated, but should be the proper way to let qt handle construction and destruction of row widgets.  There was some complexity involved when hooking up buttons / slots inside these row widgets, since widgets can be created or destroyed at any time.  This means saving connection slots in a way that can be re-initialized at will.

I made an effort to keep the existing widgets and their functionality.

## How Has This Been Tested?
interactively

## Where Has This Been Documented?
This PR

![image](https://github.com/pcdshub/atef/assets/35379409/d090c4d8-cdc4-47ed-ad52-3c6359b5b9e0)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
