### PR TITLE
BLD: unpin numpy, xraylib now compatible

### DIFF
--- a/atef/widgets/config/data_active.py
+++ b/atef/widgets/config/data_active.py
@@ -477,7 +477,7 @@ class PassiveEditWidget(DesignerDisplay, DataWidget):
         super().__init__(data=data, **kwargs)
         self.select_file(filepath=self.bridge.filepath.get())
 
-        self.select_button.setIcon(qtawesome.icon('fa.folder-open-o'))
+        self.select_button.setIcon(qtawesome.icon('fa5.folder-open'))
         self.open_button.setIcon(qtawesome.icon('mdi.open-in-new'))
         # set up buttons, connect to tree-opening method
         self.select_button.clicked.connect(self.select_file)

--- a/atef/widgets/config/find_replace.py
+++ b/atef/widgets/config/find_replace.py
@@ -908,7 +908,7 @@ class TemplateEditRowWidget(DesignerDisplay, QtWidgets.QWidget):
         widget_menu = QtWidgets.QMenu(self.setting_button)
         widget_menu.addAction(widget_action)
         self.setting_button.setMenu(widget_menu)
-        self.setting_button.setIcon(qta.icon('fa.gear'))
+        self.setting_button.setIcon(qta.icon('ph.gear-fill'))
 
     def update_replace_fn(self, *args, **kwargs) -> None:
         """Update the standard replace function for this edit"""

--- a/atef/widgets/config/run_active.py
+++ b/atef/widgets/config/run_active.py
@@ -59,7 +59,7 @@ class PassiveRunWidget(DesignerDisplay, DataWidget):
 
         self.setup_tree()
 
-        self.refresh_button.setIcon(qtawesome.icon('fa.refresh'))
+        self.refresh_button.setIcon(qtawesome.icon('ei.refresh'))
         self.refresh_button.clicked.connect(self.run_config)
 
     def setup_tree(self):
@@ -227,7 +227,7 @@ class TemplateRunWidget(DesignerDisplay, DataWidget):
         self.setup_tree()
         self.setup_edits_list()
 
-        self.refresh_button.setIcon(qtawesome.icon('fa.refresh'))
+        self.refresh_button.setIcon(qtawesome.icon('ei.refresh'))
         self.refresh_button.clicked.connect(self.run_config)
 
     def setup_tree(self):

--- a/atef/widgets/config/window.py
+++ b/atef/widgets/config/window.py
@@ -445,10 +445,10 @@ class LandingPage(DesignerDisplay, QWidget):
 
     def setup_ui(self):
         # icons for buttons
-        self.open_button.setIcon(qtawesome.icon('fa.folder-open-o'))
-        self.exit_button.setIcon(qtawesome.icon('fa.close'))
-        self.new_passive_button.setIcon(qtawesome.icon('fa.file-text-o'))
-        self.new_active_button.setIcon(qtawesome.icon('fa.file-code-o'))
+        self.open_button.setIcon(qtawesome.icon('fa5.folder-open'))
+        self.exit_button.setIcon(qtawesome.icon('mdi.close-thick'))
+        self.new_passive_button.setIcon(qtawesome.icon('mdi.file-document-outline'))
+        self.new_active_button.setIcon(qtawesome.icon('fa5.file-code'))
         # links for buttons... maybe
         self.docs_button.clicked.connect(
             lambda: webbrowser.open('https://confluence.slac.stanford.edu/display/PCDS/atef')

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
   - ipython
   # matplotlib 3.9.1 pulls pyside6, which is too much qt6 for us
   - matplotlib <=3.9.0
-  - numpy <2.0.0
+  - numpy
   - ophyd
   - pcdsutils >=0.14.1
   - pydm

--- a/docs/source/upcoming_release_notes/262-bld_unpin_numpy.rst
+++ b/docs/source/upcoming_release_notes/262-bld_unpin_numpy.rst
@@ -1,0 +1,23 @@
+262 bld_unpin_numpy
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Unpins numpy, now that upstream packages are compatible
+- Adjusts fonts to not rely on FontAwesome4 ("fa." prefix), which was deprecated in recent QtAwesome releases
+
+Contributors
+------------
+- tangkong

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ happi
 ipython
 # matplotlib 3.9.1 pulls pyside6, which is too much qt6 for us
 matplotlib<=3.9.0
-# numpy >2 incompatible with xraylib and others
-numpy<2.0.0
+numpy
 ophyd
 pcdsutils>=0.14.1
 pydm


### PR DESCRIPTION
## Description
Try unpinning numpy, now that more upstream packages are compatible

## Motivation and Context
new environment time?

## How Has This Been Tested?
CI

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
