### PR TITLE
MNT: increase timeout limits (limits on all form spinboxes), prevent aggressive navigation

### DIFF
--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -597,6 +597,7 @@ class SetValueEditWidget(DesignerDisplay, DataWidget):
             self.checks_table.add_row(data=check)
 
         self.checks_table.cellClicked.connect(self.update_all_desc)
+        self.checks_table.table_updated.connect(self.nav_to_self)
 
         # checkboxes
         self.bridge.halt_on_fail.changed_value.connect(
@@ -651,6 +652,14 @@ class SetValueEditWidget(DesignerDisplay, DataWidget):
         for ind in range(self.checks_table.rowCount()):
             row_widget: CheckRowWidget = self.checks_table.cellWidget(ind, 0)
             row_widget.update_summary()
+
+    def nav_to_self(self):
+        # A bit of a hack to prevent navigating to details prematurely
+        # normally an isinstance check would be good, but circular imports
+        try:
+            self.parent().parent().full_tree.select_by_data(self.data)
+        except AttributeError:
+            return
 
 
 class TargetRowWidget(DesignerDisplay, SimpleRowWidget):

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -971,6 +971,7 @@ class MultiInputDialog(QtWidgets.QDialog):
         elif isinstance(value, int):
             int_edit = QtWidgets.QSpinBox()
             int_edit.setMinimum(-1)
+            int_edit.setMaximum(2147483648)
             int_edit.setSpecialValueText('None')
             int_edit.setToolTip('Input -1 to set value to None')
             int_edit.setValue(value)
@@ -978,6 +979,7 @@ class MultiInputDialog(QtWidgets.QDialog):
         elif isinstance(value, float):
             float_edit = QtWidgets.QDoubleSpinBox()
             float_edit.setMinimum(-1)
+            float_edit.setMaximum(2147483648)
             float_edit.setSpecialValueText('None')
             float_edit.setToolTip('Input -1 to set value to None')
             float_edit.setValue(value)

--- a/docs/source/upcoming_release_notes/259-mnt_timeout_nav.rst
+++ b/docs/source/upcoming_release_notes/259-mnt_timeout_nav.rst
@@ -1,0 +1,23 @@
+259 mnt_timeout_nav
+###################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- increase the limit on spinboxes generated from MultiInputFormDialog, in response to a request that set-value-step timeouts not be limited to 99
+- navigate BACK to the parent page when creating a new check in SetValueStep, preventing extra navigation clicks
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- increase the limit on spinboxes generated from MultiInputFormDialog, in response to a request that set-value-step timeouts not be limited to 99s (we have very slow motors)
- navigate BACK to the parent page when creating a new check in SetValueStep
  - This negates the default behavior of StepPage, which selects new items when they are created. 
  - Because SetValueStep initialized a row/new item without setting a PV, this resulted in extraneous navigation back to the parent page to set the PV, then back to the details to set the comparison information
  - Hacky but I'm too lazy to figure out a better way

## Motivation and Context
Bug reports from @c-tsoi 

## How Has This Been Tested?
Interactively.  Test suite still passes

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
