### PR TITLE
BUG: fix spinbox maximum setting

### DIFF
--- a/atef/tests/test_widgets.py
+++ b/atef/tests/test_widgets.py
@@ -9,6 +9,7 @@ import yaml
 from pytestqt.qtbot import QtBot
 from qtpy import QtCore, QtWidgets
 
+from atef.widgets.config.utils import MultiInputDialog
 from atef.widgets.happi import HappiDeviceComponentWidget
 from atef.widgets.ophyd import OphydDeviceTableWidget
 
@@ -337,3 +338,13 @@ def test_device_table(qtbot: QtBot, happi_client: happi.Client):
     otable.device = new_dev
     assert otable.windowTitle() == new_dev.name
     qtbot.addWidget(otable)
+
+
+def test_multiinput_dialog(qtbot: QtBot):
+    info = {
+        "str": "",
+        "float": 5.5,
+        "int": 5,
+    }
+    dialog = MultiInputDialog(init_values=info)
+    qtbot.addWidget(dialog)

--- a/atef/widgets/config/utils.py
+++ b/atef/widgets/config/utils.py
@@ -971,7 +971,7 @@ class MultiInputDialog(QtWidgets.QDialog):
         elif isinstance(value, int):
             int_edit = QtWidgets.QSpinBox()
             int_edit.setMinimum(-1)
-            int_edit.setMaximum(2147483648)
+            int_edit.setMaximum(2147483647)
             int_edit.setSpecialValueText('None')
             int_edit.setToolTip('Input -1 to set value to None')
             int_edit.setValue(value)
@@ -979,7 +979,7 @@ class MultiInputDialog(QtWidgets.QDialog):
         elif isinstance(value, float):
             float_edit = QtWidgets.QDoubleSpinBox()
             float_edit.setMinimum(-1)
-            float_edit.setMaximum(2147483648)
+            float_edit.setMaximum(2147483647)
             float_edit.setSpecialValueText('None')
             float_edit.setToolTip('Input -1 to set value to None')
             float_edit.setValue(value)

--- a/docs/source/upcoming_release_notes/268-bug_spinbox_max.rst
+++ b/docs/source/upcoming_release_notes/268-bug_spinbox_max.rst
@@ -1,0 +1,22 @@
+268 bug_spinbox_max
+###################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Adjusts spinbox maximum limit to avoid overflow
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- Adjusts the integer spinbox maximum setting to avoid overflow.  Adjusts the float spinbox to match, for symmetry

## Motivation and Context
This has apparently been a bug for months, but nobody tried to build a report so we never ran into it.
The double spinbox is fine since doubles have a larger range

Bug was reported by Tong today

## How Has This Been Tested?
Interactively, and a smoke test has been added

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
