### PR TITLE
MNT: fix broken cli subcommand smoke tests

### DIFF
--- a/atef/tests/test_commandline.py
+++ b/atef/tests/test_commandline.py
@@ -13,7 +13,8 @@ from .test_comparison_device import at2l0, mock_signal_cache  # noqa: F401
 
 def test_help_main(monkeypatch):
     monkeypatch.setattr(sys, 'argv', ["atef", '--help'])
-    atef_main.main()
+    with pytest.raises(SystemExit):
+        atef_main.main()
 
 
 @pytest.mark.parametrize('subcommand', list(atef_main.COMMANDS))

--- a/atef/tests/test_commandline.py
+++ b/atef/tests/test_commandline.py
@@ -12,13 +12,13 @@ from .test_comparison_device import at2l0, mock_signal_cache  # noqa: F401
 
 
 def test_help_main(monkeypatch):
-    monkeypatch.setattr(sys, 'argv', ['--help'])
+    monkeypatch.setattr(sys, 'argv', ["atef", '--help'])
     atef_main.main()
 
 
 @pytest.mark.parametrize('subcommand', list(atef_main.COMMANDS))
 def test_help_module(monkeypatch, subcommand):
-    monkeypatch.setattr(sys, 'argv', [subcommand, '--help'])
+    monkeypatch.setattr(sys, 'argv', ["atef", subcommand, '--help'])
     with pytest.raises(SystemExit):
         atef_main.main()
 

--- a/docs/source/upcoming_release_notes/261-mnt_cli_sub.rst
+++ b/docs/source/upcoming_release_notes/261-mnt_cli_sub.rst
@@ -1,0 +1,22 @@
+261 mnt_cli_subcmd
+##################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Fixes broken tests so they properly exercise the appropriate cli subcommands
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Fixes broken (though passing) smoke tests for the atef cli subcommands

## Motivation and Context
I was copying the pattern to a different repo and found it didn't work. 

Previously we were patching `sys.argv` to hold the arguments we wanted to invoke the cli with, but these did nothing if the actual command "atef" wasn't included.  Without "atef" in the argv list, we would just see what happens if we invoke "atef" with no arguments.  

## How Has This Been Tested?
By un-suppressing the output in pytest and making sure each sub-command's help message got printed properly

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
