### PR TITLE
MNT/REF: separate find replace logic from widgets

### DIFF
--- a/atef/find_replace.py
+++ b/atef/find_replace.py
@@ -1,0 +1,324 @@
+"""Find-and-Replace functionality, for use in templating checkouts as well"""
+import logging
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass, fields, is_dataclass
+from enum import Enum
+from typing import (Any, Callable, Generator, List, Optional, Tuple, Union,
+                    get_args)
+
+import happi
+
+from atef.cache import DataCache
+from atef.config import ConfigurationFile
+from atef.procedure import ProcedureFile
+from atef.type_hints import PrimitiveType
+
+logger = logging.getLogger(__name__)
+
+MatchFunction = Callable[[Any], bool]
+ReplaceFunction = Callable[[Any], Any]
+
+
+@contextmanager
+def patch_client_cache():
+    old_happi_cache = happi.loader.cache
+    try:
+        happi.loader.cache = {}
+        dcache = DataCache()
+        dcache.signals.clear()
+        yield
+    finally:
+        happi.loader.cache = old_happi_cache
+        dcache.signals.clear()
+
+
+def walk_find_match(
+    item: Any,
+    match: Callable,
+    parent: List[Tuple[Any, Any]] = []
+) -> Generator[List[Tuple[Any, Any]], None, None]:
+    """
+    Walk the dataclass and find every key / field where ``match`` evaluates to True.
+
+    Yields a list of 'paths' to the matching key / field. A path is a list of
+    (object, field) tuples that lead from the top level ``item`` to the matching
+    key / field.
+    - If the object is a dataclass, ``field`` will be a field in that dataclass
+    - If the object is a list, ``field`` will be the index in that list
+    - If the object is a dict, ``field`` will be a key in that dictionary
+
+    ``match`` should be a Callable taking a single argument and returning a boolean,
+    specifying whether that argument matched a search term or not.  This is
+    commonly a simple lambda wrapping an equality or regex search.
+
+    Ex:
+    paths = walk_find_match(ConfigFile, lambda x: x == 5)
+    paths = walk_find_match(ConfigFile, lambda x: re.compile('^warning$').search(x) is not None)
+
+    Parameters
+    ----------
+    item : Any
+        the item to search in.  A dataclass at the top level, but can also be a
+        list or dict
+    match : Callable
+        a function that takes a single argument and returns a boolean
+    parent : List[Tuple[Union[str, int], Any]], optional
+        the 'path' traveled to arive at ``item`` at this point, by default []
+        (used internally)
+
+    Yields
+    ------
+    List[Tuple[Any, Any]]
+        paths leading to keys or fields where ``match`` is True
+    """
+    if is_dataclass(item):
+        # get fields, recurse through fields
+        for field in fields(item):
+            yield from walk_find_match(getattr(item, field.name), match,
+                                       parent=parent + [(item, field.name)])
+    elif isinstance(item, list):
+        for idx, l_item in enumerate(item):
+            # TODO: py3.10 allows isinstance with Unions
+            if isinstance(l_item, get_args(PrimitiveType)) and match(l_item):
+                yield parent + [('__list__', idx)]
+            else:
+                yield from walk_find_match(l_item, match,
+                                           parent=parent + [('__list__', idx)])
+    elif isinstance(item, dict):
+        for d_key, d_value in item.items():
+            # don't halt at first key match, values could also have matches
+            if isinstance(d_value, get_args(PrimitiveType)) and match(d_value):
+                yield parent + [('__dictvalue__', d_key)]
+            else:
+                yield from walk_find_match(d_value, match,
+                                           parent=parent + [('__dictvalue__', d_key)])
+            if match(d_key):
+                yield parent + [('__dictkey__', d_key)]
+
+    elif isinstance(item, Enum):
+        if match(item.name):
+            yield parent + [('__enum__', item)]
+
+    elif match(item):
+        yield parent
+
+
+def get_item_from_path(
+    path: List[Tuple[Any, Any]],
+    item: Optional[Any] = None
+) -> Any:
+    """
+    Get the item the path points to.  This can work for any subpath
+
+    If ``item`` is not provided, use the stashed objects in ``path``.
+    Item is expected to be top-level object, if provided.
+    (i.e. analagous to path[0][0]).
+
+    Parameters
+    ----------
+    path : List[Tuple[Any, Any]]
+        A "path" to a search match, as returned by walk_find_match
+    item : Optional[Any], optional
+        the item of interest to explore, by default None
+
+    Returns
+    -------
+    Any
+        the object at the end of ``path``, starting from ``item``
+    """
+    if not item:
+        item = path[0][0]
+    for seg in path:
+        if seg[0] == '__dictkey__':
+            item = seg[1]
+        elif seg[0] == '__dictvalue__':
+            item = item[seg[1]]
+        elif seg[0] == '__list__':
+            item = item[seg[1]]
+        elif seg[0] == '__enum__':
+            item = item.name
+        else:
+            # general dataclass case
+            item = getattr(item, seg[1])
+    return item
+
+
+def get_deepest_dataclass_in_path(
+    path: List[Tuple[Any, Any]],
+    item: Optional[Any] = None
+) -> Tuple[Any, str]:
+    """
+    Grab the deepest dataclass in the path, and return its segment
+
+    Parameters
+    ----------
+    path : List[Tuple[Any, Any]]
+        A "path" to a search match, as returned by walk_find_match
+    item : Any
+        An object to start the path from
+
+    Returns
+    -------
+    Tuple[AnyDataclass, str]
+        The deepest dataclass, and field name for the next step
+    """
+    rev_idx = -1
+    while rev_idx > (-len(path) - 1):
+        if is_dataclass(path[rev_idx][0]):
+            break
+        else:
+            rev_idx -= 1
+    if item:
+        return get_item_from_path(path[:rev_idx], item), path[rev_idx][1]
+
+    return path[rev_idx]
+
+
+def replace_item_from_path(
+    item: Any,
+    path: List[Tuple[Any, Any]],
+    replace_fn: ReplaceFunction
+) -> None:
+    """
+    replace some object in ``item`` located at the end of ``path``, according
+    to ``replace_fn``.
+
+    ``replace_fn`` should take the original value, and return the new value
+    for insertion into ``item``.  This function frequently involves string
+    substitution, and possibly type conversions
+
+    Parameters
+    ----------
+    item : Any
+        The object to replace information in
+    path : List[Tuple[Any, Any]]
+        A "path" to a search match, as returned by walk_find_match
+    replace_fn : ReplaceFunction
+        A function that returns the replacement object
+    """
+    # need the final step to specify what is being replaced
+    final_step = path[-1]
+    # need the item one step before the last to perform the assignment on
+    parent_item = get_item_from_path(path[:-1], item=item)
+
+    if final_step[0] == "__dictkey__":
+        parent_item[replace_fn(final_step[1])] = parent_item.pop(final_step[1])
+    elif final_step[0] in ("__dictvalue__", "__list__"):
+        # replace value
+        old_value = parent_item[final_step[1]]
+        parent_item[final_step[1]] = replace_fn(old_value)
+    elif final_step[0] == "__enum__":
+        parent_item = get_item_from_path(path[:-2], item=item)
+        old_enum: Enum = getattr(parent_item, path[-2][1])
+        new_enum = getattr(final_step[1], replace_fn(old_enum.name))
+        setattr(parent_item, path[-2][1], new_enum)
+    else:
+        # simple field paths don't have a final (__sth__, ?) segment
+        old_value = getattr(parent_item, path[-1][1])
+        setattr(parent_item, path[-1][1], replace_fn(old_value))
+
+
+def get_default_match_fn(search_regex: re.Pattern) -> MatchFunction:
+    """
+    Returns a standard match function using the provided regex pattern
+
+    Parameters
+    ----------
+    search_regex : re.Pattern
+        compiled regex pattern to match items against
+
+    Returns
+    -------
+    MatchFunction
+        a match function to be used in ``walk_find_match``
+    """
+    def match_fn(match):
+        return search_regex.search(str(match)) is not None
+
+    return match_fn
+
+
+def get_default_replace_fn(
+    replace_text: str,
+    search_regex: re.Pattern
+) -> ReplaceFunction:
+    """
+    Returns a standard replace function, which attempts to match the type of the
+    item being replaced
+
+    Parameters
+    ----------
+    replace_text : str
+        text to replace
+    search_regex : re.Pattern
+        the compiled regex search pattern, for use in string replacements
+
+    Returns
+    -------
+    ReplaceFunction
+        a replacement function for use in ``replace_item_from_path``
+    """
+    def replace_fn(value):
+        if isinstance(value, str):
+            return search_regex.sub(replace_text, value)
+        elif isinstance(value, int):
+            # cast to float first
+            return int(float(value))
+        else:  # try to cast as original type
+            return type(value)(replace_text)
+
+    return replace_fn
+
+
+@dataclass
+class FindReplaceAction:
+    target: Union[ConfigurationFile, ProcedureFile]
+    path: List[Tuple[Any, Any]]
+    replace_fn: ReplaceFunction
+
+    def apply(
+        self,
+        target: Optional[Union[ConfigurationFile, ProcedureFile]] = None,
+        path: Optional[List[Tuple[Any, Any]]] = None,
+        replace_fn: Optional[ReplaceFunction] = None
+    ) -> bool:
+        """
+        Apply the find-replace action, return True if action was applied
+        successfully.
+
+        Can specify any of ``target``, ``path``, or ``replace_fn`` in order
+        to use that object instead of the stored object
+
+        Parameters
+        ----------
+        target : Optional[Union[ConfigurationFile, ProcedureFile]], optional
+            The file to apply the find-replace action to, by default this applies
+            to the current target of the action, by default None
+        path : Optional[List[Tuple[Any, Any]]], optional
+            A "path" to a search match, as returned by walk_find_match,
+            by default None
+        replace_fn : Optional[ReplaceFunction], optional
+            A function that takes the value and returns the replaced value,
+            by default None
+
+        Returns
+        -------
+        bool
+            the success of the apply action
+        """
+
+        target = target or self.target
+        path = path or self.path
+        replace_fn = replace_fn or self.replace_fn
+        try:
+            replace_item_from_path(target, path, replace_fn)
+        except KeyError as ex:
+            logger.warning(f'Unable to find key ({ex}) in file. '
+                           'File may have already been edited')
+            return False
+        except Exception as ex:
+            logger.warning(f'Unable to apply change. {ex}')
+            return False
+
+        return True

--- a/atef/tests/test_find_replace.py
+++ b/atef/tests/test_find_replace.py
@@ -8,10 +8,9 @@ from atef.check import Equals, GreaterOrEqual
 from atef.config import (ConfigurationGroup, DeviceConfiguration,
                          PreparedDeviceConfiguration)
 from atef.enums import Severity
-from atef.widgets.config.find_replace import (get_deepest_dataclass_in_path,
-                                              get_item_from_path,
-                                              replace_item_from_path,
-                                              walk_find_match)
+from atef.find_replace import (get_deepest_dataclass_in_path,
+                               get_item_from_path, replace_item_from_path,
+                               walk_find_match)
 
 
 @pytest.mark.parametrize(

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -23,7 +23,7 @@ from atef.find_replace import (FindReplaceAction, MatchFunction,
                                ReplaceFunction, get_deepest_dataclass_in_path,
                                get_default_match_fn, get_default_replace_fn,
                                get_item_from_path, patch_client_cache,
-                               walk_find_match)
+                               verify_file, walk_find_match)
 from atef.procedure import PreparedProcedureFile, ProcedureFile
 from atef.util import get_happi_client
 from atef.widgets.config.utils import TableWidgetWithAddRow
@@ -56,38 +56,13 @@ def verify_file_and_notify(
     bool
         the verification success
     """
-    verified = True
-    try:
-        if isinstance(file, ConfigurationFile):
-            prep_file = PreparedFile.from_config(file)
-            if len(prep_file.root.prepare_failures) > 0:
-                verified = False
-        elif isinstance(file, ProcedureFile):
-            # clear all results when making a new run tree
-            prep_file = PreparedProcedureFile.from_origin(file)
-            if len(prep_file.root.prepare_failures) > 0:
-                verified = False
-        else:
-            QtWidgets.QMessageBox.warning(
-                parent_widget,
-                'Verification FAIL',
-                'File type not recognized.'
-            )
-            return False
-    except Exception as ex:
-        logger.debug(ex)
-        QtWidgets.QMessageBox.warning(
-            parent_widget,
-            'Verification FAIL',
-            f'Unknown Error: {ex}.'
-        )
-        return False
+    verified, msg = verify_file(file)
 
     if not verified:
         QtWidgets.QMessageBox.warning(
             parent_widget,
             'Verification FAIL',
-            'File could not be prepared successfully, edits will not work'
+            'File could not be prepared, edits will not work.\n' + msg
         )
     else:
         QtWidgets.QMessageBox.information(

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -6,13 +6,10 @@ import json
 import logging
 import os
 import re
-from contextlib import contextmanager
-from dataclasses import dataclass, fields, is_dataclass
-from enum import Enum
 from functools import partial
 from pathlib import Path
-from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Generator,
-                    Iterable, List, Optional, Tuple, Union, get_args)
+from typing import (TYPE_CHECKING, Any, ClassVar, Iterable, List, Optional,
+                    Union)
 
 import happi
 import qtawesome as qta
@@ -20,10 +17,14 @@ from apischema import ValidationError, serialize
 from pcdsutils.qt.callbacks import WeakPartialMethodSlot
 from qtpy import QtCore, QtWidgets
 
-from atef.cache import DataCache, get_signal_cache
+from atef.cache import get_signal_cache
 from atef.config import ConfigurationFile, PreparedFile
+from atef.find_replace import (FindReplaceAction, MatchFunction,
+                               ReplaceFunction, get_deepest_dataclass_in_path,
+                               get_default_match_fn, get_default_replace_fn,
+                               get_item_from_path, patch_client_cache,
+                               walk_find_match)
 from atef.procedure import PreparedProcedureFile, ProcedureFile
-from atef.type_hints import PrimitiveType
 from atef.util import get_happi_client
 from atef.widgets.config.utils import TableWidgetWithAddRow
 from atef.widgets.core import DesignerDisplay
@@ -33,260 +34,6 @@ if TYPE_CHECKING:
     from .window import Window
 
 logger = logging.getLogger(__name__)
-
-ReplaceFunction = Callable[[Any], Any]
-MatchFunction = Callable[[Any], bool]
-
-
-@contextmanager
-def patch_client_cache():
-    old_happi_cache = happi.loader.cache
-    try:
-        happi.loader.cache = {}
-        dcache = DataCache()
-        dcache.signals.clear()
-        yield
-    finally:
-        happi.loader.cache = old_happi_cache
-        dcache.signals.clear()
-
-
-def walk_find_match(
-    item: Any,
-    match: Callable,
-    parent: List[Tuple[Any, Any]] = []
-) -> Generator[List[Tuple[Any, Any]], None, None]:
-    """
-    Walk the dataclass and find every key / field where ``match`` evaluates to True.
-
-    Yields a list of 'paths' to the matching key / field. A path is a list of
-    (object, field) tuples that lead from the top level ``item`` to the matching
-    key / field.
-    - If the object is a dataclass, ``field`` will be a field in that dataclass
-    - If the object is a list, ``field`` will be the index in that list
-    - If the object is a dict, ``field`` will be a key in that dictionary
-
-    ``match`` should be a Callable taking a single argument and returning a boolean,
-    specifying whether that argument matched a search term or not.  This is
-    commonly a simple lambda wrapping an equality or regex search.
-
-    Ex:
-    paths = walk_find_match(ConfigFile, lambda x: x == 5)
-    paths = walk_find_match(ConfigFile, lambda x: re.compile('^warning$').search(x) is not None)
-
-    Parameters
-    ----------
-    item : Any
-        the item to search in.  A dataclass at the top level, but can also be a
-        list or dict
-    match : Callable
-        a function that takes a single argument and returns a boolean
-    parent : List[Tuple[Union[str, int], Any]], optional
-        the 'path' traveled to arive at ``item`` at this point, by default []
-        (used internally)
-
-    Yields
-    ------
-    List[Tuple[Any, Any]]
-        paths leading to keys or fields where ``match`` is True
-    """
-    if is_dataclass(item):
-        # get fields, recurse through fields
-        for field in fields(item):
-            yield from walk_find_match(getattr(item, field.name), match,
-                                       parent=parent + [(item, field.name)])
-    elif isinstance(item, list):
-        for idx, l_item in enumerate(item):
-            # TODO: py3.10 allows isinstance with Unions
-            if isinstance(l_item, get_args(PrimitiveType)) and match(l_item):
-                yield parent + [('__list__', idx)]
-            else:
-                yield from walk_find_match(l_item, match,
-                                           parent=parent + [('__list__', idx)])
-    elif isinstance(item, dict):
-        for d_key, d_value in item.items():
-            # don't halt at first key match, values could also have matches
-            if isinstance(d_value, get_args(PrimitiveType)) and match(d_value):
-                yield parent + [('__dictvalue__', d_key)]
-            else:
-                yield from walk_find_match(d_value, match,
-                                           parent=parent + [('__dictvalue__', d_key)])
-            if match(d_key):
-                yield parent + [('__dictkey__', d_key)]
-
-    elif isinstance(item, Enum):
-        if match(item.name):
-            yield parent + [('__enum__', item)]
-
-    elif match(item):
-        yield parent
-
-
-def get_deepest_dataclass_in_path(
-    path: List[Tuple[Any, Any]],
-    item: Optional[Any] = None
-) -> Tuple[Any, str]:
-    """
-    Grab the deepest dataclass in the path, and return its segment
-
-    Parameters
-    ----------
-    path : List[Tuple[Any, Any]]
-        A "path" to a search match, as returned by walk_find_match
-    item : Any
-        An object to start the path from
-
-    Returns
-    -------
-    Tuple[AnyDataclass, str]
-        The deepest dataclass, and field name for the next step
-    """
-    rev_idx = -1
-    while rev_idx > (-len(path) - 1):
-        if is_dataclass(path[rev_idx][0]):
-            break
-        else:
-            rev_idx -= 1
-    if item:
-        return get_item_from_path(path[:rev_idx], item), path[rev_idx][1]
-
-    return path[rev_idx]
-
-
-def get_item_from_path(
-    path: List[Tuple[Any, Any]],
-    item: Optional[Any] = None
-) -> Any:
-    """
-    Get the item the path points to.  This can work for any subpath
-
-    If ``item`` is not provided, use the stashed objects in ``path``.
-    Item is expected to be top-level object, if provided.
-    (i.e. analagous to path[0][0]).
-
-    Parameters
-    ----------
-    path : List[Tuple[Any, Any]]
-        A "path" to a search match, as returned by walk_find_match
-    item : Optional[Any], optional
-        the item of interest to explore, by default None
-
-    Returns
-    -------
-    Any
-        the object at the end of ``path``, starting from ``item``
-    """
-    if not item:
-        item = path[0][0]
-    for seg in path:
-        if seg[0] == '__dictkey__':
-            item = seg[1]
-        elif seg[0] == '__dictvalue__':
-            item = item[seg[1]]
-        elif seg[0] == '__list__':
-            item = item[seg[1]]
-        elif seg[0] == '__enum__':
-            item = item.name
-        else:
-            # general dataclass case
-            item = getattr(item, seg[1])
-    return item
-
-
-def replace_item_from_path(
-    item: Any,
-    path: List[Tuple[Any, Any]],
-    replace_fn: ReplaceFunction
-) -> None:
-    """
-    replace some object in ``item`` located at the end of ``path``, according
-    to ``replace_fn``.
-
-    ``replace_fn`` should take the original value, and return the new value
-    for insertion into ``item``.  This function frequently involves string
-    substitution, and possibly type conversions
-
-    Parameters
-    ----------
-    item : Any
-        The object to replace information in
-    path : List[Tuple[Any, Any]]
-        A "path" to a search match, as returned by walk_find_match
-    replace_fn : ReplaceFunction
-        A function that returns the replacement object
-    """
-    # need the final step to specify what is being replaced
-    final_step = path[-1]
-    # need the item one step before the last to perform the assignment on
-    parent_item = get_item_from_path(path[:-1], item=item)
-
-    if final_step[0] == "__dictkey__":
-        parent_item[replace_fn(final_step[1])] = parent_item.pop(final_step[1])
-    elif final_step[0] in ("__dictvalue__", "__list__"):
-        # replace value
-        old_value = parent_item[final_step[1]]
-        parent_item[final_step[1]] = replace_fn(old_value)
-    elif final_step[0] == "__enum__":
-        parent_item = get_item_from_path(path[:-2], item=item)
-        old_enum: Enum = getattr(parent_item, path[-2][1])
-        new_enum = getattr(final_step[1], replace_fn(old_enum.name))
-        setattr(parent_item, path[-2][1], new_enum)
-    else:
-        # simple field paths don't have a final (__sth__, ?) segment
-        old_value = getattr(parent_item, path[-1][1])
-        setattr(parent_item, path[-1][1], replace_fn(old_value))
-
-
-def get_default_match_fn(search_regex: re.Pattern) -> MatchFunction:
-    """
-    Returns a standard match function using the provided regex pattern
-
-    Parameters
-    ----------
-    search_regex : re.Pattern
-        compiled regex pattern to match items against
-
-    Returns
-    -------
-    MatchFunction
-        a match function to be used in ``walk_find_match``
-    """
-    def match_fn(match):
-        return search_regex.search(str(match)) is not None
-
-    return match_fn
-
-
-def get_default_replace_fn(
-    replace_text: str,
-    search_regex: re.Pattern
-) -> ReplaceFunction:
-    """
-    Returns a standard replace function, which attempts to match the type of the
-    item being replaced
-
-    Parameters
-    ----------
-    replace_text : str
-        text to replace
-    search_regex : re.Pattern
-        the compiled regex search pattern, for use in string replacements
-
-    Returns
-    -------
-    ReplaceFunction
-        a replacement function for use in ``replace_item_from_path``
-    """
-    def replace_fn(value):
-        if isinstance(value, str):
-            return search_regex.sub(replace_text, value)
-        elif isinstance(value, int):
-            # cast to float first
-            return int(float(value))
-        else:  # try to cast as original type
-            return type(value)(replace_text)
-
-    return replace_fn
 
 
 def verify_file_and_notify(
@@ -349,59 +96,6 @@ def verify_file_and_notify(
             'File prepared successfully, edits should work'
         )
     return verified
-
-
-@dataclass
-class FindReplaceAction:
-    target: Union[ConfigurationFile, ProcedureFile]
-    path: List[Tuple[Any, Any]]
-    replace_fn: ReplaceFunction
-
-    def apply(
-        self,
-        target: Optional[Union[ConfigurationFile, ProcedureFile]] = None,
-        path: Optional[List[Tuple[Any, Any]]] = None,
-        replace_fn: Optional[ReplaceFunction] = None
-    ) -> bool:
-        """
-        Apply the find-replace action, return True if action was applied
-        successfully.
-
-        Can specify any of ``target``, ``path``, or ``replace_fn`` in order
-        to use that object instead of the stored object
-
-        Parameters
-        ----------
-        target : Optional[Union[ConfigurationFile, ProcedureFile]], optional
-            The file to apply the find-replace action to, by default this applies
-            to the current target of the action, by default None
-        path : Optional[List[Tuple[Any, Any]]], optional
-            A "path" to a search match, as returned by walk_find_match,
-            by default None
-        replace_fn : Optional[ReplaceFunction], optional
-            A function that takes the value and returns the replaced value,
-            by default None
-
-        Returns
-        -------
-        bool
-            the success of the apply action
-        """
-
-        target = target or self.target
-        path = path or self.path
-        replace_fn = replace_fn or self.replace_fn
-        try:
-            replace_item_from_path(target, path, replace_fn)
-        except KeyError as ex:
-            logger.warning(f'Unable to find key ({ex}) in file. '
-                           'File may have already been edited')
-            return False
-        except Exception as ex:
-            logger.warning(f'Unable to apply change. {ex}')
-            return False
-
-        return True
 
 
 class FindReplaceWidget(DesignerDisplay, QtWidgets.QWidget):

--- a/docs/source/upcoming_release_notes/237-mnt_sep_find_replace.rst
+++ b/docs/source/upcoming_release_notes/237-mnt_sep_find_replace.rst
@@ -1,0 +1,22 @@
+237 mnt_sep_find_replace
+########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Refactors find-replace logic and dataclasses into a separate module from the widgets that display them
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Separates the find-replace logic and dataclasses from the widgets that display them.
No functional changes in this PR

## Motivation and Context
In preparation for future explicit templating steps, and also just something that should be done anyway.

## How Has This Been Tested?
The test suite still works 🎉 

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
