### PR TITLE
ENH: add support for template steps/configs in reports

### DIFF
--- a/docs/source/upcoming_release_notes/246-enh_template_report.rst
+++ b/docs/source/upcoming_release_notes/246-enh_template_report.rst
@@ -1,0 +1,22 @@
+246 enh_template_report
+#######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds report support for template steps
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Pins numpy>2.0 to avoid issues with upstream incompatibilities
+
+Contributors
+------------
+- tangkong

--- a/docs/source/upcoming_release_notes/246-enh_template_report.rst
+++ b/docs/source/upcoming_release_notes/246-enh_template_report.rst
@@ -15,7 +15,7 @@ Bugfixes
 
 Maintenance
 -----------
-- Pins numpy>2.0 to avoid issues with upstream incompatibilities
+- Pins numpy<2.0 to avoid issues with upstream incompatibilities
 
 Contributors
 ------------


### PR DESCRIPTION
## Description
Adds report output for template steps/reports

More refining to do, but the start is here

## Motivation and Context
Reports are basically the reason atef exists.

We probably want some better reprs for the `RegexFindReplace` classes.

## How Has This Been Tested?
interactively

## Where Has This Been Documented?
This PR

![image](https://github.com/pcdshub/atef/assets/35379409/5581fc8a-27b1-4c73-944e-df35fe3b567f)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
