### PR TITLE
BUG: Fix widget-deleted errors in `MultiModeValueEdit`

### DIFF
--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -2109,17 +2109,22 @@ class MultiModeValueEdit(DesignerDisplay, QWidget):
                             enums_in_order.append(enum_str)
 
         def fill_enums():
-            for text in enums_in_order:
-                self.enum_input.addItem(text)
-            value = str(self.value.get())
-            if value in enums_in_order:
-                self.enum_input.setCurrentText(value)
+            try:
+                for text in enums_in_order:
+                    self.enum_input.addItem(text)
+                value = str(self.value.get())
+                if value in enums_in_order:
+                    self.enum_input.setCurrentText(value)
 
-            if set_mode:
-                if enums_in_order:
-                    self.set_mode(EditMode.ENUM)
-                else:
-                    self.set_mode(EditMode.STR)
+                if set_mode:
+                    if enums_in_order:
+                        self.set_mode(EditMode.ENUM)
+                    else:
+                        self.set_mode(EditMode.STR)
+            except RuntimeError:
+                # Widget sometimes destroyed before this completes
+                # simply return if this happens
+                return
 
         self.thread_worker = BusyCursorThread(func=get_signal_enums)
         self.thread_worker.task_finished.connect(fill_enums)

--- a/docs/source/upcoming_release_notes/234-bug_mmve_late_cb.rst
+++ b/docs/source/upcoming_release_notes/234-bug_mmve_late_cb.rst
@@ -1,0 +1,22 @@
+234 bug_mmve_late_cb
+####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Catch RuntimeErrors from widget deletion during enum filling
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Makes the `BusyCursorThread` called in `MultiModeValueEdit` more tolerant of widgets being garbage collected while EPICS is timing out

## Motivation and Context
closes #234 

In summary, aspects of `MultiModeValueEdit` (`MMVE`) call EPICS, and if we're thumbing quickly through the pages, we can pop the parent page from the cache and delete it before the connection times out.   The callback would then fire, and cause ATEF to throw an error. 

We just catch those and ignore it if this is the case.

## How Has This Been Tested?
interactively, and by removing the cache limitation in `test_open_all_pages`

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
