### PR TITLE
MNT: remove selectionModel calls, use `QTreeView.setCurrentIndex()`

### DIFF
--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -519,9 +519,6 @@ class DualTree(DesignerDisplay, QWidget):
 
         self.toggle = Toggle()
 
-        # select top level root
-        self.tree_view.setCurrentIndex(self.model.index(0, 0, QtCore.QModelIndex()))
-
     def assemble_tree(self) -> None:
         """init-time tree setup.  Sets the tree into edit mode"""
         # self.tree_view = QtWidgets.QTreeView()
@@ -574,6 +571,9 @@ class DualTree(DesignerDisplay, QWidget):
         self.tree_view.selectionModel().selectionChanged.connect(
             self.show_selected_display
         )
+
+        # select top level root
+        self.tree_view.setCurrentIndex(self.model.index(0, 0, QtCore.QModelIndex()))
 
     def select_by_item(self, item: TreeItem) -> None:
         """Select desired TreeItem(and show corresponding page) in TreeView"""
@@ -819,12 +819,17 @@ class DualTree(DesignerDisplay, QWidget):
             self.tree_view.setColumnHidden(1, True)
 
         # navigate away and back to trigger selectionChanged
-        if update_run:
+        curr_item = self.current_item
+        curr_index = self.model.index_from_item(self.current_item)
+        alt_index = self.tree_view.indexBelow(curr_index)
+        if self.model.data(alt_index, 0) is None:
             self.select_by_item(self.root_item)
+        else:
+            self.tree_view.setCurrentIndex(alt_index)
+
+        if update_run:
             self.select_by_item(self.root_item.child(0))
         else:
-            curr_item = self.current_item
-            self.select_by_item(self.root_item)
             self.select_by_item(curr_item)
 
     def print_report(self, *args, **kwargs):

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -556,9 +556,8 @@ class DualTree(DesignerDisplay, QWidget):
 
         # Clear widget caches
         for cache in (self.edit_widget_cache, self.run_widget_cache):
-            for widget in cache.values():
-                widget.setParent(None)
-                widget.deleteLater()
+            for _ in range(len(cache)):
+                cache.popitem()
 
         self.root_item = create_tree_from_file(
             data=self.orig_file,

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -520,7 +520,7 @@ class DualTree(DesignerDisplay, QWidget):
         self.toggle = Toggle()
 
         # select top level root
-        self.select_by_item(self.root_item.child(0))
+        self.tree_view.setCurrentIndex(self.model.index(0, 0, QtCore.QModelIndex()))
 
     def assemble_tree(self) -> None:
         """init-time tree setup.  Sets the tree into edit mode"""
@@ -581,8 +581,7 @@ class DualTree(DesignerDisplay, QWidget):
         # check if item is in tree before selecting?
         logger.debug(f'selecting page for item: {item.data(0)}')
         new_index = self.model.index_from_item(item)
-        sel_model = self.tree_view.selectionModel()
-        sel_model.select(new_index, sel_model.ClearAndSelect | sel_model.Rows)
+        self.tree_view.setCurrentIndex(new_index)
 
     def select_by_data(self, data: AnyDataclass) -> None:
         """Select the TreeItem containing ``data``"""

--- a/docs/source/upcoming_release_notes/233-mnt_avoid_selectionModel.rst
+++ b/docs/source/upcoming_release_notes/233-mnt_avoid_selectionModel.rst
@@ -1,0 +1,22 @@
+233 mnt_avoid_selectionModel
+############################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Make selection behavior more consistent by using QTreeView.setCurrentIndex() instead of manipulating the selectionModel
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Replaces selectionModel calls, use `QTreeView.setCurrentIndex()`.  

## Motivation and Context
Closes #232 , but also allows me to write (slightly) better tests for #231 

## How Has This Been Tested?
Interactively, but also I added a test.

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
