### PR TITLE
BLD: specify bluesky-base in conda recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   - python >=3.7
   - apischema
   - archapp >=1.1.0
-  - bluesky
+  - bluesky-base
   - bluesky-queueserver >=0.0.19
   - bluesky-widgets
   # databroker >2 incompatible with pydantic v2

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -21,6 +21,7 @@ Maintenance
 -----------
 - Pins numpy<2.0 to avoid issues with upstream incompatibilities
 - Refactors find-replace logic and dataclasses into a separate module from the widgets that display them
+- Specify bluesky-base in conde dependnecies to avoid matplotlib
 
 Contributors
 ------------


### PR DESCRIPTION
## Description
Specify bluesky-base in conda-recipe

## Motivation and Context
Fix broken conda builds, where bluesky --> matplotlib --> qt6-main

## How Has This Been Tested?
Surely the CI passes 

## Where Has This Been Documented?
this PR

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
