### PR TITLE
BUG: remove deleteLater() and setParent(None) calls

### DIFF
--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -652,15 +652,6 @@ class DualTree(DesignerDisplay, QWidget):
             logger.debug(f'{mode} cache full, popping last widget: '
                          f'({oldest_widget})')
 
-            # typically this is fast enough, but if garbage collection is quick
-            # the widget may be deleted before we can delete it ourselves
-            try:
-                logger.debug(f'deleting widget from cache: {type(oldest_widget)}')
-                oldest_widget.setParent(None)
-                oldest_widget.deleteLater()
-            except RuntimeError:
-                pass
-
     def create_widget(self, item: TreeItem, mode: str) -> PageWidget:
         """Create the widget for ``item`` in ``mode``."""
         data = item.orig_data

--- a/docs/source/upcoming_release_notes/231-bug_segfault_deleteLater.rst
+++ b/docs/source/upcoming_release_notes/231-bug_segfault_deleteLater.rst
@@ -1,0 +1,22 @@
+231 bug_segfault_deleteLater
+############################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Avoid running deleteLater on widgets that garbage collection handles, preventing segfaults
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Remove `deleteLater()` and `setParent(None)` calls from cached widget deletion process, as they seem to cause segfaults and are not strictly necessary...

## Motivation and Context
closes #230 

## How Has This Been Tested?
Interactively, I need to add (better) tests though (for a followup)

My interactive testing focused on making sure widgets were actually being deleted by garbage collection, despite not explicitly requesting it.  To do this I held a weakref to widgets that were popped from the cache, and observed that these weakrefs weren't piling up as I loaded and popped widgets.   This could be made more empirical of course, I'll hopefully fix that soon.

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
