### PR TITLE
BUG: store _setpoint_pv in Target where possible

### DIFF
--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -874,7 +874,7 @@ class TargetEntryWidget(DesignerDisplay, QtWidgets.QWidget):
         dot_attr = attr.attr
         _attr = '_' + dot_attr.replace('.', '_')
         dev_name = full_name[:-len(_attr)]
-        write_pv = getattr(attr.signal, 'setpoint_pvname', attr.pvname)
+        write_pv = attr.setpoint_pvname or attr.pvname
 
         return Target(device=dev_name, attr=dot_attr, pv=write_pv)
 

--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -874,8 +874,9 @@ class TargetEntryWidget(DesignerDisplay, QtWidgets.QWidget):
         dot_attr = attr.attr
         _attr = '_' + dot_attr.replace('.', '_')
         dev_name = full_name[:-len(_attr)]
+        write_pv = getattr(attr.signal, 'setpoint_pvname', attr.pvname)
 
-        return Target(device=dev_name, attr=dot_attr, pv=attr.pvname)
+        return Target(device=dev_name, attr=dot_attr, pv=write_pv)
 
 
 class ActionRowWidget(TargetRowWidget):

--- a/atef/widgets/ophyd.py
+++ b/atef/widgets/ophyd.py
@@ -68,10 +68,11 @@ class OphydAttributeData:
     attr: str
     description: Dict[str, Any]
     docstring: Optional[str]
-    pvname: str
+    pvname: str  # the readback, if setpoint_pvname is provided.
+    setpoint_pvname: Optional[str]
     read_only: bool
-    readback: Any
-    setpoint: Any
+    readback: Any  # readback value
+    setpoint: Any  # setpoint value
     units: Optional[str]
     signal: ophyd.Signal
 
@@ -88,6 +89,7 @@ class OphydAttributeData:
             description={},
             docstring=cpt.doc,
             pvname=getattr(inst, "pvname", "(Python)"),
+            setpoint_pvname=getattr(inst, "setpoint_pvname", None),
             read_only=read_only,
             readback=None,
             setpoint=None,
@@ -506,7 +508,7 @@ class PolledDeviceModel(QtCore.QAbstractTableModel):
             if column == DeviceColumn.read_pvname:
                 return info.pvname
             if column == DeviceColumn.set_pvname:
-                return getattr(info.signal, 'setpoint_pvname', 'None')
+                return info.setpoint_pvname
             return ""
 
         if role == Qt.ToolTipRole:

--- a/docs/source/upcoming_release_notes/254-bug_action_writepv.rst
+++ b/docs/source/upcoming_release_notes/254-bug_action_writepv.rst
@@ -1,0 +1,22 @@
+254 bug_action_writepv
+######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Store the setpoint pv when creating a Target when possible, instead of storing pvname, which could be the readback pv.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
when selecting a ophyd device/signal, the original behavior would store both the PV name and device-attribute pair.  If the device signal has a separate write pv, we weren't saving that properly

Adjust this to save the `_setpoint_pv` if available, then the `pvname` after.  (ophyd signals have no write_pv attribute explicitly 🤷 )

## Motivation and Context
A bug Christian found while using atef and templates

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
This PR 

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
