### PR TITLE
TST: tweak for updated pytest syntax parsing

### DIFF
--- a/atef/tests/test_abort.py
+++ b/atef/tests/test_abort.py
@@ -18,7 +18,7 @@ def assert_task_running(tree: DualTree, is_running: bool = True):
             and tree.running_task.done() != is_running)
 
 
-@pytest.mark.parametrize("click_abort,", [
+@pytest.mark.parametrize("click_abort", [
     (True,),
     (False,),
 ])

--- a/atef/tests/test_status_logging.py
+++ b/atef/tests/test_status_logging.py
@@ -36,7 +36,7 @@ def create_blank_prep_active():
     return PreparedProcedureFile.from_origin(ProcedureFile())
 
 
-@pytest.mark.parametrize("prepared_file_fn,", [
+@pytest.mark.parametrize("prepared_file_fn", [
     create_blank_prep_passive, create_blank_prep_active
 
 ])
@@ -61,7 +61,7 @@ def test_status_tempfile_creation(
     assert prepared_file.uuid not in tempfile_cache
 
 
-@pytest.mark.parametrize("prepared_file_fn,", [
+@pytest.mark.parametrize("prepared_file_fn", [
     create_blank_prep_passive, create_blank_prep_active
 ])
 def test_logging_stream(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Try to resolve the CI errors in this repo by updating the parameterize syntax

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A recent pytest update changed the meaning of the parameterize syntax to more closely match normal python syntax

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It will be tested in CI here

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [ ] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
