### PR TITLE
BLD: pin matplotlib<=3.9.0, avoid qt6 deps

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
   - databroker <2.0.0a0
   - happi
   - ipython
+  # matplotlib 3.9.1 pulls pyside6, which is too much qt6 for us
   - matplotlib <=3.9.0
   - numpy <2.0.0
   - ophyd

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
   - databroker <2.0.0a0
   - happi
   - ipython
+  - matplotlib <=3.9.0
   - numpy <2.0.0
   - ophyd
   - pcdsutils >=0.14.1

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -21,7 +21,7 @@ Maintenance
 -----------
 - Pins numpy<2.0 to avoid issues with upstream incompatibilities
 - Refactors find-replace logic and dataclasses into a separate module from the widgets that display them
-- Specify bluesky-base in conde dependnecies to avoid matplotlib
+- Specify bluesky-base and pin matplotlib in conda dependnecies to avoid unintended qt6 dependencies
 
 Contributors
 ------------

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -21,7 +21,7 @@ Maintenance
 -----------
 - Pins numpy<2.0 to avoid issues with upstream incompatibilities
 - Refactors find-replace logic and dataclasses into a separate module from the widgets that display them
-- Specify bluesky-base and pin matplotlib in conda dependnecies to avoid unintended qt6 dependencies
+- Specify bluesky-base and pin matplotlib in conda dependencies to avoid unintended qt6 dependencies
 
 Contributors
 ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ bluesky-widgets
 databroker<2.0.0a0
 happi
 ipython
+# matplotlib 3.9.1 pulls pyside6, which is too much qt6 for us
+matplotlib<=3.9.0
 # numpy >2 incompatible with xraylib and others
 numpy<2.0.0
 ophyd


### PR DESCRIPTION
## Description
see title

## Motivation and Context
I stg if I have to pin another thing

## How Has This Been Tested?
CI please bless me 🙏 

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
