### PR TITLE
ENH: add report output option to atef check cli

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
   - databroker <2.0.0a0
   - happi
   - ipython
-  - numpy
+  - numpy <2.0.0
   - ophyd
   - pcdsutils >=0.14.1
   - pydm

--- a/docs/source/upcoming_release_notes/248-enh_cli_report.rst
+++ b/docs/source/upcoming_release_notes/248-enh_cli_report.rst
@@ -1,0 +1,22 @@
+248 enh_cli_report
+##################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds report output option to `atef check` cli tool
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ bluesky-widgets
 databroker<2.0.0a0
 happi
 ipython
-numpy
+# numpy >2 incompatible with xraylib and others
+numpy<2.0.0
 ophyd
 pcdsutils>=0.14.1
 pydm


### PR DESCRIPTION
## Description
Adds the option to save a report after running a passive checkout from the CLI

## Motivation and Context
I promised this in a meeting earlier today and it didn't exist

## How Has This Been Tested?
Interactively: `atef check checkout.json -r report.pdf`

## Where Has This Been Documented?
This PR, and in some docstrings

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
