### PR TITLE
GUI/ENH: add template steps to passive and active checkout GUI

### DIFF
--- a/atef/config.py
+++ b/atef/config.py
@@ -1352,10 +1352,19 @@ class PreparedTemplateConfiguration(PreparedConfiguration):
         return prepared
 
     async def compare(self) -> Result:
-        """Run the edited checkoutand return the combined result"""
+        """Run the edited checkout and return the combined result"""
         result = await self.file.compare()
         self.combined_result = result
         return result
+
+    @property
+    def result(self) -> Result:
+        """
+        Re-compute combined result and return it.  Override standard since this
+        configuration has no comparisons
+        """
+        self.combined_result = self.file.root.result
+        return self.combined_result
 
 
 @dataclass

--- a/atef/exceptions.py
+++ b/atef/exceptions.py
@@ -61,6 +61,11 @@ class UnpreparedComparisonException(ComparisonException):
     ...
 
 
+class PreparationError(Exception):
+    """Raise this when failing to prepare a configuration or procedure"""
+    ...
+
+
 class PreparedComparisonException(Exception):
     """Exception caught during preparation of comparisons."""
     #: The exception instance itself.

--- a/atef/find_replace.py
+++ b/atef/find_replace.py
@@ -138,6 +138,38 @@ def simplify_path(path: List[Tuple[Any, Any]]) -> List[Tuple[str, Any]]:
     return simplified_path
 
 
+def expand_path(path: List[Tuple[str, Any]], target: Any) -> List[Tuple[Any, Any]]:
+    """
+    Expands ``path`` using ``target`` as the object to traverse.
+    Replaces all string type references with the object in question.
+
+    The inverse of ``simplify_path``
+
+    Parameters
+    ----------
+    path : List[Tuple[str, Any]]
+        the simplified path to expand
+    target : Any
+        the object that ``path`` is referring to
+
+    Returns
+    -------
+    List[Tuple[Any, Any]]
+        the expanded path
+    """
+    new_path = []
+    new_path.append((target, path[0][1]))
+    # Look at all path segments after index 0, replace the next object in line.
+    for idx in range(len(path) - 1):
+        if path[idx+1][0].startswith("__") and path[idx+1][0].endswith("__"):
+            seg_object = path[idx+1][0]
+        else:
+            seg_object = get_item_from_path(path[:idx+1], item=target)
+        new_path.append((seg_object, path[idx + 1][1]))
+
+    return new_path
+
+
 def get_item_from_path(
     path: List[Tuple[Any, Any]],
     item: Optional[Any] = None
@@ -323,15 +355,21 @@ class RegexFindReplace:
 
     def to_action(self, target: Optional[Any] = None) -> FindReplaceAction:
         """Create FindReplaceAction from a SerializableFindReplaceAction"""
+        flags = re.IGNORECASE if not self.case_sensitive else 0
         try:
-            re.compile(self.search_regex)
+            search_regex = re.compile(self.search_regex, flags=flags)
         except re.error:
             raise ValueError(f'regex is not valid: {self.search_regex}, '
                              'could not construct FindReplaceAction')
         replace_fn = get_default_replace_fn(
-            self.replace_text, re.compile(self.search_regex)
+            self.replace_text, re.compile(search_regex)
         )
-        return FindReplaceAction(target=target, path=self.path, replace_fn=replace_fn)
+        if target:
+            path = expand_path(self.path, target=target)
+        else:
+            path = self.path
+
+        return FindReplaceAction(target=target, path=path, replace_fn=replace_fn)
 
 
 @dataclass
@@ -340,6 +378,8 @@ class FindReplaceAction:
     replace_fn: ReplaceFunction
     # Union[ConfigurationFile, ProcedureFile], but circular imports
     target: Optional[Any] = None
+
+    origin: Optional[RegexFindReplace] = None
 
     def apply(
         self,

--- a/atef/find_replace.py
+++ b/atef/find_replace.py
@@ -369,7 +369,12 @@ class RegexFindReplace:
         else:
             path = self.path
 
-        return FindReplaceAction(target=target, path=path, replace_fn=replace_fn)
+        return FindReplaceAction(
+            path=path,
+            replace_fn=replace_fn,
+            target=target,
+            origin=self,
+        )
 
 
 @dataclass

--- a/atef/find_replace.py
+++ b/atef/find_replace.py
@@ -362,7 +362,7 @@ class RegexFindReplace:
             raise ValueError(f'regex is not valid: {self.search_regex}, '
                              'could not construct FindReplaceAction')
         replace_fn = get_default_replace_fn(
-            self.replace_text, re.compile(search_regex)
+            self.replace_text, search_regex
         )
         if target:
             path = expand_path(self.path, target=target)

--- a/atef/find_replace.py
+++ b/atef/find_replace.py
@@ -31,11 +31,11 @@ def patch_client_cache():
     try:
         happi.loader.cache = {}
         dcache = DataCache()
+        # Clear the global signal cache to prevent previous signals from leaking
         dcache.signals.clear()
         yield
     finally:
         happi.loader.cache = old_happi_cache
-        dcache.signals.clear()
 
 
 def walk_find_match(

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -616,6 +616,10 @@ class PreparedProcedureStep:
                 return PreparedPlanStep.from_origin(
                     origin=step, parent=parent
                 )
+            if isinstance(step, TemplateStep):
+                return PreparedTemplateStep.from_origin(
+                    step=step, parent=parent,
+                )
 
             raise NotImplementedError(f"Step type unsupported: {type(step)}")
         except Exception as ex:

--- a/atef/procedure.py
+++ b/atef/procedure.py
@@ -37,7 +37,7 @@ from atef.check import Comparison
 from atef.config import (ConfigurationFile, PreparedComparison, PreparedFile,
                          PreparedSignalComparison, run_passive_step)
 from atef.enums import GroupResultMode, PlanDestination, Severity
-from atef.exceptions import PreparedComparisonException
+from atef.exceptions import PreparationError, PreparedComparisonException
 from atef.find_replace import RegexFindReplace
 from atef.plan_utils import (BlueskyState, GlobalRunEngine,
                              get_default_namespace, register_run_identifier,
@@ -944,8 +944,21 @@ class PreparedTemplateStep(PreparedProcedureStep):
 
         # convert and apply edits
         edits = [e.to_action() for e in step.edits]
-        for edit in edits:
-            edit.apply(target=orig_file)
+        edit_results = [edit.apply(target=orig_file) for edit in edits]
+
+        if not all(edit_results):
+            return FailedStep(
+                origin=step,
+                parent=parent,
+                exception=PreparationError,
+                result=Result(
+                    severity=Severity.internal_error,
+                    reason=(
+                        f'Failed to prepare templated config: ({step.name}) '
+                        f'Could not apply all edits.'
+                    )
+                )
+            )
 
         # verify edited file
         success, msg = orig_file.validate()
@@ -953,7 +966,7 @@ class PreparedTemplateStep(PreparedProcedureStep):
             return FailedStep(
                 origin=step,
                 parent=parent,
-                exception=ValueError,  # TODO: get a better exception
+                exception=PreparationError,
                 combined_result=Result(
                     severity=Severity.internal_error,
                     reason=(

--- a/atef/tests/test_page.py
+++ b/atef/tests/test_page.py
@@ -4,6 +4,7 @@ import pytest
 from pytestqt.qtbot import QtBot
 from qtpy import QtCore, QtWidgets
 
+from atef.config import TemplateConfiguration
 from atef.type_hints import AnyDataclass
 from atef.widgets.config.page import ComparisonPage, ConfigurationGroupPage
 
@@ -178,3 +179,26 @@ def test_change_comparison(
         full_tree.select_by_data(group_data)
         full_tree.select_by_data(new_data)
         comp_page = full_tree.current_widget
+
+
+def test_template_page(
+    qtbot: QtBot,
+    template_configuration: TemplateConfiguration,
+    make_page: Callable,
+):
+    group_page = make_page(template_configuration)
+
+    # Does the configuration initialize properly?
+    qtbot.wait_until(
+        lambda: group_page.template_page_widget.staged_list.count() == 1
+    )
+
+    # test preparation
+    group_page.full_tree.mode = 'run'
+    group_page.full_tree.switch_mode('run')
+
+    qtbot.wait_signal(group_page.full_tree.mode_switch_finished)
+    qtbot.wait_until(
+        lambda: group_page.template_page_widget.staged_list.count() == 1
+    )
+    qtbot.addWidget(group_page)

--- a/atef/ui/template_group_page.ui
+++ b/atef/ui/template_group_page.ui
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>380</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QWidget" name="name_desc_tags_placeholder" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="template_page_placeholder" native="true"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/ui/template_run_widget.ui
+++ b/atef/ui/template_run_widget.ui
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>342</width>
+    <height>297</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTreeView" name="tree_view"/>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="edits_list"/>
+   </item>
+   <item>
+    <widget class="QPushButton" name="refresh_button">
+     <property name="text">
+      <string>Refresh Status Icons</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -477,6 +477,13 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
             return
 
         def finish_setup():
+            if self.fp is None:
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    'Template Checkout type error',
+                    'Loaded checkout is NOT one of the allowed types: '
+                    f'{[t.__name__ for t in self.allowed_types]}'
+                )
             self.details_list.clear()
             self.staged_list.clear()
             self.staged_actions.clear()
@@ -507,11 +514,6 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
         if self.allowed_types and not isinstance(data, self.allowed_types):
             logger.error("loaded checkout is of a disallowed type: "
                          f"({type(data)})")
-            QtWidgets.QMessageBox.warning(
-                self,
-                'Template Checkout type error',
-                f'Loaded checkout is one of the allowed types: {self.allowed_types}'
-            )
             self.fp = None
             self.orig_file = None
             return

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -748,6 +748,7 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
         self.staged_actions.remove(data)
         self.staged_list.takeItem(self.staged_list.row(item))
         self.update_title()
+        self.data_updated.emit()
 
     def stage_item_from_details(
         self,

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -577,12 +577,21 @@ class FillTemplatePage(DesignerDisplay, QtWidgets.QWidget):
 
     def verify_changes(self) -> None:
         """Apply staged changes and validate copy of file"""
-        if self.orig_file is not None:
-            temp_file = copy.deepcopy(self.orig_file)
-            for action in self.staged_actions:
-                action.apply(target=temp_file)
+        if self.orig_file is None:
+            return
+        temp_file = copy.deepcopy(self.orig_file)
 
-            verify_file_and_notify(temp_file, self)
+        edit_results = [e.apply(target=temp_file) for e in self.staged_actions]
+        if not all(edit_results):
+            fail_idx = [i for i, result in enumerate(edit_results) if not result]
+            QtWidgets.QMessageBox.warning(
+                self,
+                'Verification FAIL',
+                f'Some staged edits at {fail_idx} could not be applied:'
+            )
+            return
+
+        verify_file_and_notify(temp_file, self)
 
     def save_file(self) -> None:
         if self.orig_file is None:

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -1416,6 +1416,7 @@ class TemplateConfigurationPage(DesignerDisplay, PageWidget):
         super().__init__(data=data, **kwargs)
         self.setup_name_desc_tags_init()
         self.setup_template_widget_init()
+        self.post_tree_setup()
 
     def setup_template_widget_init(self) -> None:
         self.template_page_widget = FillTemplatePage()
@@ -1456,7 +1457,6 @@ class TemplateConfigurationPage(DesignerDisplay, PageWidget):
             edits.append(row_data.origin)
 
         self.data.edits = edits
-        print(f'update_data: {self.data.filename}, {len(self.data.edits)}')
 
     def post_tree_setup(self) -> None:
         super().post_tree_setup()

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -1417,7 +1417,7 @@ class TemplateConfigurationPage(DesignerDisplay, PageWidget):
 
     data: Union[TemplateConfiguration, TemplateStep]
     ALLOWED_TYPE_MAP: ClassVar[Dict[Any, Tuple[Any]]] = {
-        TemplateConfiguration: (ConfigurationFile),
+        TemplateConfiguration: (ConfigurationFile,),
         TemplateStep: (ConfigurationFile, ProcedureFile)
     }
 

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -33,7 +33,7 @@ from qtpy.QtWidgets import (QComboBox, QFrame, QLabel, QMessageBox,
 from atef.check import (ALL_COMPARISONS, AnyComparison, AnyValue, Comparison,
                         Equals, Greater, GreaterOrEqual, Less, LessOrEqual,
                         NotEquals, Range, ValueSet)
-from atef.config import (Configuration, ConfigurationGroup,
+from atef.config import (Configuration, ConfigurationFile, ConfigurationGroup,
                          DeviceConfiguration, PreparedConfiguration,
                          PreparedGroup, PreparedTemplateConfiguration,
                          PVConfiguration, TemplateConfiguration,
@@ -41,8 +41,9 @@ from atef.config import (Configuration, ConfigurationGroup,
 from atef.procedure import (ComparisonToTarget, DescriptionStep, PassiveStep,
                             PreparedDescriptionStep, PreparedPassiveStep,
                             PreparedProcedureStep, PreparedSetValueStep,
-                            PreparedTemplateStep, ProcedureGroup,
-                            ProcedureStep, SetValueStep, TemplateStep)
+                            PreparedTemplateStep, ProcedureFile,
+                            ProcedureGroup, ProcedureStep, SetValueStep,
+                            TemplateStep)
 from atef.tools import Ping, PingResult, Tool, ToolResult
 from atef.type_hints import AnyDataclass
 from atef.widgets.config.data_active import (CheckRowWidget,
@@ -1414,16 +1415,22 @@ class TemplateConfigurationPage(DesignerDisplay, PageWidget):
     template_page_widget: FillTemplatePage
     template_page_placeholder: QWidget
 
-    data: TemplateConfiguration
+    data: Union[TemplateConfiguration, TemplateStep]
+    ALLOWED_TYPE_MAP: ClassVar[Dict[Any, Tuple[Any]]] = {
+        TemplateConfiguration: (ConfigurationFile),
+        TemplateStep: (ConfigurationFile, ProcedureFile)
+    }
 
-    def __init__(self, data: TemplateConfiguration, **kwargs):
+    def __init__(self, data: Union[TemplateConfiguration, TemplateStep], **kwargs):
         super().__init__(data=data, **kwargs)
         self.setup_name_desc_tags_init()
         self.setup_template_widget_init()
         self.post_tree_setup()
 
     def setup_template_widget_init(self) -> None:
-        self.template_page_widget = FillTemplatePage()
+        self.template_page_widget = FillTemplatePage(
+            allowed_types=self.ALLOWED_TYPE_MAP[type(self.data)]
+        )
 
         def finish_widget_setup(*args, **kwargs):
             # only run this once, when we're loading an existing template checkout

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -1416,7 +1416,7 @@ class TemplateConfigurationPage(DesignerDisplay, PageWidget):
     template_page_placeholder: QWidget
 
     data: Union[TemplateConfiguration, TemplateStep]
-    ALLOWED_TYPE_MAP: ClassVar[Dict[Any, Tuple[Any]]] = {
+    ALLOWED_TYPE_MAP: ClassVar[Dict[Any, Tuple[Any, ...]]] = {
         TemplateConfiguration: (ConfigurationFile,),
         TemplateStep: (ConfigurationFile, ProcedureFile)
     }

--- a/atef/widgets/config/page.py
+++ b/atef/widgets/config/page.py
@@ -1669,6 +1669,45 @@ class ProcedureGroupPage(DesignerDisplay, PageWidget):
         )
         self.procedure_table.setCellWidget(found_row, 0, step_row)
 
+    def delete_table_row(
+        self,
+        *args,
+        table: QTableWidget,
+        item: TreeItem,
+        row: DataWidget,
+        **kwargs
+    ) -> None:
+        # Use old QTableWidget handling
+        # Confirmation dialog
+        reply = QMessageBox.question(
+            self,
+            'Confirm deletion',
+            (
+                'Are you sure you want to delete the '
+                f'{item.data(2)} named "{item.data(0)}"? '
+                'Note that this will delete any child nodes in the tree.'
+            ),
+        )
+        if reply != QMessageBox.Yes:
+            return
+        # Get the identity of the data
+        data = row.bridge.data
+        # Remove item from the tree
+        with self.full_tree.modifies_tree():
+            try:
+                self.tree_item.removeChild(item)
+            except ValueError:
+                pass
+
+        # Remove row from the table
+        for row_index in range(table.rowCount()):
+            widget = table.cellWidget(row_index, 0)
+            if widget is row:
+                table.removeRow(row_index)
+                break
+        # Remove configuration from the data structure
+        self.remove_table_data(data)
+
 
 class StepPage(DesignerDisplay, PageWidget):
     """

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -26,9 +26,10 @@ from qtpy.QtWidgets import (QAction, QFileDialog, QMainWindow, QMessageBox,
                             QTabWidget, QWidget)
 
 from atef.cache import DataCache
-from atef.config import ConfigurationFile, PreparedFile
+from atef.config import ConfigurationFile, PreparedFile, TemplateConfiguration
 from atef.procedure import (DescriptionStep, PassiveStep,
-                            PreparedProcedureFile, ProcedureFile, SetValueStep)
+                            PreparedProcedureFile, ProcedureFile, SetValueStep,
+                            TemplateStep)
 from atef.report import ActiveAtefReport, PassiveAtefReport
 from atef.type_hints import AnyDataclass
 from atef.walk import get_prepared_step, get_relevant_configs_comps
@@ -38,7 +39,7 @@ from atef.widgets.utils import reset_cursor, set_wait_cursor
 
 from ..archive_viewer import get_archive_viewer
 from ..core import DesignerDisplay
-from .page import PAGE_MAP, FailPage, PageWidget, RunStepPage
+from .page import PAGE_MAP, FailPage, PageWidget, RunConfigPage, RunStepPage
 from .result_summary import ResultsSummaryWidget
 from .run_base import create_tree_from_file, make_run_page
 from .utils import (ConfigTreeModel, MultiInputDialog, Toggle, TreeItem,
@@ -457,9 +458,11 @@ class LandingPage(DesignerDisplay, QWidget):
 
 
 EDIT_TO_RUN_PAGE: Dict[type, PageWidget] = {
+    TemplateConfiguration: RunConfigPage,
     DescriptionStep: RunStepPage,
     PassiveStep: RunStepPage,
     SetValueStep: RunStepPage,
+    TemplateStep: RunStepPage,
 }
 
 

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -27,6 +27,7 @@ from qtpy.QtWidgets import (QAction, QFileDialog, QMainWindow, QMessageBox,
 
 from atef.cache import DataCache
 from atef.config import ConfigurationFile, PreparedFile, TemplateConfiguration
+from atef.exceptions import PreparationError
 from atef.procedure import (DescriptionStep, PassiveStep,
                             PreparedProcedureFile, ProcedureFile, SetValueStep,
                             TemplateStep)
@@ -797,9 +798,12 @@ class DualTree(DesignerDisplay, QWidget):
         update_run = False
         if self.mode == 'run':
             # store a copy of the edit tree to detect diffs
-            current_edit_config = deepcopy(
-                serialize(type(self.orig_file), self.orig_file)
-            )
+            try:
+                ser = serialize(type(self.orig_file), self.orig_file)
+            except Exception:
+                logger.debug(f'Unable to serialize file as defined: {self.orig_file}')
+                raise PreparationError('Unable to serialize file with current settings')
+            current_edit_config = deepcopy(ser)
 
             if self.prepared_file is None:
                 update_run = True

--- a/docs/source/upcoming_release_notes/241-enh_template_gui.rst
+++ b/docs/source/upcoming_release_notes/241-enh_template_gui.rst
@@ -1,0 +1,22 @@
+241 enh_template_gui
+####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds atef config GUI pages for passive and active templated checkouts, refactoring some pieces of atef.find_replace as necessary
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- Adds `TemplateConfigurationPage` and `TemplateRunWidget` for editing and running Template-steps in the atef config gui.
  - Plugs `TemplateStep`/`TemplateConfiguration` into the various "maps" we have littered around the repo.
- Plugs a few holes from previous PRs.  (There should be no more holes, since this should be the last Template step PR)

## Motivation and Context
In a bit of laziness / DRY, I've used the same pages for both the active and passive checkout cases.  

There's a bit of finicky business when it comes to preparing checkouts with template-steps.  As is, the step/config fails to prepare if the file is invalid.  This will cause the entire page to fail.  In my initial formulation this was the proper thing to do, but I'm starting to think it's not transparent enough about its failure mode.

## How Has This Been Tested?
Interactively, primarily.  I'll be seeing if I can't blow up the test suite by trying to build one of these widgets in CI.

## Where Has This Been Documented?
This PR

![image](https://github.com/pcdshub/atef/assets/35379409/f1fb1755-92da-469e-ac03-28f0e1fd4309)

![image](https://github.com/pcdshub/atef/assets/35379409/0e9d1623-e3e9-4026-a5b2-94386476db58)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
