### PR TITLE
ENH: Add Template Configuration and Step

### DIFF
--- a/atef/config.py
+++ b/atef/config.py
@@ -1260,8 +1260,6 @@ class PreparedToolConfiguration(PreparedConfiguration):
 class PreparedTemplateConfiguration(PreparedConfiguration):
     # configuration origin
     config: TemplateConfiguration = field(default_factory=TemplateConfiguration)
-    # original, unprepared file
-    original_file: ConfigurationFile = field(default_factory=ConfigurationFile)
     # prepared file with edits applied
     file: PreparedFile = field(default_factory=PreparedFile)
 
@@ -1307,7 +1305,6 @@ class PreparedTemplateConfiguration(PreparedConfiguration):
 
         prepared = PreparedTemplateConfiguration(
             config=config,
-            original_file=config_file,
             file=prep_file,
             parent=parent,
             cache=cache,

--- a/atef/config.py
+++ b/atef/config.py
@@ -404,6 +404,20 @@ class ConfigurationFile:
         init_yaml_support()
         return yaml.dump(self.to_json())
 
+    def verify(self) -> Tuple[bool, str]:
+        """Verify the file is properly formed and can be prepared"""
+        try:
+            prep_file = PreparedFile.from_origin(self)
+            prep_failures = len(prep_file.root.prepare_failures)
+            if prep_failures > 0:
+                return False, f'Failed to prepare {prep_failures} steps'
+        except Exception as ex:
+            logger.debug(ex)
+            msg = f'Unknown Error: {ex}.'
+            return False, msg
+
+        return True, ''
+
 
 @dataclass
 class PreparedFile:

--- a/atef/find_replace.py
+++ b/atef/find_replace.py
@@ -10,8 +10,8 @@ from typing import (Any, Callable, Generator, List, Optional, Tuple, Union,
 import happi
 
 from atef.cache import DataCache
-from atef.config import ConfigurationFile, PreparedFile
-from atef.procedure import PreparedProcedureFile, ProcedureFile
+from atef.config import ConfigurationFile
+from atef.procedure import ProcedureFile
 from atef.type_hints import PrimitiveType
 
 logger = logging.getLogger(__name__)
@@ -322,26 +322,3 @@ class FindReplaceAction:
             return False
 
         return True
-
-
-def verify_file(
-    file: Union[ConfigurationFile, ProcedureFile],
-) -> Tuple[bool, str]:
-    try:
-        if isinstance(file, ConfigurationFile):
-            prep_file = PreparedFile.from_config(file)
-        elif isinstance(file, ProcedureFile):
-            # clear all results when making a new run tree
-            prep_file = PreparedProcedureFile.from_origin(file)
-        else:
-            msg = 'File type not recognized.'
-            return False, msg
-        prep_failures = len(prep_file.root.prepare_failures)
-        if prep_failures > 0:
-            return False, f'Failed to prepare {prep_failures} steps'
-    except Exception as ex:
-        logger.debug(ex)
-        msg = f'Unknown Error: {ex}.'
-        return False, msg
-
-    return True, ''

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -1430,7 +1430,8 @@ AnyProcedure = Union[
     DescriptionStep,
     PassiveStep,
     SetValueStep,
-    PlanStep
+    PlanStep,
+    TemplateStep,
 ]
 
 AnyPreparedProcedure = Union[
@@ -1438,5 +1439,6 @@ AnyPreparedProcedure = Union[
     PreparedDescriptionStep,
     PreparedPassiveStep,
     PreparedSetValueStep,
-    PreparedPlanStep
+    PreparedPlanStep,
+    PreparedTemplateStep,
 ]

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -965,6 +965,10 @@ class PreparedTemplateStep(PreparedProcedureStep):
         if filetype == "passive":
             prep_file = PreparedFile.from_config(file=orig_file)
         else:
+            # need to set all the verifications off.
+            # TODO: refactor when global settings are implemented
+            for step in orig_file.walk_steps():
+                step.verify_required = False
             prep_file = PreparedProcedureFile.from_origin(file=orig_file)
 
         prepared = PreparedTemplateStep(
@@ -973,6 +977,22 @@ class PreparedTemplateStep(PreparedProcedureStep):
             parent=parent,
         )
         return prepared
+
+    async def _run(self) -> Result:
+        """
+        Run the edited ProcedureFile
+
+        Returns
+        -------
+        Result
+            the step_reesult for this step
+        """
+        if isinstance(self.file, PreparedFile):
+            result = await self.file.compare()
+        else:
+            result = await self.file.run()
+
+        return result
 
 
 @dataclass

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -420,8 +420,8 @@ class ProcedureFile:
         init_yaml_support()
         return yaml.dump(self.to_json())
 
-    def verify(self) -> Tuple[bool, str]:
-        """Verify the file is properly formed and can be prepared"""
+    def validate(self) -> Tuple[bool, str]:
+        """Validate the file is properly formed and can be prepared"""
         try:
             prep_file = PreparedProcedureFile.from_origin(self)
             prep_failures = len(prep_file.root.prepare_failures)
@@ -945,7 +945,7 @@ class PreparedTemplateStep(PreparedProcedureStep):
             edit.apply(target=orig_file)
 
         # verify edited file
-        success, msg = orig_file.verify()
+        success, msg = orig_file.validate()
         if not success:
             return FailedStep(
                 origin=step,

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -535,7 +535,6 @@ class PreparedProcedureStep:
         """
         results = []
         reason = ''
-        print(type(self), self.origin.verify_required, self.origin.step_success_required)
         if self.origin.verify_required:
             results.append(self.verify_result)
             if self.verify_result.severity != Severity.success:

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -410,6 +410,20 @@ class ProcedureFile:
         init_yaml_support()
         return yaml.dump(self.to_json())
 
+    def verify(self) -> Tuple[bool, str]:
+        """Verify the file is properly formed and can be prepared"""
+        try:
+            prep_file = PreparedProcedureFile.from_origin(self)
+            prep_failures = len(prep_file.root.prepare_failures)
+            if prep_failures > 0:
+                return False, f'Failed to prepare {prep_failures} steps'
+        except Exception as ex:
+            logger.debug(ex)
+            msg = f'Unknown Error: {ex}.'
+            return False, msg
+
+        return True, ''
+
 
 ######################
 # Prepared Dataclasses

--- a/atef/tests/conftest.py
+++ b/atef/tests/conftest.py
@@ -20,7 +20,9 @@ from atef.cache import get_signal_cache
 from atef.check import Equals, Greater, GreaterOrEqual, LessOrEqual, NotEquals
 from atef.config import (AnyConfiguration, ConfigurationFile,
                          ConfigurationGroup, DeviceConfiguration,
-                         PVConfiguration, ToolConfiguration)
+                         PVConfiguration, TemplateConfiguration,
+                         ToolConfiguration)
+from atef.find_replace import RegexFindReplace
 from atef.procedure import AnyProcedure, ProcedureFile
 from atef.tools import Ping
 from atef.type_hints import AnyDataclass
@@ -376,6 +378,25 @@ def tool_configuration():
         name='ping tool',
         tool=Ping(hosts=['psbuild-rhel7', 'localhost']),
         shared=[Equals(value=3)]
+    )
+    return group
+
+
+@pytest.fixture
+def template_configuration():
+    replace_title_path = [
+        ('atef.config.ConfigurationFile', 'root'),
+        ('atef.config.ConfigurationGroup', 'name')
+    ]
+    replace_title_edit = RegexFindReplace(
+        path=replace_title_path,
+        search_regex='root',
+        replace_text='template replaced title'
+    )
+    group = TemplateConfiguration(
+        name='template all fields',
+        filename=CONFIG_PATH / 'blank_passive.json',
+        edits=[replace_title_edit],
     )
     return group
 

--- a/atef/tests/test_configuration.py
+++ b/atef/tests/test_configuration.py
@@ -5,6 +5,7 @@ import pytest
 from atef.config import (ConfigurationFile, DeviceConfiguration, PreparedFile,
                          PreparedTemplateConfiguration, PVConfiguration,
                          TemplateConfiguration)
+from atef.enums import Severity
 from atef.type_hints import AnyDataclass
 from atef.widgets.config.utils import get_relevant_pvs
 
@@ -53,10 +54,14 @@ def test_gather_pvs(
     assert len(get_relevant_pvs(readback_comp, device_configuration)) == 2
 
 
-def test_template_configuration(template_configuration: TemplateConfiguration):
+@pytest.mark.asyncio
+async def test_template_configuration(template_configuration: TemplateConfiguration):
     assert len(template_configuration.edits) == 1
 
     # prepare and verify changes were applied
     ptc = PreparedTemplateConfiguration.from_config(template_configuration)
 
     assert ptc.file.root.config.name == 'template replaced title'
+
+    result = await ptc.compare()
+    assert result.severity == Severity.success

--- a/atef/tests/test_configuration.py
+++ b/atef/tests/test_configuration.py
@@ -3,7 +3,8 @@ import pathlib
 import pytest
 
 from atef.config import (ConfigurationFile, DeviceConfiguration, PreparedFile,
-                         PVConfiguration)
+                         PreparedTemplateConfiguration, PVConfiguration,
+                         TemplateConfiguration)
 from atef.type_hints import AnyDataclass
 from atef.widgets.config.utils import get_relevant_pvs
 
@@ -50,3 +51,12 @@ def test_gather_pvs(
     readback_comp = device_configuration.by_attr['readback'][0]
     assert len(get_relevant_pvs(setpoint_comp, device_configuration)) == 2
     assert len(get_relevant_pvs(readback_comp, device_configuration)) == 2
+
+
+def test_template_configuration(template_configuration: TemplateConfiguration):
+    assert len(template_configuration.edits) == 1
+
+    # prepare and verify changes were applied
+    ptc = PreparedTemplateConfiguration.from_config(template_configuration)
+
+    assert ptc.file.root.config.name == 'template replaced title'

--- a/atef/tests/test_procedure.py
+++ b/atef/tests/test_procedure.py
@@ -2,10 +2,14 @@ import pytest
 
 from atef.check import Equals
 from atef.enums import Severity
+from atef.find_replace import RegexFindReplace
 from atef.procedure import (ComparisonToPlanData, DescriptionStep, PlanOptions,
                             PlanStep, PreparedPlanStep, PreparedProcedureFile,
-                            PreparedProcedureStep, ProcedureFile)
+                            PreparedProcedureStep, PreparedTemplateStep,
+                            ProcedureFile, TemplateStep)
 from atef.result import Result
+
+from .conftest import CONFIG_PATH
 
 pass_result = Result()
 fail_result = Result(severity=Severity.error)
@@ -106,3 +110,46 @@ async def test_plan_step():
     assert prepared_plan_step.prepared_checks[0].result.severity == pass_result.severity
     print(prepared_plan_step.prepared_plans[0].result)
     assert prepared_plan_step.prepared_plans[0].result.severity == pass_result.severity
+
+
+def test_template_step_active_target(active_config_path):
+    replace_title_path = [
+        ('atef.config.ConfigurationFile', 'root'),
+        ('atef.config.ConfigurationGroup', 'name')
+    ]
+    replace_title_edit = RegexFindReplace(
+        path=replace_title_path,
+        search_regex='root',
+        replace_text='template replaced title'
+    )
+    ts = TemplateStep(
+        name='template all fields',
+        filename=active_config_path,
+        edits=[replace_title_edit],
+    )
+
+    pts = PreparedTemplateStep.from_origin(step=ts)
+
+    assert pts.file.root.origin.name == 'template replaced title'
+
+
+def test_template_step_passive_target():
+    # configs with happi devices fail to prepare, at no fault of the find-replace
+    replace_title_path = [
+        ('atef.config.ConfigurationFile', 'root'),
+        ('atef.config.ConfigurationGroup', 'name')
+    ]
+    replace_title_edit = RegexFindReplace(
+        path=replace_title_path,
+        search_regex='root',
+        replace_text='template replaced title'
+    )
+    ts = TemplateStep(
+        name='template all fields',
+        filename=CONFIG_PATH / 'blank_passive.json',
+        edits=[replace_title_edit],
+    )
+
+    pts = PreparedTemplateStep.from_origin(step=ts)
+
+    assert pts.file.root.config.name == 'template replaced title'

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -23,7 +23,7 @@ from atef.find_replace import (FindReplaceAction, MatchFunction,
                                ReplaceFunction, get_deepest_dataclass_in_path,
                                get_default_match_fn, get_default_replace_fn,
                                get_item_from_path, patch_client_cache,
-                               verify_file, walk_find_match)
+                               walk_find_match)
 from atef.procedure import PreparedProcedureFile, ProcedureFile
 from atef.util import get_happi_client
 from atef.widgets.config.utils import TableWidgetWithAddRow
@@ -56,7 +56,7 @@ def verify_file_and_notify(
     bool
         the verification success
     """
-    verified, msg = verify_file(file)
+    verified, msg = file.verify()
 
     if not verified:
         QtWidgets.QMessageBox.warning(

--- a/docs/source/upcoming_release_notes/238-enh_template_step.rst
+++ b/docs/source/upcoming_release_notes/238-enh_template_step.rst
@@ -1,0 +1,23 @@
+238 enh_template_step
+#####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds template step active and passive dataclasses.
+- Adds RegexFindReplace for serializable, regex specific FindReplaceAction
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Adds a configuration/step for finding/replacing objects in an existing checkout, and running it.  GUI elements will be added in a separate effort

## Motivation and Context
A frequently requested feature.  This is the first part of this

Much refactoring needed to be done here, for a couple of reasons:
- The existing `FindReplaceAction` was not serializable
  - The callables used to encapsulate replacement actions could not be stored in a json
  - I created a more specific, but less flexible version (`RegexFindReplace`) that gets converted to the existing `FindReplaceAction` before application.
- A bunch of refactoring was needed to still type hint while preventing circular imports.  

Fun note: using `asyncio.run(config.compare())` in the test suite seemed to sometimes "kill the main thread", and would cause later bluesky plan tests to fail (which also wanted to access the "main thread" for the RunEngine.  This was resolved with `@pytest.mark.asyncio`, but in returning to the issue I wasn't able to reproduce the error

## How Has This Been Tested?
Interactively, primarily.  A small test was added, but more should come.

## Where Has This Been Documented?
This PR.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
