### PR TITLE
MNT: Refactor scripts into `atef scripts` subcommand

### DIFF
--- a/atef/bin/main.py
+++ b/atef/bin/main.py
@@ -19,6 +19,7 @@ DESCRIPTION = __doc__
 COMMAND_TO_MODULE = {
     "check": "check",
     "config": "config",
+    "scripts": "scripts",
 }
 
 

--- a/atef/bin/scripts.py
+++ b/atef/bin/scripts.py
@@ -1,8 +1,5 @@
 """
 `atef scripts` runs helper scripts.  Scripts may be added over time.
-
-Try:
-
 """
 
 import argparse
@@ -20,6 +17,7 @@ def gather_scripts() -> Dict[str, Tuple[Callable, Callable]]:
     """Gather scripts, one main function from each submodule"""
     # similar to main's _build_commands
     global DESCRIPTION
+    DESCRIPTION += "\nTry:\n"
     results = {}
     unavailable = []
 

--- a/atef/bin/scripts.py
+++ b/atef/bin/scripts.py
@@ -1,0 +1,70 @@
+"""
+`atef scripts` runs helper scripts.  Scripts may be added over time.
+
+Try:
+
+"""
+
+import argparse
+import importlib
+import logging
+from pkgutil import iter_modules
+from typing import Callable, Dict, Tuple
+
+logger = logging.getLogger(__name__)
+
+DESCRIPTION = __doc__
+
+
+def gather_scripts() -> Dict[str, Tuple[Callable, Callable]]:
+    """Gather scripts, one main function from each submodule"""
+    # similar to main's _build_commands
+    global DESCRIPTION
+    results = {}
+    unavailable = []
+
+    scripts_module = importlib.import_module("atef.scripts")
+    for sub_module in iter_modules(scripts_module.__path__):
+        module_name = sub_module.name
+        try:
+            module = importlib.import_module(f".{module_name}", "atef.scripts")
+        except Exception as ex:
+            unavailable.append((module_name, ex))
+        else:
+            results[module_name] = (module.build_arg_parser, module.main)
+            DESCRIPTION += f'\n    $ atef scripts {module_name} --help'
+
+    if unavailable:
+        DESCRIPTION += '\n\n'
+
+        for command, ex in unavailable:
+            DESCRIPTION += (
+                f'\nWARNING: "atef scripts {command}" is unavailable due to:'
+                f'\n\t{ex.__class__.__name__}: {ex}'
+            )
+
+    return results
+
+
+SCRIPTS = gather_scripts()
+
+
+def build_arg_parser(argparser=None):
+    if argparser is None:
+        argparser = argparse.ArgumentParser()
+
+    argparser.description = """
+    Runs atef related scripts.  Pick a subcommand to run its script
+    """
+
+    sub_parsers = argparser.add_subparsers(help='available script subcommands')
+    for script_name, (build_parser_func, script_main) in SCRIPTS.items():
+        sub = sub_parsers.add_parser(script_name)
+        build_parser_func(sub)
+        sub.set_defaults(func=script_main)
+
+    return argparser
+
+
+def main():
+    print(DESCRIPTION)

--- a/atef/scripts/pmgr_check.py
+++ b/atef/scripts/pmgr_check.py
@@ -58,7 +58,11 @@ def get_pv(prefix: str, key: str):
     return pv
 
 
-def get_cfg_data(hutch: str, config_name: str, table_name: str = 'ims_motor') -> Dict[str, Any]:
+def get_cfg_data(
+    hutch: str,
+    config_name: str,
+    table_name: str = 'ims_motor'
+) -> Dict[str, Any]:
     """
     Get pmgr config data corresponding to ``config_name`` and ``hutch``
 
@@ -82,7 +86,11 @@ def get_cfg_data(hutch: str, config_name: str, table_name: str = 'ims_motor') ->
     return cfg_data
 
 
-def create_atef_check(config_name: str, cfg_data: Dict[str, Any], prefix: str) -> PVConfiguration:
+def create_atef_check(
+    config_name: str,
+    cfg_data: Dict[str, Any],
+    prefix: str
+) -> PVConfiguration:
     """
     Construct the full atef checkout.  Simply creates an Equals comparison for each
     value in the pmgr configuration, and groups it in a PVConfiguration
@@ -128,11 +136,11 @@ def build_arg_parser(argparser=None) -> argparse.ArgumentParser:
 
     argparser.add_argument(
         "--names",
-        "-m",
+        "-n",
         dest="pmgr_names",
         type=str,
         nargs="+",
-        help="a list of stored pmgr configuration names, case and whitespace sensitive."
+        help="a list of stored pmgr configuration names, case and whitespace sensitive. "
              "e.g. 'KB1 DS SLIT LEF'.  Length must match --prefixes",
     )
 

--- a/atef/tests/conftest.py
+++ b/atef/tests/conftest.py
@@ -339,7 +339,7 @@ def make_page():
         else:
             raise NotImplementedError()
 
-        tree = DualTree(orig_file=file)
+        tree = DualTree(orig_file=file, widget_cache_size=50)
         tree.select_by_data(cfg)
         cfg_page = tree.current_widget
 

--- a/docs/source/upcoming_release_notes/229-mnt_pmgr_cli.rst
+++ b/docs/source/upcoming_release_notes/229-mnt_pmgr_cli.rst
@@ -1,0 +1,22 @@
+229 mnt_pmgr_cli
+################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- adds `atef scripts` subcommand for invoking existing scripts
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Refactors the scripts in the separate "scripts" folder into a sub-subcommand, so people can use them without knowing the exact path

## Motivation and Context
If someone wanted to use these scripts before, they'd have to do call the precise path:

```
python ./atef/scripts/converter_v0.py [args, kwargs]
```

This seems less than accessible, so I wanted to fold them into the atef CLI.  We now scan the scripts submodule, and each sub-sub-module gets its own `atef scripts` subsubcommand

<details><summary>Example CLI invocations</summary>
<p>

```bash
$ atef -h
usage: atef [-h] [--version] [--log LOG_LEVEL] {check,config,scripts} ...

`atef` is the top-level command for accessing various subcommands.

Try:

    $ atef check --help
    $ atef config --help
    $ atef scripts --help

positional arguments:
  {check,config,scripts}
                        Possible subcommands

optional arguments:
  -h, --help            show this help message and exit
  --version, -V         Show the atef version number and exit.
  --log LOG_LEVEL, -l LOG_LEVEL
                        Python logging level (e.g. DEBUG, INFO, WARNING)
```

```bash
$ atef scripts -h
usage: atef scripts [-h] {converter_v0,pmgr_check} ...

Runs atef related scripts. Pick a subcommand to run its script

positional arguments:
  {converter_v0,pmgr_check}
                        available script subcommands

optional arguments:
  -h, --help            show this help message and exit
```

```bash
$ atef scripts pmgr_check -h
usage: atef scripts pmgr_check [-h] [--names PMGR_NAMES [PMGR_NAMES ...]] [--prefixes PREFIXES [PREFIXES ...]] [--table TABLE_NAME] hutch filename

This script creates an atef check from a pmgr configuration.  The configuration will
be converted into a PVConfiguration.  Note that default tolerances will be used for
checks.

An example invocation might be:
python scripts/pmgr_check.py cxi test_pmgr_checkout.json --names "KB1 DS SLIT LEF" --prefix CXI:KB1:MMS:13

positional arguments:
  hutch                 name of hutch, e.g. 'cxi'
  filename              Output filepath

optional arguments:
  -h, --help            show this help message and exit
  --names PMGR_NAMES [PMGR_NAMES ...], -m PMGR_NAMES [PMGR_NAMES ...]
                        a list of stored pmgr configuration names, case and whitespace sensitive.e.g. 'KB1 DS SLIT LEF'.  Length must match --prefixes
  --prefixes PREFIXES [PREFIXES ...], -p PREFIXES [PREFIXES ...]
                        a list of EPICS PV prefixes, e.g. 'CXI:KB1:MMS:13'.  Length must match --names
  --table TABLE_NAME, -t TABLE_NAME
                        Table type, by default 'ims_motor'
```

</p>
</details> 

One caveat here is that doing all this requires we import the modules.  This was how we did this before, but I'm realizing the sluggishness of the CLI is likely largely due to all the importing we do.  If we wanted to defer these imports, we'd have to hard code the subcommands and lose the import error messages that have saved me multiple times in the past

## How Has This Been Tested?
Interactively, I need to re-learn how to pytest CLI stuff without click

## Where Has This Been Documented?
This PR, as well as in the cli help text

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [ ] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
