### PR TITLE
ENH: Adding parent info to status output

### DIFF
--- a/atef/config_model/active.py
+++ b/atef/config_model/active.py
@@ -571,6 +571,9 @@ class PreparedProcedureStep:
 
     async def run(self) -> Result:
         """Run the step and return the result"""
+
+        self.parent.name = getattr(self.parent, "name", "(no parent)")
+
         status_logger = get_status_logger(self)
         status_logger.info(
             f"Parent step: {self.parent.name}, Starting step: '{self.name}' ({type(self).__name__})"
@@ -854,7 +857,6 @@ class PreparedSetValueStep(PreparedProcedureStep):
                     reason="Step aborted, action skipped"
                 )
             try:
-                # NEED TO ADD PARENT STEP
                 status_logger.info(f" > Starting Action: Group: '{prep_action.parent.name}', Step: '{prep_action.name}'")
                 action_result = await prep_action.run()
                 status_logger.info(f" > Finished Action: Group: '{prep_action.parent.name}', Step: '{prep_action.name}'")
@@ -870,7 +872,7 @@ class PreparedSetValueStep(PreparedProcedureStep):
                 # TODO Is this really necessary? super().run() stashes the step result already...
                 self.step_result = Result(
                     severity=Severity.error,
-                    reason=f'action failed ({prep_action.name}), step halted'
+                    reason=f'action failed Group: ({prep_action.parent.name}), Step: ({prep_action.name}), step halted'
                 )
                 return self.step_result
 

--- a/atef/config_model/active.py
+++ b/atef/config_model/active.py
@@ -682,7 +682,7 @@ class PreparedProcedureGroup(PreparedProcedureStep):
         -------
         PreparedProcedureGroup
         """
-        prepared = cls(origin=group, parent=parent, steps=[], name = group.name)
+        prepared = cls(origin=group, parent=parent, steps=[], name=group.name)
 
         for step in group.steps:
             prep_step = PreparedProcedureStep.from_origin(

--- a/atef/config_model/active.py
+++ b/atef/config_model/active.py
@@ -573,7 +573,7 @@ class PreparedProcedureStep:
         """Run the step and return the result"""
         status_logger = get_status_logger(self)
         status_logger.info(
-            f"Starting step: '{self.name}' ({type(self).__name__})"
+            f"Parent step: {self.parent.name}, Starting step: '{self.name}' ({type(self).__name__})"
         )
         try:
             result = await self._run()
@@ -587,7 +587,7 @@ class PreparedProcedureStep:
         self.step_result = result
         # return the overall result, including verification
         status_logger.info(
-            f"Finished step: '{self.name}' ({type(self).__name__}). "
+            f"Parent step: {self.parent.name}, Finished step: '{self.name}' ({type(self).__name__}). "
             f"Result: {self.result.severity.name}"
         )
         return self.result
@@ -682,7 +682,7 @@ class PreparedProcedureGroup(PreparedProcedureStep):
         -------
         PreparedProcedureGroup
         """
-        prepared = cls(origin=group, parent=parent, steps=[])
+        prepared = cls(origin=group, parent=parent, steps=[], name = group.name)
 
         for step in group.steps:
             prep_step = PreparedProcedureStep.from_origin(
@@ -854,9 +854,10 @@ class PreparedSetValueStep(PreparedProcedureStep):
                     reason="Step aborted, action skipped"
                 )
             try:
-                status_logger.info(f" > Starting Action: '{prep_action.name}'")
+                # NEED TO ADD PARENT STEP
+                status_logger.info(f" > Starting Action: Group: '{prep_action.parent.name}', Step: '{prep_action.name}'")
                 action_result = await prep_action.run()
-                status_logger.info(f" > Finished Action: '{prep_action.name}'")
+                status_logger.info(f" > Finished Action: Group: '{prep_action.parent.name}', Step: '{prep_action.name}'")
             except CancelledError:
                 cancelled = True
                 prep_action.result = Result(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I added parent step information to the status output so that users can tell which common component procedure group they are running and the corresponding step information.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is to help users with tracking which step they are on in the live gui.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually, not sure if I need to do aditional tests.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
