### PR TITLE
ENH/REF: Modify FillTemplatePage to have staging area

### DIFF
--- a/atef/find_replace.py
+++ b/atef/find_replace.py
@@ -386,3 +386,8 @@ class FindReplaceAction:
             return False
 
         return True
+
+    def same_path(self, path: List[Tuple[Any, Any]]) -> bool:
+        """Checks if this FindReplaceAction's path matches ``path``, ignoring objects"""
+        return all([own_step[1] == other_step[1]
+                    for own_step, other_step in zip(self.path, path)])

--- a/atef/ui/fill_template_page.ui
+++ b/atef/ui/fill_template_page.ui
@@ -27,6 +27,19 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="top_open_button">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Select File</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="type_label">
        <property name="text">
         <string>[file type]</string>
@@ -37,8 +50,14 @@
    </item>
    <item>
     <widget class="QSplitter" name="vert_splitter">
+     <property name="midLineWidth">
+      <number>5</number>
+     </property>
      <property name="orientation">
       <enum>Qt::Vertical</enum>
+     </property>
+     <property name="handleWidth">
+      <number>10</number>
      </property>
      <widget class="QSplitter" name="overview_splitter">
       <property name="orientation">
@@ -91,7 +110,7 @@
           </column>
           <column>
            <property name="text">
-            <string>Signals</string>
+            <string>PVs</string>
            </property>
           </column>
          </widget>
@@ -108,7 +127,7 @@
       </property>
       <property name="minimumSize">
        <size>
-        <width>50</width>
+        <width>200</width>
         <height>0</height>
        </size>
       </property>
@@ -162,7 +181,7 @@
       <property name="frameShadow">
        <enum>QFrame::Raised</enum>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
+      <layout class="QHBoxLayout" name="horizontalLayout">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -176,24 +195,54 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QLabel" name="detail_label">
-         <property name="text">
-          <string>Edit Details</string>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <property name="topMargin">
+          <number>0</number>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
+         <item>
+          <widget class="QLabel" name="detail_label">
+           <property name="text">
+            <string>Edit Details</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QListWidget" name="details_list"/>
+         </item>
+        </layout>
        </item>
        <item>
-        <widget class="QListWidget" name="details_list"/>
-       </item>
-       <item>
-        <widget class="QPushButton" name="stage_all_button">
-         <property name="text">
-          <string>Stage All</string>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="leftMargin">
+          <number>0</number>
          </property>
-        </widget>
+         <item>
+          <widget class="QPushButton" name="stage_all_button">
+           <property name="text">
+            <string>Stage All</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMDrawingLine" name="PyDMDrawingLine">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="penWidth" stdset="0">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="rotation" stdset="0">
+            <double>90.000000000000000</double>
+           </property>
+           <property name="arrowStartPoint" stdset="0">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>
@@ -241,6 +290,12 @@
      </property>
      <item>
       <widget class="QPushButton" name="open_button">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
        <property name="text">
         <string>Select File</string>
        </property>
@@ -264,6 +319,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMDrawingLine</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/atef/ui/fill_template_page.ui
+++ b/atef/ui/fill_template_page.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>750</width>
-    <height>481</height>
+    <width>702</width>
+    <height>610</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,153 +40,197 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="childrenCollapsible">
-      <bool>false</bool>
-     </property>
-     <widget class="QFrame" name="device_frame">
-      <layout class="QVBoxLayout" name="verticalLayout_4">
+     <widget class="QSplitter" name="overview_splitter">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <widget class="QTreeView" name="tree_view">
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+      </widget>
+      <widget class="QWidget" name="verticalLayoutWidget">
+       <layout class="QVBoxLayout" name="device_info_layout">
+        <property name="leftMargin">
+         <number>5</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="device_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Devices in template</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QTableWidget" name="device_table">
+          <property name="toolTip">
+           <string>Devices and Signals found in the original checkout</string>
+          </property>
+          <property name="editTriggers">
+           <set>QAbstractItemView::NoEditTriggers</set>
+          </property>
+          <property name="selectionMode">
+           <enum>QAbstractItemView::NoSelection</enum>
+          </property>
+          <property name="columnCount">
+           <number>2</number>
+          </property>
+          <attribute name="verticalHeaderVisible">
+           <bool>false</bool>
+          </attribute>
+          <column>
+           <property name="text">
+            <string>Devices</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Signals</string>
+           </property>
+          </column>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+     <widget class="QFrame" name="edits_frame">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>50</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::StyledPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
-        <widget class="QLabel" name="device_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
+        <widget class="QLabel" name="edits_table_placeholder">
          <property name="text">
-          <string>Devices in template</string>
+          <string>Open a file to get started!</string>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QTableWidget" name="device_table">
-         <property name="toolTip">
-          <string>Devices and Signals found in the original checkout</string>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
          </property>
-         <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::NoSelection</enum>
-         </property>
-         <property name="columnCount">
-          <number>2</number>
-         </property>
-         <attribute name="verticalHeaderVisible">
-          <bool>false</bool>
-         </attribute>
-         <column>
-          <property name="text">
-           <string>Devices</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Signals</string>
-          </property>
-         </column>
         </widget>
        </item>
       </layout>
      </widget>
-     <widget class="QSplitter" name="horiz_splitter">
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+     <widget class="QFrame" name="details_frame">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
       </property>
-      <property name="childrenCollapsible">
-       <bool>false</bool>
+      <property name="minimumSize">
+       <size>
+        <width>50</width>
+        <height>0</height>
+       </size>
       </property>
-      <widget class="QFrame" name="edits_frame">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+      <property name="frameShape">
+       <enum>QFrame::StyledPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="minimumSize">
-        <size>
-         <width>50</width>
-         <height>0</height>
-        </size>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-       <property name="frameShadow">
-        <enum>QFrame::Raised</enum>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QLabel" name="edits_table_placeholder">
-          <property name="text">
-           <string>Open a file to get started!</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QFrame" name="details_frame">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+       <item>
+        <widget class="QLabel" name="detail_label">
+         <property name="text">
+          <string>Edit Details</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QListWidget" name="details_list"/>
+       </item>
+       <item>
+        <widget class="QPushButton" name="stage_all_button">
+         <property name="text">
+          <string>Stage All</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QFrame" name="stage_frame">
+      <property name="frameShape">
+       <enum>QFrame::StyledPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="minimumSize">
-        <size>
-         <width>50</width>
-         <height>0</height>
-        </size>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
+       <property name="rightMargin">
+        <number>1</number>
        </property>
-       <property name="frameShadow">
-        <enum>QFrame::Raised</enum>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QLabel" name="detail_label">
-          <property name="text">
-           <string>Edit Details</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QListWidget" name="details_list"/>
-        </item>
-       </layout>
-      </widget>
+       <item>
+        <widget class="QLabel" name="staged_label">
+         <property name="text">
+          <string>Staged Edits</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QListWidget" name="staged_list"/>
+       </item>
+      </layout>
      </widget>
     </widget>
    </item>
@@ -198,28 +242,21 @@
      <item>
       <widget class="QPushButton" name="open_button">
        <property name="text">
-        <string>Open File</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="apply_all_button">
-       <property name="text">
-        <string>Apply All</string>
+        <string>Select File</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QPushButton" name="verify_button">
        <property name="text">
-        <string>Verify</string>
+        <string>Validate</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QPushButton" name="save_button">
        <property name="text">
-        <string>Save As...</string>
+        <string>Apply Staged, Save As...</string>
        </property>
       </widget>
      </item>

--- a/atef/ui/template_edit_row_widget.ui
+++ b/atef/ui/template_edit_row_widget.ui
@@ -36,7 +36,7 @@
       </size>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Retry</set>
+      <set>QDialogButtonBox::Retry</set>
      </property>
      <property name="centerButtons">
       <bool>true</bool>
@@ -76,7 +76,7 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMDrawingLine" name="arrow" native="true">
+    <widget class="PyDMDrawingLine" name="arrow">
      <property name="minimumSize">
       <size>
        <width>20</width>

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -522,8 +522,6 @@ class PassiveEditWidget(DesignerDisplay, DataWidget):
         model = ConfigTreeModel(data=root_item)
 
         self.tree_view.setModel(model)
-        header = self.tree_view.header()
-        header.setSectionResizeMode(header.ResizeToContents)
         # Hide the irrelevant status column
         self.tree_view.setColumnHidden(1, True)
         self.tree_view.expandAll()

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -39,7 +39,7 @@ from atef.result import Result, incomplete_result
 from atef.widgets.config.data_base import DataWidget, SimpleRowWidget
 from atef.widgets.config.run_base import create_tree_from_file
 from atef.widgets.config.utils import (ConfigTreeModel, MultiInputDialog,
-                                       TableWidgetWithAddRow, TreeItem)
+                                       TableWidgetWithAddRow)
 from atef.widgets.core import DesignerDisplay
 from atef.widgets.happi import HappiDeviceComponentWidget
 from atef.widgets.ophyd import OphydAttributeData
@@ -517,8 +517,7 @@ class PassiveEditWidget(DesignerDisplay, DataWidget):
             Passive checkout configuration file dataclass
         """
         # tree data
-        root_item = TreeItem(data=config_file)
-        create_tree_from_file(data=config_file.root, parent=root_item)
+        root_item = create_tree_from_file(data=config_file)
 
         model = ConfigTreeModel(data=root_item)
 

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -386,6 +386,7 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
 
     stage_all_button: QtWidgets.QPushButton
     open_button: QtWidgets.QPushButton
+    top_open_button: QtWidgets.QPushButton
     save_button: QtWidgets.QPushButton
     verify_button: QtWidgets.QPushButton
 
@@ -408,12 +409,15 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
         self._devices: List[str] = []
         self.busy_thread = None
         self._partial_slots: list[WeakPartialMethodSlot] = []
+        self.file_name_label.hide()
+        self.type_label.hide()
         if filepath:
             self.open_file(filename=filepath)
         self.setup_ui()
 
     def setup_ui(self) -> None:
         self.open_button.clicked.connect(self.open_file)
+        self.top_open_button.clicked.connect(self.open_file)
         self.save_button.clicked.connect(self.save_file)
         self.stage_all_button.clicked.connect(self.stage_all)
         self.verify_button.clicked.connect(self.verify_changes)
@@ -471,6 +475,7 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
             self.setup_tree_view()
             self.setup_devices_list()
             self.update_title()
+            self.vert_splitter.setSizes([200, 200, 200, 200,])
 
         self.busy_thread = BusyCursorThread(
             func=partial(self.load_file, filepath=filename)
@@ -653,7 +658,14 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
         Update the title.  Will be the name and the number of staged edits
         """
         if self.fp is None:
+            self.type_label.hide()
+            self.file_name_label.hide()
+            self.top_open_button.show()
             return
+
+        self.type_label.show()
+        self.file_name_label.show()
+        self.top_open_button.hide()
 
         file_name = os.path.basename(self.fp)
         if len(self.staged_actions) > 0:
@@ -752,7 +764,11 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
         """Move actions from edit details to staged_actions and refresh table"""
         for _ in range(self.details_list.count()):
             l_item = self.details_list.item(0)
-            data = self.details_list.itemWidget(l_item).data
+            widget = self.details_list.itemWidget(l_item)
+            if widget is None:
+                return  # no details loaded, simple help text item
+
+            data = widget.data
             self.stage_item_from_details(data, item=l_item)
 
     def stage_edit(self, edit: FindReplaceAction) -> None:

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -431,7 +431,7 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
     def setup_edits_table(self) -> None:
         # set up add row widget for edits
         self.edits_table = TableWidgetWithAddRow(
-            add_row_text='add edit', title_text='edits',
+            add_row_text='add edit', title_text='Edits',
             row_widget_cls=partial(TemplateEditRowWidget, orig_file=self.orig_file)
         )
         insert_widget(self.edits_table, self.edits_table_placeholder)

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -706,7 +706,6 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
             l_item = self.details_list.item(0)
             data = self.details_list.itemWidget(l_item).data
             self.stage_item_from_details(data, item=l_item)
-            self.details_list.takeItem(0)
 
     def stage_edit(self, edit: FindReplaceAction) -> None:
         """Add ``edit`` to the staging list, do nothing to the GUI"""

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -761,12 +761,6 @@ class TemplateEditRowWidget(DesignerDisplay, QtWidgets.QWidget):
         refresh_button.setToolTip('refresh edit details')
         refresh_button.setIcon(qta.icon('ei.refresh'))
 
-        apply_button = self.button_box.button(QtWidgets.QDialogButtonBox.Apply)
-        apply_button.clicked.connect(self.apply_edits)
-        apply_button.setText('')
-        apply_button.setToolTip('apply all changes')
-        apply_button.setIcon(qta.icon('ei.check'))
-
         # settings menu (regex, case)
         self.setting_widget = QtWidgets.QWidget()
         self.setting_layout = QtWidgets.QHBoxLayout()
@@ -811,30 +805,6 @@ class TemplateEditRowWidget(DesignerDisplay, QtWidgets.QWidget):
 
         match_fn = get_default_match_fn(self._search_regex)
         self._match_fn = match_fn
-
-    def apply_edits(self) -> None:
-        """Apply all the actions corresponding to this edit"""
-        self.refresh_paths()
-        if len(self.actions) <= 0:
-            return
-
-        reply = QtWidgets.QMessageBox.question(
-            self,
-            'Apply remaning edits?',
-            (
-                'Would you like to apply the remaining '
-                f'({len(self.actions)}) edits?'
-            )
-        )
-        if reply == QtWidgets.QMessageBox.Yes:
-            for action in self.actions:
-                success = action.apply()
-                if not success:
-                    logger.warning(f'action failed {action}')
-
-            self.actions.clear()
-
-        self.refresh_paths()
 
     def refresh_paths(self) -> None:
         """

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -20,8 +20,8 @@ import dataclasses
 import logging
 from collections import OrderedDict
 from functools import partial
-from typing import (TYPE_CHECKING, Any, ClassVar, Dict, Generator, List,
-                    Optional, Tuple, Type, Union)
+from typing import (TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple,
+                    Type, Union)
 from weakref import WeakValueDictionary
 
 from pcdsutils.qt.callbacks import WeakPartialMethodSlot
@@ -73,26 +73,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-def walk_tree_items(item: TreeItem) -> Generator[TreeItem, None, None]:
-    """
-    Walk the tree depth first, starting at `item`.
-
-    Parameters
-    ----------
-    item : TreeItem
-        the root node of the tree to walk
-
-    Yields
-    ------
-    Generator[TreeItem, None, None]
-        Yields TreeItem from the the tree.
-    """
-    yield item
-
-    for child_idx in range(item.childCount()):
-        yield from walk_tree_items(item.child(child_idx))
 
 
 def setup_multi_mode_edit_widget(

--- a/atef/widgets/config/run_active.py
+++ b/atef/widgets/config/run_active.py
@@ -17,7 +17,7 @@ from atef.procedure import (PreparedDescriptionStep, PreparedPassiveStep,
                             PreparedSetValueStep, PreparedValueToSignal)
 from atef.widgets.config.data_base import DataWidget
 from atef.widgets.config.run_base import ResultStatus, create_tree_from_file
-from atef.widgets.config.utils import ConfigTreeModel, TreeItem
+from atef.widgets.config.utils import ConfigTreeModel
 from atef.widgets.core import DesignerDisplay
 from atef.widgets.utils import insert_widget
 
@@ -57,11 +57,11 @@ class PassiveRunWidget(DesignerDisplay, DataWidget):
 
     def setup_tree(self):
         """Sets up ConfigTreeModel with the data from the ConfigurationFile"""
-        root_item = TreeItem(
-            data=self.config_file, prepared_data=self.prepared_config
+
+        root_item = create_tree_from_file(
+            data=self.config_file,
+            prepared_file=self.prepared_config
         )
-        create_tree_from_file(data=self.config_file.root, parent=root_item,
-                              prepared_file=self.prepared_config)
 
         model = ConfigTreeModel(data=root_item)
         self.tree_view.setModel(model)

--- a/atef/widgets/config/run_active.py
+++ b/atef/widgets/config/run_active.py
@@ -66,9 +66,6 @@ class PassiveRunWidget(DesignerDisplay, DataWidget):
         model = ConfigTreeModel(data=root_item)
         self.tree_view.setModel(model)
 
-        # Customize the look of the table
-        header = self.tree_view.header()
-        header.setSectionResizeMode(header.ResizeToContents)
         self.tree_view.header().swapSections(0, 1)
         self.tree_view.expandAll()
 

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -430,7 +430,7 @@ class VerifyEntryWidget(DesignerDisplay, QWidget):
 
 def create_tree_from_file(
     data: Union[ConfigurationFile, ProcedureFile],
-    prepared_file: Union[PreparedFile, PreparedProcedureFile]
+    prepared_file: Optional[Union[PreparedFile, PreparedProcedureFile]] = None,
 ) -> TreeItem:
     """
     Create a TreeItem Tree with items linked to original and prepared dataclasses
@@ -463,12 +463,14 @@ def create_tree_from_file(
     else:
         raise TypeError("Data was not a passive or active checkout file")
 
-    def create_tree(data, parent: TreeItem, prepared_data):
+    def create_tree(data, parent: TreeItem, prepared_data=None):
         if not hasattr(data, 'children'):
             return
         for child_data in data.children():
             if prepared_data:
                 prepared_subset = gather_fn(prepared_data, child_data)
+            else:
+                prepared_subset = None
             item = TreeItem(child_data, prepared_data=prepared_subset)
             create_tree(child_data, item, prepared_data)
             parent.addChild(item)

--- a/atef/widgets/config/run_base.py
+++ b/atef/widgets/config/run_base.py
@@ -442,8 +442,9 @@ def create_tree_from_file(
     ----------
     data : Union[ConfigurationFile, ProcedureFile]
         The "original" file (edit-mode, un-prepared)
-    prepared_file : Union[PreparedFile, PreparedProcedureFile]
-        The "prepared" file (run-mode, prepared)
+    prepared_file : Optional[Union[PreparedFile, PreparedProcedureFile]], optional
+        The "prepared" file (run-mode, prepared), by default None.
+        If no prepared file is provided, tree will not include gathered prepared data
 
     Returns
     -------

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -2259,3 +2259,23 @@ def gather_relevant_identifiers(
                     identifiers.append(signal.pvname)
 
     return identifiers
+
+
+def walk_tree_items(item: TreeItem) -> Generator[TreeItem, None, None]:
+    """
+    Walk the tree depth first, starting at `item`.
+
+    Parameters
+    ----------
+    item : TreeItem
+        the root node of the tree to walk
+
+    Yields
+    ------
+    Generator[TreeItem, None, None]
+        Yields TreeItem from the the tree.
+    """
+    yield item
+
+    for child_idx in range(item.childCount()):
+        yield from walk_tree_items(item.child(child_idx))

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -38,10 +38,11 @@ from atef.widgets.utils import reset_cursor, set_wait_cursor
 
 from ..archive_viewer import get_archive_viewer
 from ..core import DesignerDisplay
-from .page import PAGE_MAP, FailPage, PageWidget, RunStepPage, walk_tree_items
+from .page import PAGE_MAP, FailPage, PageWidget, RunStepPage
 from .result_summary import ResultsSummaryWidget
 from .run_base import create_tree_from_file, make_run_page
-from .utils import ConfigTreeModel, MultiInputDialog, Toggle, TreeItem
+from .utils import (ConfigTreeModel, MultiInputDialog, Toggle, TreeItem,
+                    walk_tree_items)
 
 logger = logging.getLogger(__name__)
 

--- a/docs/source/upcoming_release_notes/239-enh_ref_fill_template_page.rst
+++ b/docs/source/upcoming_release_notes/239-enh_ref_fill_template_page.rst
@@ -1,0 +1,22 @@
+239 enh_ref_fill_template_page
+##############################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Refines the flow of FillTemplatePage, adding a clear staging area and tree-view for added clarity
+
+Bugfixes
+--------
+- Unifies usage of ``create_tree_from_file``
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- Adds a staging area to `FillTemplatePage`, to be more clear about which changes are being queued for application
- Refactors various helpers and widgets to support this
- Adds tree-view that highlights closest tree-item when a row detail is examined

## Motivation and Context
In looking into reusing `FillTemplatePage` for templated checkouts, it became clear that the page needed a refactor
- If we were to serialize actions, we would need some way to display those queued actions.
  - Previously, `FillTemplatePage` would maintain an internal "all actions" list and a user could apply them gradually.  This made the current state of the loaded checkout ambiguous (had we applied changes yet?)
- Edit actions (`FindReplaceAction`) saved in a templated checkout would need to be loaded without knowledge of the search query that produced it.
  - Prior to this `FillTemplatePage` would gather all actions in any populated edit when asked to apply all.  The user would either have to know that these were the right actions or click through them all to verify
  - Now the staging area makes clear what will be applied when we save the file, and edits are not applied until the new file is saved

## How Has This Been Tested?
Entirely interactively so far.  But the test suite passes

## Where Has This Been Documented?
This PR.

![image](https://github.com/pcdshub/atef/assets/35379409/084f9258-711b-4bdc-bcdb-cf06d6823b29)

![image](https://github.com/pcdshub/atef/assets/35379409/5a8a9187-fe36-4cfb-bae8-a6689c695aef)


Compare to before:
<details><summary>Details</summary>
<p>

![image](https://github.com/pcdshub/atef/assets/35379409/d7dcceb1-993e-4360-bef9-90442d6cf66d)

</p>
</details> 

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
